### PR TITLE
Remove CVE-2010-4051 and CVE-2010-4052 from test

### DIFF
--- a/e2etests/vuln_test.go
+++ b/e2etests/vuln_test.go
@@ -288,7 +288,6 @@ func TestDistrolessVulnImages(t *testing.T) {
 					{name: "CVE-2019-1010024"},
 					{name: "CVE-2018-6485"},
 					{name: "CVE-2019-9169"},
-					{name: "CVE-2010-4052"},
 					{name: "CVE-2015-8985"},
 					{name: "CVE-2016-10228"},
 					{name: "CVE-2019-1010022"},


### PR DESCRIPTION
https://security-tracker.debian.org/tracker/CVE-2010-4051 https://security-tracker.debian.org/tracker/CVE-2010-4052 the CVEs were fixed in this version. Not exactly sure why we only found out now? Perhaps it was so old that nobody cared to check until now?