### PR TITLE
Some minor code cleanup around updaters

### DIFF
--- a/ext/vulnsrc/alpine/alpine.go
+++ b/ext/vulnsrc/alpine/alpine.go
@@ -47,7 +47,7 @@ type updater struct {
 	repositoryLocalPath string
 }
 
-func (u *updater) Update(db database.Datastore) (resp vulnsrc.UpdateResponse, err error) {
+func (u *updater) Update(db vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {
 	log.WithField("package", "Alpine").Info("Start fetching vulnerabilities")
 
 	// Pull the master branch.
@@ -84,13 +84,9 @@ func (u *updater) Update(db database.Datastore) (resp vulnsrc.UpdateResponse, er
 	// Append any changed vulnerabilities to the response.
 	for _, namespace := range namespaces {
 		var vulns []database.Vulnerability
-		var note string
-		vulns, note, err = parseVulnsFromNamespace(u.repositoryLocalPath, namespace)
+		vulns, err = parseVulnsFromNamespace(u.repositoryLocalPath, namespace)
 		if err != nil {
 			return
-		}
-		if note != "" {
-			resp.Notes = append(resp.Notes, note)
 		}
 		resp.Vulnerabilities = append(resp.Vulnerabilities, vulns...)
 	}
@@ -143,7 +139,7 @@ func ls(path string, filter lsFilter) ([]string, error) {
 	return files, nil
 }
 
-func parseVulnsFromNamespace(repositoryPath, namespace string) (vulns []database.Vulnerability, note string, err error) {
+func parseVulnsFromNamespace(repositoryPath, namespace string) (vulns []database.Vulnerability, err error) {
 	nsDir := filepath.Join(repositoryPath, namespace)
 	var dbFilenames []string
 	dbFilenames, err = ls(nsDir, filesOnly)

--- a/ext/vulnsrc/amzn/amzn.go
+++ b/ext/vulnsrc/amzn/amzn.go
@@ -79,7 +79,7 @@ func init() {
 	vulnsrc.RegisterUpdater("amzn2", &amazonLinux2Updater)
 }
 
-func (u *updater) Update(datastore database.Datastore) (vulnsrc.UpdateResponse, error) {
+func (u *updater) Update(datastore vulnsrc.DataStore) (vulnsrc.UpdateResponse, error) {
 	log.WithField("package", u.Name).Info("Start fetching vulnerabilities")
 
 	// Get the most recent updated date of the previous update.

--- a/ext/vulnsrc/debian/debian.go
+++ b/ext/vulnsrc/debian/debian.go
@@ -58,7 +58,7 @@ func init() {
 	vulnsrc.RegisterUpdater("debian", &updater{})
 }
 
-func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateResponse, err error) {
+func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {
 	log.WithField("package", "Debian").Info("Start fetching vulnerabilities")
 
 	// Download JSON.

--- a/ext/vulnsrc/driver.go
+++ b/ext/vulnsrc/driver.go
@@ -42,11 +42,15 @@ type UpdateResponse struct {
 	Vulnerabilities []database.Vulnerability
 }
 
+type DataStore interface {
+	GetKeyValue(key string) (string, error)
+}
+
 // Updater represents anything that can fetch vulnerabilities and insert them
 // into a Clair datastore.
 type Updater interface {
 	// Update gets vulnerability updates.
-	Update(database.Datastore) (UpdateResponse, error)
+	Update(DataStore) (UpdateResponse, error)
 
 	// Clean deletes any allocated resources.
 	// It is invoked when Clair stops.

--- a/ext/vulnsrc/oracle/oracle.go
+++ b/ext/vulnsrc/oracle/oracle.go
@@ -113,7 +113,7 @@ func compareELSA(left, right int) int {
 	return len(lstr) - len(rstr)
 }
 
-func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateResponse, err error) {
+func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {
 	log.WithField("package", "Oracle Linux").Info("Start fetching vulnerabilities")
 	// Get the first ELSA we have to manage.
 	flagValue, err := datastore.GetKeyValue(updaterFlag)

--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -146,7 +146,7 @@ func init() {
 	vulnsrc.RegisterUpdater("rhel", &updater{})
 }
 
-func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateResponse, err error) {
+func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {
 	log.WithField("package", "RHEL").Info("Start fetching vulnerabilities")
 	// Get the first RHSA we have to manage.
 	flagValue, err := datastore.GetKeyValue(updaterFlag)

--- a/ext/vulnsrc/ubuntu/ubuntu.go
+++ b/ext/vulnsrc/ubuntu/ubuntu.go
@@ -80,7 +80,7 @@ func init() {
 	vulnsrc.RegisterUpdater("ubuntu", &updater{})
 }
 
-func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateResponse, err error) {
+func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {
 	log.WithField("package", "Ubuntu").Info("Start fetching vulnerabilities")
 
 	// Pull the master branch.

--- a/updater.go
+++ b/updater.go
@@ -104,7 +104,7 @@ func RunUpdater(config *UpdaterConfig, datastore database.Datastore, st *stopper
 				// Launch update in a new go routine.
 				doneC := make(chan bool, 1)
 				go func() {
-					updateSuccessful = update(datastore, firstUpdate)
+					updateSuccessful = update(datastore)
 					doneC <- true
 				}()
 
@@ -185,7 +185,7 @@ func sleepUpdater(approxWakeup time.Time, st *stopper.Stopper) (stopped bool) {
 
 // update fetches all the vulnerabilities from the registered fetchers, upserts
 // them into the database and then sends notifications.
-func update(datastore database.Datastore, firstUpdate bool) (updateSuccessful bool) {
+func update(datastore database.Datastore) (updateSuccessful bool) {
 	defer setUpdaterDuration(time.Now())
 
 	log.Info("updating vulnerabilities")


### PR DESCRIPTION
* Scope down the datastore interface that gets passed down to updaters to make it more obvious that updaters don't write anything to postgres.
* Remove a couple of unused variables.