### PR TITLE
[ROX-5582] Turn on ROX_CONTINUE_UNKNOWN_OS

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -3,5 +3,5 @@ package features
 var (
 	LanguageVulns = registerFeature("Enable language vulnerabilities", "ROX_LANGUAGE_VULNS", true, NoRoxAllowed())
 
-	ContinueUnknownOS = registerFeature("Enable continuation upon detecting unknown OS", "ROX_CONTINUE_UNKNOWN_OS", false)
+	ContinueUnknownOS = registerFeature("Enable continuation upon detecting unknown OS", "ROX_CONTINUE_UNKNOWN_OS", true)
 )


### PR DESCRIPTION
Once merged I don't plan on making a new scanner version just yet because we can just do that at the end of the sprint once we make the new genesis dump. Instead, I'm thinking of setting the scanner version in rox to whatever the master build will be, so we can at least have this turned on in rox. I will also be adding a CHANGELOG there. Again, I figure setting the SCANNER version to a non-final version is ok since we will be making a new genesis dump at the end of the sprint and setting the SCANNER_VERSION again then anyway.

Turning this flag on means something like `fedora:32` will no longer error when doing `roxctl image scan -i fedora:32`. Instead, we will get a scan with notes saying we could not complete the scan