### PR TITLE
Use E2 machine type in CI

### DIFF
--- a/.circleci/create-cluster.sh
+++ b/.circleci/create-cluster.sh
@@ -22,7 +22,7 @@ create-cluster() {
       echo "Trying zone $zone"
       gcloud config set compute/zone "${zone}"
       timeout 420 gcloud beta container clusters create \
-          --machine-type n1-standard-4 \
+          --machine-type e2-standard-4 \
           --num-nodes "${NUM_NODES}" \
           --disk-type=pd-standard \
           --disk-size=20GB \


### PR DESCRIPTION
Saw in the billing overview that we still pay for N1 machines in CI, guess this is one of the culprits