### PR TITLE
DO NOT MERGE: Push scanner artifacts to tagged 2.22.1 location for use downstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -815,12 +815,9 @@ jobs:
               # changes that the downstream release can be unprepared to deal with.
               scanner_version="latest"
             fi
-            destination="gs://definitions.stackrox.io/scanner-data/${scanner_version}/"
+            destination="gs://definitions.stackrox.io/scanner-data/2.20.1/"
 
             cmd=()
-            if [[ "${CIRCLE_BRANCH}" != "master" && -z "${CIRCLE_TAG}" ]]; then
-              cmd+=(echo "Would do")
-            fi
 
             "${cmd[@]}" gsutil cp /tmp/vuln-dump/nvd-definitions.zip "$destination"
             "${cmd[@]}" gsutil cp /tmp/vuln-dump/k8s-definitions.zip "$destination"


### PR DESCRIPTION
Currently, the latest tag seen by Red Hat downstream is `2.22.1`, however there are no artifacts for it because pushing step failed (info here https://github.com/stackrox/scanner/pull/514 ).

I'm pushing the current state in 2.22.1 directory in order to fully test the downstream procedure.