### PR TITLE
Defer cluster creation to avoid janitor teardown mid test run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -798,6 +798,8 @@ workflows:
             - upload-dumps-for-embedding-into-image
       - provision-cluster:
           <<: *runOnAllTagsWithDockerIOPullCtx
+          requires:
+            - create-postgres-dump-from-genesis-dump
       - e2e-tests:
           <<: *runOnAllTagsWithRedHatCtx
           requires:
@@ -856,8 +858,12 @@ workflows:
           - upload-dumps-for-embedding-into-image
     - provision-cluster:
         <<: *runOnAllTagsWithDockerIOPullCtx
+        requires:
+          - create-postgres-dump-from-genesis-dump
     - provision-cluster-rhel:
         <<: *runOnAllTagsWithDockerIOPullCtx
+        requires:
+          - create-postgres-dump-from-genesis-dump
     - e2e-tests:
         <<: *runOnAllTagsWithRedHatCtx
         requires:


### PR DESCRIPTION
Defer cluster creation to avoid janitor teardown mid test run

Teardown: https://app.circleci.com/pipelines/github/stackrox/janitor/68082/workflows/b8d367f0-378d-4be6-b64c-dead273ac059/jobs/453478/steps

Caused this failure: https://app.circleci.com/pipelines/github/stackrox/scanner/15291/workflows/023d4ef8-1156-4314-84ab-949f2b11d4c0

Because dump generation took 50m and Janitor tears down stackrox-scanner-ci clusters after 1h: https://github.com/stackrox/janitor/blob/master/main.go#L27-L30