### PR TITLE
Add ubuntu:20.10 support

### DIFF
--- a/database/namespace_mapping.go
+++ b/database/namespace_mapping.go
@@ -51,4 +51,5 @@ var UbuntuReleasesMapping = map[string]string{
 	"disco":   "19.04",
 	"eoan":    "19.10",
 	"focal":   "20.04",
+	"groovy":  "20.10",
 }

--- a/pkg/wellknownnamespaces/set.go
+++ b/pkg/wellknownnamespaces/set.go
@@ -49,5 +49,6 @@ var (
 		"ubuntu:16.04",
 		"ubuntu:18.04",
 		"ubuntu:20.04",
+		"ubuntu:20.10",
 	)
 )


### PR DESCRIPTION
Doing it this way for now to make sure we don't forget to add 20.10 support. I believe we want to change how we do this, though?