### PR TITLE
Update severity labels

### DIFF
--- a/ext/vulnmdsrc/nvd/nvd.go
+++ b/ext/vulnmdsrc/nvd/nvd.go
@@ -174,13 +174,13 @@ func SeverityFromCVSS(meta *Metadata) database.Severity {
 	switch {
 	case score < 1.0:
 		return database.NegligibleSeverity
-	case score < 3.9:
+	case score < 4.0:
 		return database.LowSeverity
-	case score < 6.9:
+	case score < 7.0:
 		return database.MediumSeverity
-	case score < 8.9:
+	case score < 9.0:
 		return database.HighSeverity
-	case score <= 10:
+	case score <= 10.0:
 		return database.CriticalSeverity
 	}
 	return database.UnknownSeverity


### PR DESCRIPTION
Severity is supposed to be based on the table referenced in rhe godoc; however, it looks off by 0.1 (inclusion/exclusion differences)

<img width="775" alt="Screen Shot 2020-08-21 at 12 17 26 PM" src="https://user-images.githubusercontent.com/7704495/90926620-4d5a5d00-e3a8-11ea-9ad8-214f9c257b44.png">