### PR TITLE
RS-307 update cache-control sanity test

### DIFF
--- a/tests/sanity-check-vuln-updates.sh
+++ b/tests/sanity-check-vuln-updates.sh
@@ -138,7 +138,7 @@ EOF
 
   if [[ "$cache_control_cloudflare" != "cache-control: public, max-age=3600" ]]; then
     # known issue -- https://stack-rox.atlassian.net/browse/RS-307
-    warn "Incorrect cloudflare cache control setting, expected max-age=3600"
+    testfail "Incorrect cloudflare cache control setting, expected max-age=3600"
   fi
 
   if [[ "$cache_control_gcs_https" != "cache-control: public, max-age=3600" ]]; then


### PR DESCRIPTION
https://stack-rox.atlassian.net/browse/RS-307

Cleaned up the test and enabled CDN cache-control verification with https://github.com/stackrox/scanner/pull/517 but this required a second CDN to compare against. I have lots of test data demonstrating correct behavior from both CDN’s with respect to our use case so the secondary CDN is no longer needed.

Removing the google cdn checks from test with this PR.