### PR TITLE
Minor refactor: Move the Location field into the top-level of the Component struct

### DIFF
--- a/pkg/analyzer/java/analyzer.go
+++ b/pkg/analyzer/java/analyzer.go
@@ -24,15 +24,11 @@ func (a analyzerImpl) Analyze(fileMap tarutil.FilesMap) ([]*component.Component,
 		if !match(filePath) {
 			continue
 		}
-		packages, err := parseContents(filePath, contents)
+		components, err := parseContents(filePath, contents)
 		if err != nil {
 			return nil, err
 		}
-		for _, p := range packages {
-			allComponents = append(allComponents, &component.Component{
-				JavaPkgMetadata: p,
-			})
-		}
+		allComponents = append(allComponents, components...)
 	}
 	return allComponents, nil
 }

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -5,13 +5,15 @@ type Component struct {
 	Name    string
 	Version string
 
+	// Location specifies a path to a file that the component's existence was derived from.
+	Location string
+
 	JavaPkgMetadata *JavaPkgMetadata
 }
 
 // JavaPkgMetadata contains additional metadata that Java-based components have.
 type JavaPkgMetadata struct {
 	ImplementationVersion string
-	Location              string
 	MavenVersion          string
 	Name                  string
 	Origin                string


### PR DESCRIPTION
Splitting another tiny PR out of the Python one. Essentially there is no reason for Location to be scoped down to the Java-specific struct. I'm going to re-use it for Python.

We don't currently use the location, so this shouldn't really affect anything.