### PR TITLE
Change default endpoint to central.stackrox.svc

### DIFF
--- a/pkg/updater/genesis_manifests.go
+++ b/pkg/updater/genesis_manifests.go
@@ -35,7 +35,7 @@ type genesisManifest struct {
 func getRelevantDownloadURL(config Config, centralEndpoint string) (downloadURL string, isCentral bool, err error) {
 	if config.FetchFromCentral {
 		if centralEndpoint == "" {
-			centralEndpoint = "https://central.stackrox"
+			centralEndpoint = "https://central.stackrox.svc"
 		}
 		centralEndpoint = urlfmt.FormatURL(centralEndpoint, urlfmt.HTTPS, urlfmt.NoTrailingSlash)
 		return fmt.Sprintf("%s/%s", centralEndpoint, apiPathInCentral), true, nil


### PR DESCRIPTION
Not required for the next release, but just generally something to think about