### PR TITLE
Update Genesis Dump

### DIFF
--- a/image/scanner/dump/genesis_manifests.json
+++ b/image/scanner/dump/genesis_manifests.json
@@ -86,6 +86,11 @@
       "config": {
         "ignoreKubernetesVulns": true
       }
+    },
+    {
+      "dumpLocationInGS": "gs://stackrox-scanner-ci-vuln-dump/genesis-20210112210506.zip",
+      "timestamp": "2021-01-12T21:05:06.509624306Z",
+      "diffLocation": "gs://definitions.stackrox.io/1ef1caff-3e20-461c-a4d6-33f175f3ee24/diff.zip"
     }
   ]
 }


### PR DESCRIPTION
Node scanning isn't in 54, but there is an issue with the code introduced in 53 such that it assumes the k8s vulns should exist in the dump. This is fixed in 54 by just adding them, as there are not many to begin with