### PR TITLE
Don't run uploads when building tagged releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ commands:
             set +e
             if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
               echo "On master, running the step"
-            else if [[ -n "${CIRCLE_TAG}" ]]; then
+            elif [[ -n "${CIRCLE_TAG}" ]]; then
               if [[ "<< parameters.runOnTag >>" == "true" ]]; then
                 echo "On tag ${CIRCLE_TAG} with runOnTag set to true, running the step"
               else


### PR DESCRIPTION
We still need to build the genesis dump because of potential schema changes and we cannot just download the values. We should not upload diffs because these could be diffs from older versions of scanner that we support. Diffs should only be uploaded from the master branch