### PR TITLE
Treat 32 byte layers as empty

### DIFF
--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -18,10 +18,6 @@ import (
 	"github.com/stackrox/scanner/pkg/clairify/types"
 )
 
-const (
-	emptyLayer = "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
-)
-
 func analyzeLayers(storage database.Datastore, registry types.Registry, image *types.Image, layers []string, uncertifiedRHEL bool) error {
 	var prevLayer string
 	for _, layer := range layers {
@@ -84,7 +80,11 @@ func process(storage database.Datastore, image *types.Image, reg types.Registry,
 }
 
 func isEmptyLayer(layer string) bool {
-	return layer == emptyLayer
+	return layer == "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+}
+
+func isEmptyLayerSize(size int64) bool {
+	return size == 32
 }
 
 func parseV1Layers(manifest *schema1.SignedManifest) []string {
@@ -103,7 +103,7 @@ func parseV1Layers(manifest *schema1.SignedManifest) []string {
 func parseLayers(manifestLayers []distribution.Descriptor) []string {
 	var layers []string
 	for _, layer := range manifestLayers {
-		if isEmptyLayer(layer.Digest.String()) {
+		if isEmptyLayer(layer.Digest.String()) || isEmptyLayerSize(layer.Size) {
 			continue
 		}
 		layers = append(layers, layer.Digest.String())


### PR DESCRIPTION
Open to other ideas, but I think this will work

WORKDIRs and other things that will not influence vulns will now have a layer that is non empty, but instead will be 32 bytes. We have a general fundamental problem that we assume that layers are unique, which is in fact false as seen below.

However, it should fix issues like where WORKDIR is not nil and it has a layer digest like 4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 which based on a google is certainly not unique: https://www.google.com/search?q=4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1

```
FROM alpine:latest
RUN echo foo >a.txt
RUN rm a.txt
RUN echo foo >a.txt
RUN rm a.txt
```

```
{
	"schemaVersion": 2,
	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
	"config": {
		"mediaType": "application/vnd.docker.container.image.v1+json",
		"size": 1440,
		"digest": "sha256:abbb07730a4d610c18326dc361270c7fa87e72465fc0c72b59aa0dc80fd99b0b"
	},
	"layers": [
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 2811969,
			"digest": "sha256:540db60ca9383eac9e418f78490994d0af424aab7bf6d0e47ac8ed4e2e9bcbba"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 134,
			"digest": "sha256:48f75b344bd7c2e8af665bdbcedee7f87841b0d881671fe509a6d9a512d9bcd3"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 121,
			"digest": "sha256:bc59688b1849eb39e529b4d712c06c8157d9828187bd531a15428eabbaaf046f"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 134,
			"digest": "sha256:48f75b344bd7c2e8af665bdbcedee7f87841b0d881671fe509a6d9a512d9bcd3"
		},
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 123,
			"digest": "sha256:ba445a5ccb84acb45da5035a15351bec1e01edb3136ee484f2fa86d70a519c21"
		}
	]
}
```