### PR TITLE
Ignore .NET vuln if no location found for it

### DIFF
--- a/pkg/analyzer/dotnetcoreruntime/analyzer.go
+++ b/pkg/analyzer/dotnetcoreruntime/analyzer.go
@@ -121,11 +121,15 @@ func getAllDLLComponentsRecursive(m map[string]interface{}, dllToLocationMap map
 			if !ok {
 				continue
 			}
+			location, ok := dllToLocationMap[baseName]
+			if !ok {
+				continue
+			}
 			*comps = append(*comps, &component.Component{
 				Name:       strings.ToLower(name),
 				Version:    version,
 				SourceType: component.DotNetCoreRuntimeSourceType,
-				Location:   dllToLocationMap[baseName],
+				Location:   location,
 			})
 			continue
 		}


### PR DESCRIPTION
Not sure if this is what FNF is seeing, I'll know more at noon today, but if there is no location for the dll then that means that it's not in the container and we should ignore it