### PR TITLE
Don't run RHEL tests in the hourly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -658,18 +658,11 @@ workflows:
             - upload-nvd-dump-for-embedding-into-image
       - provision-cluster:
           <<: *runOnAllTagsWithDockerIOPullCtx
-      - provision-cluster-rhel:
-          <<: *runOnAllTagsWithDockerIOPullCtx
       - e2e-tests:
           <<: *runOnAllTagsWithDockerIOPullCtx
           requires:
             - build
             - provision-cluster
-      - e2e-tests-rhel:
-          <<: *runOnAllTagsWithDockerIOPullCtx
-          requires:
-            - build-rhel
-            - provision-cluster-rhel
 
   build:
     jobs:


### PR DESCRIPTION
Just to avoid using more clusters than necessary.