### PR TITLE
Clean up attribute getter log

### DIFF
--- a/cpe/cpe.go
+++ b/cpe/cpe.go
@@ -89,8 +89,8 @@ func escapeDash(s string) string {
 }
 
 func getAttributes(c *component.Component) []*wfn.Attributes {
-	getAttributes, ok := attributeGetter[c.SourceType]
-	if !ok {
+	getAttributes := attributeGetter[c.SourceType]
+	if getAttributes == nil {
 		log.Errorf("No attribute getter available for %q", c.SourceType.String())
 		return nil
 	}


### PR DESCRIPTION
The log was showing up when we ignore packages which isn't the case when the log should be shown. It's okay that we return no attributes if the pkg is ignored