### PR TITLE
Add step to upload rhel image bundles on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,8 +521,7 @@ jobs:
       - run:
           name: Check if tagged
           command: |
-            # remove ! before commit
-            if [[ ! -z "$CIRCLE_TAG" ]]; then
+            if [[ -z "$CIRCLE_TAG" ]]; then
                 circleci step halt
                 exit 0
             fi
@@ -532,11 +531,9 @@ jobs:
           command: |
             gcloud auth list
             tag="$(./get-tag)"
-            # remove TEST_PATH before commit
-            TEST_PATH="f4797d572d06eea8bef7d8ceb9cbe2f08adb8ec6"
-            GCP_DSOP_BUCKET="gs://dsop-artifacts.stackrox.io/${TEST_PATH}"
+            GCP_DSOP_BUCKET="gs://dsop-artifacts.stackrox.io"
             gsutil cp "image/scanner/rhel/bundle.tar.gz" "${GCP_DSOP_BUCKET}/scanner-rhel/${tag}/"
-            gsutil cp "image/db/rhel/bundle.tar.gz" "${GCP_DSOP_BUCKET}/scanner-db-rhel/${tag}/"
+            gsutil cp "image/db/rhel/bundle.tar.gz"      "${GCP_DSOP_BUCKET}/scanner-db-rhel/${tag}/"
 
   provision-cluster:
     <<: *defaults


### PR DESCRIPTION
**Changes:**
Add a step to upload the scanner-rhel bundle and scanner-db-rhel bundle when a new release is tagged.

**Testing:**
```
$ curl -O https://dsop-artifacts.stackrox.io/f4797d572d06eea8bef7d8ceb9cbe2f08adb8ec6/scanner-rhel/$(./get-tag)/bundle.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 49.7M  100 49.7M    0     0   9.9M      0  0:00:04  0:00:04 --:--:-- 10.1M
$ curl -O https://dsop-artifacts.stackrox.io/f4797d572d06eea8bef7d8ceb9cbe2f08adb8ec6/scanner-db-rhel/$(./get-tag)/bundle.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 50.4M  100 50.4M    0     0  7375k      0  0:00:07  0:00:07 --:--:-- 10.2M
```