### PR TITLE
Remove some sanity check for oval update

### DIFF
--- a/e2etests/orchestrator_scan_test.go
+++ b/e2etests/orchestrator_scan_test.go
@@ -65,8 +65,6 @@ func TestGRPCGetOpenShiftVulnerabilities(t *testing.T) {
 				} else if strings.HasPrefix(vuln.Name, "CVE-") {
 					assert.Empty(t, vuln.FixedBy)
 				}
-				assert.NotEmpty(t, vuln.Severity)
-				assert.NotEmpty(t, vuln.Link)
 				assert.True(t, vuln.MetadataV2.CvssV2 != nil || vuln.MetadataV2.CvssV3 != nil)
 				vulnNameMap[vuln.Name] = vuln
 			}


### PR DESCRIPTION
New Redhat oval release removes severity for some RHBAs. Orchestrator scan test fails in sanity check. This diff remove these checks.
A sample looks like:

```
@@ -332,7 +332,7 @@
   </definition>
   <definition class="patch" id="oval:com.redhat.rhba:def:20190024" version="635">
    <metadata>
-    <title>RHBA-2019:0024: OpenShift Container Platform 3.11 bug fix and enhancement update (Important)</title>
+    <title>RHBA-2019:0024: OpenShift Container Platform 3.11 bug fix and enhancement update ()</title>
     <affected family="unix">
      <platform>Red Hat OpenShift Container Platform 3.11</platform>
     </affected>
@@ -360,7 +360,7 @@
 All OpenShift Container Platform 3.11 users are advised to upgrade to these
 updated packages and images.</description>
     <advisory from="secalert@redhat.com">
-     <severity>Important</severity>
+     <severity/>
      <rights>Copyright 2019 Red Hat, Inc.</rights>
      <issued date="2019-01-10"/>
      <updated date="2019-01-10"/>

```