### PR TITLE
[ROX-5394] Fix potential buggy resource not found error in features

### DIFF
--- a/database/pgsql/feature.go
+++ b/database/pgsql/feature.go
@@ -149,6 +149,7 @@ func (pgSQL *pgSQL) insertFeatureVersion(fv database.FeatureVersion) (id int, er
 
 	if err == sql.ErrNoRows {
 		// Query Feature Version for id.
+		// It is possible another replica inserted the feature version right before this replica attempted.
 		err := pgSQL.QueryRow(searchFeatureVersion, featureID, fv.Version).Scan(&fv.ID)
 		if err != nil {
 			tx.Rollback()


### PR DESCRIPTION
This will pop up when multiple scanner replicas attempt to insert the same feature version into the DB at the same time. Most of the time, we check a few lines above this if the feature version is already in the DB. I'd say this is a rather uncommon case, but possible.