### PR TITLE
DO NOT MERGE: Push scanner artifacts to tagged 2.22.0 location for use downstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -818,9 +818,6 @@ jobs:
             destination="gs://definitions.stackrox.io/scanner-data/2.20.0/"
 
             cmd=()
-            if [[ "${CIRCLE_BRANCH}" != "master" && -z "${CIRCLE_TAG}" ]]; then
-              #cmd+=(echo "Would do")
-            fi
 
             "${cmd[@]}" gsutil cp /tmp/vuln-dump/nvd-definitions.zip "$destination"
             "${cmd[@]}" gsutil cp /tmp/vuln-dump/k8s-definitions.zip "$destination"


### PR DESCRIPTION
Currently, the latest tag seen by Red Hat downstream is `2.22.0`, however there
are no artifacts for it because pushing step was added later.

```
$ gsutil ls gs://definitions.stackrox.io/scanner-data/
  gs://definitions.stackrox.io/scanner-data/2.20.0-10-g8fdc0c386a/
  gs://definitions.stackrox.io/scanner-data/2.20.0-15-ge118b05a27/
  gs://definitions.stackrox.io/scanner-data/2.20.0-16-g6447e425f7/
  gs://definitions.stackrox.io/scanner-data/latest/
```

I'm pushing the current state in 2.22.0 directory in order to fully test the
downstream procedure.