### PR TITLE
Retry git clone in the Ubuntu updater

### DIFF
--- a/ext/vulnsrc/oracle/oracle.go
+++ b/ext/vulnsrc/oracle/oracle.go
@@ -203,7 +203,10 @@ func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateRespon
 		}
 	}
 
-	log.WithField("count", len(elsaList)).Info("Got list of Oracle updates to process")
+	log.WithFields(map[string]interface{}{
+		"count":   len(elsaList),
+		"updater": "oracle",
+	}).Info("Got list of Oracle updates to process")
 
 	respChan := make(chan elsaResp)
 	urlChan := make(chan string, len(elsaList))
@@ -227,7 +230,7 @@ forloop:
 			resp.Vulnerabilities = append(resp.Vulnerabilities, elsaResp.vulns...)
 			numProcessed++
 			if numProcessed%100 == 0 {
-				log.Infof("Oracle: Processed %d/%d ELSAs", numProcessed, len(elsaList))
+				log.WithField("updater", "oracle").Infof("Processed %d/%d ELSAs", numProcessed, len(elsaList))
 			}
 		case <-errSig.Done():
 			return resp, errSig.Err()

--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -174,9 +174,9 @@ func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateRespon
 		return vulnsrc.UpdateResponse{}, errors.Wrap(err, "parsing RHSA bulk response")
 	}
 	resp.Vulnerabilities = append(resp.Vulnerabilities, vs...)
-	log.Infof("RHEL: done fetching giant update file. Got %d vulns (%d RHSAs)", len(vs), coveredIDs.Cardinality())
+	log.WithField("updater", "rhel").Infof("Done fetching giant update file. Got %d vulns (%d RHSAs)", len(vs), coveredIDs.Cardinality())
 
-	log.Info("RHEL: Fetching remaining IDs which weren't in the giant update file")
+	log.WithField("updater", "rhel").Info("Fetching remaining IDs which weren't in the giant update file")
 	ovalDirectoryResp, err := getWithRetriesAndBackoff(ovalURI)
 	if err != nil {
 		log.WithError(err).Error("could not fetch RHEL's update list")
@@ -202,7 +202,10 @@ func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateRespon
 	}
 
 	const printEvery = 100
-	log.WithField("count", len(remainingRHSAURLs)).Info("RHEL: got remaining RHSAs to fetch")
+	log.WithFields(map[string]interface{}{
+		"updater": "rhel",
+		"count":   len(remainingRHSAURLs),
+	}).Info("Got remaining RHSAs to fetch")
 	for i, rhsaURL := range remainingRHSAURLs {
 		r, err := getWithRetriesAndBackoff(ovalURI + rhsaURL)
 		if err != nil {
@@ -216,7 +219,7 @@ func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateRespon
 		}
 		resp.Vulnerabilities = append(resp.Vulnerabilities, currentVulns...)
 		if (i+1)%printEvery == 0 {
-			log.Infof("Finished collecting %d/%d additional RHSAs", i+1, len(remainingRHSAURLs))
+			log.WithField("updater", "rhel").Infof("Finished collecting %d/%d additional RHSAs", i+1, len(remainingRHSAURLs))
 		}
 	}
 


### PR DESCRIPTION
Retry `git clone` a few times in the Ubuntu scanner to mitigate the impact of transient failures. Also, do a shallow clone that doesn't fetch all git history (`--depth 1`), which empirically seems to speed the clone up 3x on my machine.