### PR TITLE
ROX-7271 vuln update test fix2

### DIFF
--- a/tests/sanity-check-vuln-updates.sh
+++ b/tests/sanity-check-vuln-updates.sh
@@ -172,7 +172,7 @@ function get_gcs_object_age_seconds {
   local diff_id created_time_raw created_time_epoch_sec now_epoch_sec obj_age_seconds
 
   diff_id="$1"
-  created_time_raw=$(grep -A2 "$diff_id" "$FPATH_DIFF_GSUTIL_STAT" | sed -Ene 's/^ +Creation time: +(.*)/\1/p')
+  created_time_raw=$(grep -A3 "$diff_id" "$FPATH_DIFF_GSUTIL_STAT" | sed -Ene 's/^ +Update time: +(.*)/\1/p')
   created_time_epoch_sec=$(parse_date_to_epoch_sec "$created_time_raw" "%a, %d %b %Y %H:%M:%S %Z")
   now_epoch_sec=$(date "+%s")
   obj_age_seconds=$(( now_epoch_sec - created_time_epoch_sec ))


### PR DESCRIPTION
Improve step-wise verifiability and error reporting in sanity-check-vuln-updates.sh test.

Still uncertain of root cause but this will help with more precise failure info when it occurs again. Also added a snippet to manually repro a single diff_id.

### Testing
* This branch -- https://app.circleci.com/pipelines/github/stackrox/scanner/15301/workflows/44cab4b7-2d5d-4f0b-958f-97559b778f0a/jobs/164298
* Master branch -- https://app.circleci.com/pipelines/github/stackrox/scanner/15303/workflows/beb21c05-816d-46dc-93db-06c22a14c0df/jobs/164313