### PR TITLE
Update rox version to pick up logspam fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/prometheus/client_golang v0.9.1
 	github.com/remind101/migrate v0.0.0-20160423010909-d22d647232c2
 	github.com/sirupsen/logrus v1.4.2
-	github.com/stackrox/rox v0.0.0-20191029215756-4d799dd775e4
+	github.com/stackrox/rox v0.0.0-20191030225938-92c4dc822b58
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/lint v0.0.0-20190930215403-16217165b5de
 	golang.org/x/tools v0.0.0-20191018203202-04252eccb9d5

--- a/go.sum
+++ b/go.sum
@@ -292,8 +292,8 @@ github.com/stackrox/docker-registry-client v0.0.0-20181115184320-3d98b2b79d1b h1
 github.com/stackrox/docker-registry-client v0.0.0-20181115184320-3d98b2b79d1b/go.mod h1:ftVRYPg9kyRYpu5y5rE+8c8P6KtAitUy57PlHhMraL8=
 github.com/stackrox/k8s-istio-cve-pusher v0.0.0-20191017214444-0f09bd56ec39 h1:LKLe/o0D257yjGXRb0558xczJPcwy9VMZzpT8FVR2Z4=
 github.com/stackrox/k8s-istio-cve-pusher v0.0.0-20191017214444-0f09bd56ec39/go.mod h1:13vPFaMtP66fobTXqiv3SB32ZCZfa9btx3O6uOlTCDY=
-github.com/stackrox/rox v0.0.0-20191029215756-4d799dd775e4 h1:DcRr/jPt9kGwEdfDl8p53aRgRR4aZoryQLDkJSnJq34=
-github.com/stackrox/rox v0.0.0-20191029215756-4d799dd775e4/go.mod h1:y8ef9LW5r9Ngre/3zIZX9Z7/yVm/46wRb/QYXfKUAao=
+github.com/stackrox/rox v0.0.0-20191030225938-92c4dc822b58 h1:KmrEGcd/gOLA88pv9eNDuC7hTrtV2GSydNAl0YPqXWg=
+github.com/stackrox/rox v0.0.0-20191030225938-92c4dc822b58/go.mod h1:y8ef9LW5r9Ngre/3zIZX9Z7/yVm/46wRb/QYXfKUAao=
 github.com/steveyen/gtreap v0.0.0-20150807155958-0abe01ef9be2/go.mod h1:mjqs7N0Q6m5HpR7QfXVBZXZWSqTjQLeTujjA/xUp2uw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Deployed locally and verified that it was gone.