### PR TITLE
Delay download until first read to avoid unnecessary call

### DIFF
--- a/pkg/scan/downloadCloser.go
+++ b/pkg/scan/downloadCloser.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+type layerDownloadReadCloser struct {
+	io.ReadCloser
+	downloader func() (io.ReadCloser, error)
+}
+
+func (l *layerDownloadReadCloser) Read(p []byte) (int, error) {
+	if l.ReadCloser == nil {
+		readCloser, err := l.downloader()
+		if err != nil {
+			return 0, errors.Wrap(err, "error downloading layer")
+		}
+		l.ReadCloser = readCloser
+	}
+	return l.ReadCloser.Read(p)
+}
+
+func (l *layerDownloadReadCloser) Close() error {
+	if l.ReadCloser != nil {
+		return l.ReadCloser.Close()
+	}
+	return nil
+}


### PR DESCRIPTION
What do you guys think? Basically, I was making a Get call with our library which is nice because it handles all the auth transparently and I also find that the reader interface is nice, especially when we start just taking in layers from a local scan. However, we are making an initial download layer call (albeit not reading from it immediately until we know we need to), but I think we can make this call lazily instead. Note, more conceptual and not fully tested though anticipate this working