### PR TITLE
Bubble up context from tarutil errors

### DIFF
--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -56,7 +56,7 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (FilesMap, error
 	// Decompress the archive.
 	tr, err := NewTarReadCloser(r)
 	if err != nil {
-		return data, errors.Wrap(err, "could not extract tar acrchive")
+		return data, errors.Wrap(err, "could not extract tar archive")
 	}
 	defer tr.Close()
 


### PR DESCRIPTION
Saw this E2E failure: https://circleci.com/gh/stackrox/scanner/1755#artifacts/containers/0

There's no way to debug it because the `tarutil` package clobbers all context from the original error. Change that.