### PR TITLE
Support IPv6 within pg_hba.conf

### DIFF
--- a/image/db/pg_hba.conf
+++ b/image/db/pg_hba.conf
@@ -95,6 +95,9 @@ host    replication     all             ::1/128                 trust
 ### STACKROX MODIFIED
 # Reject all non ssl connections from IPs
 hostnossl  all       all   0.0.0.0/0     reject
+hostnossl  all       all   ::0/0         reject
+
 # Accept connections from ssl with password
 hostssl    all       all   0.0.0.0/0     md5
+hostssl    all       all   ::0/0         md5
 ###


### PR DESCRIPTION
pg_hba.conf file dictates what can access the DB. Currently, there is no catchall matching rules for ipv6 (ssl or non ssl mode). This should match all IPv6 and enforce SSL