### PR TITLE
Refactor matcher to also take the FileInfo

### DIFF
--- a/pkg/analyzer/java/analyzer.go
+++ b/pkg/analyzer/java/analyzer.go
@@ -1,7 +1,7 @@
 package java
 
 import (
-	"path/filepath"
+	"os"
 
 	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/component"
@@ -10,14 +10,18 @@ import (
 
 type analyzerImpl struct{}
 
-func (a analyzerImpl) Match(filePath string) bool {
-	return javaRegexp.MatchString(filepath.Base(filePath))
+func (a analyzerImpl) Match(fullPath string, fileInfo os.FileInfo) bool {
+	return match(fullPath)
+}
+
+func match(fullPath string) bool {
+	return javaRegexp.MatchString(fullPath)
 }
 
 func (a analyzerImpl) Analyze(fileMap tarutil.FilesMap) ([]*component.Component, error) {
 	var allComponents []*component.Component
 	for filePath, contents := range fileMap {
-		if !a.Match(filePath) {
+		if !match(filePath) {
 			continue
 		}
 		packages, err := parseContents(filePath, contents)

--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -1,20 +1,21 @@
 package matcher
 
 import (
+	"os"
 	"strings"
 )
 
 type Matcher interface {
-	Match(fileName string) bool
+	Match(fullPath string, fileInfo os.FileInfo) bool
 }
 
 type whitelistMatcher struct {
 	whitelist []string
 }
 
-func (w *whitelistMatcher) Match(fileName string) bool {
+func (w *whitelistMatcher) Match(fullPath string, _ os.FileInfo) bool {
 	for _, s := range w.whitelist {
-		if strings.HasPrefix(fileName, s) {
+		if strings.HasPrefix(fullPath, s) {
 			return true
 		}
 	}
@@ -31,9 +32,9 @@ type orMatcher struct {
 	matchers []Matcher
 }
 
-func (o *orMatcher) Match(fileName string) bool {
+func (o *orMatcher) Match(fullPath string, fileInfo os.FileInfo) bool {
 	for _, subMatcher := range o.matchers {
-		if subMatcher.Match(fileName) {
+		if subMatcher.Match(fullPath, fileInfo) {
 			return true
 		}
 	}

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -76,7 +76,7 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (FilesMap, error
 		// Get element filename
 		filename := strings.TrimPrefix(hdr.Name, "./")
 
-		if !filenameMatcher.Match(filename) {
+		if !filenameMatcher.Match(filename, hdr.FileInfo()) {
 			continue
 		}
 


### PR DESCRIPTION
Breaking this one out of the Python one since it's isolated. Essentially, for Python, I will need to have the whole `os.FileInfo` because I want to be able to tell whether a given filepath corresponds to a directory or not.