### PR TITLE
Store the genesis dump we generate for the purpose of diffing as an artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,6 +355,10 @@ jobs:
             ./bin/updater generate-dump --out-file /tmp/genesis-dump/dump.zip
             ls -lrt /tmp/genesis-dump
 
+      - store_artifacts:
+          path: /tmp/genesis-dump/dump.zip
+          destination: genesis-dump.zip
+
       - persist_to_workspace:
           root: /tmp
           paths:


### PR DESCRIPTION
This way, I can just download it off a CI run and use it as a new genesis dump instead of generating it locally.