### PR TITLE
Fix downstream dumps upload on tagged build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,7 +749,7 @@ jobs:
       - checkout
       - check-label-to-run:
           label: generate-dumps-on-pr
-          runOnTag: false
+          runOnTag: true
 
       - setup-gcp
       - attach_workspace:
@@ -799,13 +799,7 @@ jobs:
           command: |
             set -x
 
-            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-              # For the master branch we store artifacts in "unversioned" way to make sure this upload job works and
-              # does not break on more rare tagged builds. Note that we should not consume these latest builds
-              # downstream, we should use tagged ones instead becase otherwise the master branch can introduce format
-              # changes that the downstream release can be unprepared to deal with.
-              scanner_version="latest"
-            else
+            if [[ -n "${CIRCLE_TAG}" || "${CIRCLE_BRANCH}" != "master" ]]; then
               # Tagged builds are the main ones for which we push artifacts and we use the tag as label. Makefile will
               # return tag in the `2.20.0` format for them.
 
@@ -814,6 +808,12 @@ jobs:
               # enabled for ability to dry-run this upload job.
 
               scanner_version="$(make --quiet --no-print-directory tag)"
+            else
+              # For the master branch we store artifacts in "unversioned" way to make sure this upload job works and
+              # does not break on more rare tagged builds. Note that we should not consume these latest builds
+              # downstream, we should use tagged ones instead becase otherwise the master branch can introduce format
+              # changes that the downstream release can be unprepared to deal with.
+              scanner_version="latest"
             fi
             destination="gs://definitions.stackrox.io/scanner-data/${scanner_version}/"
 


### PR DESCRIPTION
Blobs upload job did not find blobs in the workspace - https://app.circleci.com/pipelines/github/stackrox/scanner/19362/workflows/a0dca865-c4a7-409b-a168-582659cdca0d/jobs/199516?invite=true#step-105-43
because the step to prepare them was skipped - https://app.circleci.com/pipelines/github/stackrox/scanner/19362/workflows/a0dca865-c4a7-409b-a168-582659cdca0d/jobs/199503?invite=true#step-102-25

This happened due to `upload-dumps-for-embedding-into-image` being skipped on tagged builds.
This job is already enabled for master branch and does upload only for master branch. Therefore enabling tagged builds should effectively allow it to run for `master` branch when the commit is tagged.