### PR TITLE
Wrap Debian test data in an empty module

### DIFF
--- a/ext/featurefmt/dpkg/testdata/go.mod
+++ b/ext/featurefmt/dpkg/testdata/go.mod
@@ -1,1 +1,5 @@
+// Files with ":" in the name are not valid files to put int a ZIP.
+// Because of this, adding the Scanner module to Rox does not work properly.
+// To alleviate this, we have an empty module here, so these files are ignored.
+// See https://github.com/golang/go/issues/41402 for more information.
 module github.com/stackrox/scanner/ignore


### PR DESCRIPTION
This allows use to use the scanner module in rox again. Before this, we'd get this error in rox:

```
github.com/stackrox/rox/pkg/clair imports
	github.com/stackrox/scanner/api/v1: create zip: ext/featurefmt/dpkg/testdata/libgcc1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/libgcc1:amd64.list": invalid char ':'
ext/featurefmt/dpkg/testdata/pkg1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/pkg1:amd64.list": invalid char ':'
github.com/stackrox/rox/pkg/clair imports
	github.com/stackrox/scanner/pkg/clairify/client/metadata: create zip: ext/featurefmt/dpkg/testdata/libgcc1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/libgcc1:amd64.list": invalid char ':'
ext/featurefmt/dpkg/testdata/pkg1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/pkg1:amd64.list": invalid char ':'
github.com/stackrox/rox/pkg/clair imports
	github.com/stackrox/scanner/pkg/component: create zip: ext/featurefmt/dpkg/testdata/libgcc1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/libgcc1:amd64.list": invalid char ':'
ext/featurefmt/dpkg/testdata/pkg1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/pkg1:amd64.list": invalid char ':'
github.com/stackrox/rox/pkg/scanners/clairify imports
	github.com/stackrox/scanner/generated/shared/api/v1: create zip: ext/featurefmt/dpkg/testdata/libgcc1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/libgcc1:amd64.list": invalid char ':'
ext/featurefmt/dpkg/testdata/pkg1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/pkg1:amd64.list": invalid char ':'
github.com/stackrox/rox/pkg/scanners/clairify imports
	github.com/stackrox/scanner/pkg/clairify/client: create zip: ext/featurefmt/dpkg/testdata/libgcc1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/libgcc1:amd64.list": invalid char ':'
ext/featurefmt/dpkg/testdata/pkg1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/pkg1:amd64.list": invalid char ':'
github.com/stackrox/rox/pkg/scanners/clairify imports
	github.com/stackrox/scanner/pkg/clairify/types: create zip: ext/featurefmt/dpkg/testdata/libgcc1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/libgcc1:amd64.list": invalid char ':'
ext/featurefmt/dpkg/testdata/pkg1:amd64.list: malformed file path "ext/featurefmt/dpkg/testdata/pkg1:amd64.list": invalid char ':'
```

Tested via:

```
github.com/stackrox/scanner ross-empty-go-mod
```

in rox's go.mod file