### PR TITLE
Resolve token too large error in dpkg analysis

### DIFF
--- a/ext/featurefmt/dpkg/dpkg.go
+++ b/ext/featurefmt/dpkg/dpkg.go
@@ -23,11 +23,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stackrox/rox/pkg/stringutils"
-
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurefmt"


### PR DESCRIPTION
Found an error when testing the image `jupyter/datascience-notebook@sha256:4267ff0245a632f533ed747b98330211246874c28ee49323ad54345026b4029a`:

```
parsing var/lib/dpkg/status: bufio.Scanner: token too long
```

Reverting back to scanning `var/lib/dpkg/status` line-by-line, as I do not want to make assumptions about the largest potential token.

To repro with 2.19.0:

```
rtannenb:~/go/src/github.com/stackrox/rox$ lroxctl image scan -i jupyter/datascience-notebook@sha256:4267ff0245a632f533ed747b98330211246874c28ee49323ad54345026b4029a
Error: rpc error: code = Internal desc = image enrichment error: error scanning image: docker.io/jupyter/datascience-notebook@sha256:4267ff0245a632f533ed747b98330211246874c28ee49323ad54345026b4029a error: Error scanning "docker.io/jupyter/datascience-notebook@sha256:4267ff0245a632f533ed747b98330211246874c28ee49323ad54345026b4029a" with scanner "Stackrox Scanner": Expected status code 2XX. Received 500 Internal Server Error. Body: {"Error":{"Message":"error processing image \"docker.io/jupyter/datascience-notebook@sha256:4267ff0245a632f533ed747b98330211246874c28ee49323ad54345026b4029a\": parsing var/lib/dpkg/status: bufio.Scanner: token too long"}}
```