### PR TITLE
RS-251: Publish scanner and db artifacts for CPaaS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -847,7 +847,7 @@ jobs:
             "${cmd[@]}" gsutil cp /tmp/postgres/pg-definitions.sql.gz "$destination"
             # Note that we include genesis manifests for the downstream to avoid the situation when dumps taken from
             # GCloud are older than manifests taken from the source code repo.
-            "${cmd[@]}" gsutil cp /tmp/image/scanner/dump/genesis_manifests.json "$destination"
+            "${cmd[@]}" gsutil cp image/scanner/dump/genesis_manifests.json "$destination"
 
   create-diff-dumps:
     <<: *defaults


### PR DESCRIPTION
Malte, Connor and I decided that `definitions.stackrox.io`, a public bucket will be the destination for these files.

As was discussed with Malte and Connor, versioning is not a concern yet. We will adjust if it becomes so.

## Testing done

Relying on CI.
Also listed files in the directory:
```bash
$ gsutil ls -lh gs://definitions.stackrox.io/scanner-data/2.20.0-10-g8fdc0c386a/
 28.03 KiB  2021-10-11T16:59:47Z  gs://definitions.stackrox.io/scanner-data/2.20.0-10-g8fdc0c386a/k8s-definitions.zip
 36.72 MiB  2021-10-11T16:59:45Z  gs://definitions.stackrox.io/scanner-data/2.20.0-10-g8fdc0c386a/nvd-definitions.zip
108.66 MiB  2021-10-11T16:59:51Z  gs://definitions.stackrox.io/scanner-data/2.20.0-10-g8fdc0c386a/pg-definitions.sql.gz
    27 KiB  2021-10-11T16:59:48Z  gs://definitions.stackrox.io/scanner-data/2.20.0-10-g8fdc0c386a/repo2cpe.zip
TOTAL: 4 objects, 152493725 bytes (145.43 MiB)
```
