### PR TITLE
Don't use h2 when using clairify https server

### DIFF
--- a/pkg/clairify/server/server.go
+++ b/pkg/clairify/server/server.go
@@ -241,6 +241,7 @@ func (s *Server) Start() error {
 	if err != nil {
 		return err
 	}
+	tlsConfig.NextProtos = nil
 
 	listener, err = tls.Listen("tcp", s.endpoint, tlsConfig)
 	if err != nil {


### PR DESCRIPTION
Basically, we need to wrap Central's clairify client with http2.ConfigureTransport and then I won't need to drop the h2 (which was added as a part of the work on grpc). That being said, for backwards compatibility reasons, we will use HTTP 1.1 so that an older Central can work with the newer scanner. This will be useful if someone doesn't want to upgrade, but they want language vulns. In a couple releases, we'll wind all this back as we move towards grpc