### PR TITLE
go1.17.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.0-alpine
+FROM golang:1.17.1-alpine
 
 RUN apk add --update --no-cache build-base
 

--- a/build/Dockerfile_rhel
+++ b/build/Dockerfile_rhel
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ENV GOLANG_VERSION "1.17"
+ENV GOLANG_VERSION "1.17.1"
 
 RUN yum update -y && yum install -y epel-release dnf-plugins-core
 RUN yum -y groupinstall "Development Tools"


### PR DESCRIPTION
Scanner 2.19.x is used in rox version 65. go1.17.1 has the same vuln fix as go1.16.8