### PR TITLE
Move to pkill over killall

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
               cat nohup.out || true
               rm nohup.out || true
               rm FAIL || true
-              killall kubectl
+              pkill kubectl
               sleep 5
             done
 


### PR DESCRIPTION
Turns out `killall` doesn't work on Ubuntu. See https://circleci.com/gh/stackrox/scanner/805. Can't really test this till the next time we hit the port-forward flake, but that should be okay.