### PR TITLE
Make updaters fail if they don't produce an expected count of vulns

### DIFF
--- a/cmd/updater/generatedump/cmd.go
+++ b/cmd/updater/generatedump/cmd.go
@@ -113,6 +113,12 @@ func fetchVulns(datastore vulnsrc.DataStore, nvdDumpDir string) (vulns []databas
 			}
 
 			count := len(response.Vulnerabilities)
+			if count < u.ExpectedCount() {
+				err := errors.Errorf("expected %d, but obtained only %d vulnerabilities for updater %s", u.ExpectedCount(), count, name)
+				log.Error(err)
+				errSig.SignalWithError(err)
+				return
+			}
 			select {
 			case responseC <- &response:
 				log.WithFields(map[string]interface{}{

--- a/ext/vulnsrc/alpine/alpine.go
+++ b/ext/vulnsrc/alpine/alpine.go
@@ -40,7 +40,7 @@ const (
 )
 
 func init() {
-	vulnsrc.RegisterUpdater("alpine", &updater{})
+	vulnsrc.RegisterUpdater("alpine", &updater{}, 12028)
 }
 
 type updater struct {

--- a/ext/vulnsrc/debian/debian.go
+++ b/ext/vulnsrc/debian/debian.go
@@ -55,7 +55,7 @@ type jsonRel struct {
 type updater struct{}
 
 func init() {
-	vulnsrc.RegisterUpdater("debian", &updater{})
+	vulnsrc.RegisterUpdater("debian", &updater{}, 25555)
 }
 
 func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {

--- a/ext/vulnsrc/driver.go
+++ b/ext/vulnsrc/driver.go
@@ -76,7 +76,7 @@ func (u expectedCountAwareUpdater) ExpectedCount() int {
 }
 
 func wrapUpdaterWithCount(u Updater, count int) ExpectedCountAwareUpdater {
-	return &expectedCountAwareUpdater{Updater: u, count: count}
+	return expectedCountAwareUpdater{Updater: u, count: count}
 }
 
 // RegisterUpdater makes an Updater available by the provided name.

--- a/ext/vulnsrc/oracle/oracle.go
+++ b/ext/vulnsrc/oracle/oracle.go
@@ -84,7 +84,7 @@ type criterion struct {
 type updater struct{}
 
 func init() {
-	vulnsrc.RegisterUpdater("oracle", &updater{})
+	vulnsrc.RegisterUpdater("oracle", &updater{}, 3125)
 }
 
 func compareELSA(left, right int) int {

--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -151,7 +151,7 @@ func getWithRetriesAndBackoff(url string) (*http.Response, error) {
 }
 
 func init() {
-	vulnsrc.RegisterUpdater("rhel", &updater{})
+	vulnsrc.RegisterUpdater("rhel", &updater{}, 18074)
 }
 
 func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {

--- a/ext/vulnsrc/ubuntu/ubuntu.go
+++ b/ext/vulnsrc/ubuntu/ubuntu.go
@@ -77,7 +77,7 @@ type updater struct {
 }
 
 func init() {
-	vulnsrc.RegisterUpdater("ubuntu", &updater{})
+	vulnsrc.RegisterUpdater("ubuntu", &updater{}, 32592)
 }
 
 func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {


### PR DESCRIPTION
Currently, the updater will succeed and write vulns to the dump unless there's an explicit error in the process. However, while refactoring the Ubuntu updater (#125), I realized it would be beneficial to have some sort of sanity checking that we don't accidentally drop vulnerabilities. To do this, add an `ExpectedCount()` method to each updater, which returns the minimum expected count (which I filled in by running the updater manually and putting in the counts I observed). If we don't hit the minimum expected count for any updater, abort the process immediately.