### PR TITLE
Handle shutdowns gracefully

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -34,7 +34,7 @@ func RunClairify(serv *server.Server) {
 			log.Fatal(err)
 		}
 
-		// (*http.Server).Shutdown causes (*http.Server).Start to return http.ErrServerClosed.
+		// (*http.Server).Shutdown causes (*http.Server).Serve to return http.ErrServerClosed.
 		// This is ok, and we should let the scanner shutdown gracefully.
 		log.Info(err)
 	}


### PR DESCRIPTION
We previously did attempt to gracefully shutdown, but we would log a fatal error, which would force the scanner to exit in a non-graceful manner. Switched it to just log information if we catch know we are shutting down. Still log a fatal error if it's any other error, though