### PR TITLE
Fix updater by turning on debug logging for genesis

### DIFF
--- a/cmd/updater/loaddump/cmd.go
+++ b/cmd/updater/loaddump/cmd.go
@@ -25,6 +25,7 @@ func Command() *cobra.Command {
 	)
 
 	c.RunE = func(_ *cobra.Command, _ []string) error {
+		log.SetLevel(log.DebugLevel)
 		log.Infof("Attempting to open DB at %s:%d", postgresHost, postgresPort)
 		db, err := database.OpenWithRetries(database.RegistrableComponentConfig{
 			Type: "pgsql",


### PR DESCRIPTION
Circle times out after 10m of no prints, I removed the prints in the last commit