### PR TITLE
Optimize Scanner DB startup and operations

### DIFF
--- a/image/db/postgresql.conf
+++ b/image/db/postgresql.conf
@@ -195,9 +195,9 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 # - Settings -
 
-#wal_level = replica			# minimal, replica, or logical
+wal_level = minimal			# minimal, replica, or logical
 					# (change requires restart)
-#fsync = on				# flush data to disk for crash safety
+fsync = off				# flush data to disk for crash safety
 					# (turning this off can cause
 					# unrecoverable data corruption)
 #synchronous_commit = on		# synchronization level;
@@ -226,7 +226,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 # - Checkpoints -
 
 #checkpoint_timeout = 5min		# range 30s-1d
-max_wal_size = 1GB
+max_wal_size = 4GB
 min_wal_size = 80MB
 #checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
 #checkpoint_flush_after = 256kB		# measured in pages, 0 disables

--- a/image/db/postgresql.conf
+++ b/image/db/postgresql.conf
@@ -288,7 +288,7 @@ min_wal_size = 80MB
 
 # Set these on the master and on any standby that will send replication data.
 
-#max_wal_senders = 10		# max number of walsender processes
+max_wal_senders = 0		# max number of walsender processes
 				# (change requires restart)
 #wal_keep_segments = 0		# in logfile segments; 0 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables


### PR DESCRIPTION
Start up time went from a minute+ to 20s

- We rebuild the DB every time it moves so fsync'ing is not required (will try with some localized db restarts)
- Increase WAL size prevents checkpoints during initial copys