### PR TITLE
Modify WAL settings to allow for faster initial load

### DIFF
--- a/image/db/postgresql.conf
+++ b/image/db/postgresql.conf
@@ -195,7 +195,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 # - Settings -
 
-#wal_level = replica			# minimal, replica, or logical
+wal_level = minimal			# minimal, replica, or logical
 					# (change requires restart)
 #fsync = on				# flush data to disk for crash safety
 					# (turning this off can cause
@@ -226,7 +226,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 # - Checkpoints -
 
 #checkpoint_timeout = 5min		# range 30s-1d
-max_wal_size = 1GB
+max_wal_size = 4GB
 min_wal_size = 80MB
 #checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
 #checkpoint_flush_after = 256kB		# measured in pages, 0 disables
@@ -288,7 +288,7 @@ min_wal_size = 80MB
 
 # Set these on the master and on any standby that will send replication data.
 
-#max_wal_senders = 10		# max number of walsender processes
+max_wal_senders = 0		# max number of walsender processes
 				# (change requires restart)
 #wal_keep_segments = 0		# in logfile segments; 0 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables


### PR DESCRIPTION
This is in contrast to the one where I turned fsync off. Want to quantify how much the WAL settings matter vs the fsync where fsync carries more risk imo