### PR TITLE
Correctly return an error if Central sends us the wrong status code

### DIFF
--- a/pkg/licenses/fetch_from_central.go
+++ b/pkg/licenses/fetch_from_central.go
@@ -36,7 +36,7 @@ func fetchFromCentral(ctx concurrency.Waitable, formattedCentralEndpoint string,
 	if resp.StatusCode != http.StatusOK {
 		// Intentionally don't stick more from the response over here, want to make sure
 		// not to accidentally log license keys.
-		return "", errors.Wrapf(err, "got status code %d", resp.StatusCode)
+		return "", errors.Errorf("got status code %d", resp.StatusCode)
 	}
 	var license licenseResponse
 	err = json.NewDecoder(resp.Body).Decode(&license)
@@ -46,6 +46,5 @@ func fetchFromCentral(ctx concurrency.Waitable, formattedCentralEndpoint string,
 	if license.LicenseKey == "" {
 		return "", errors.New("Central returned status 200 but an empty license")
 	}
-	log.Infof("Resp status code: %d, license %v", resp.StatusCode, license)
 	return license.LicenseKey, nil
 }


### PR DESCRIPTION
🤦 
It now fails as expected:
```
{"Event":"Failed to fetch license. Will retry...","Level":"error","Location":"manager.go:130","Time":"2020-04-27 19:39:48.199630","error":"fetching license from central: got status code 404"}
```