### PR TITLE
Change postgres service to use tcp prefix instead of http

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
 spec:
   ports:
-  - name: tcp-postgres
+  - name: tcp-db
     port: 5432
     targetPort: postgresql
   selector:


### PR DESCRIPTION
Istio auto-senses protocol https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/

Postgres doesn't use HTTP https://www.postgresql.org/docs/12/protocol.html