### PR TITLE
Filter out kernel vulnerabilities from images

### DIFF
--- a/api/v1/models.go
+++ b/api/v1/models.go
@@ -257,7 +257,7 @@ func LayerFromDatabaseModel(db database.Datastore, dbLayer database.Layer, withF
 	}
 
 	if (withFeatures || withVulnerabilities) && dbLayer.Features != nil {
-OUTER:
+	OUTER:
 		for _, dbFeatureVersion := range dbLayer.Features {
 			feature := featureFromDatabaseModel(dbFeatureVersion)
 


### PR DESCRIPTION
Packages prefix with linux and kernel are kernel vulnerabilities and should not be described as having vulns that relate to the kernel. In scanning all of the top 2500 images from dockerhub, this is much more prevalent than expected