### PR TITLE
RS-322: Unify uninstall commands

### DIFF
--- a/image/scanner/rhel/Dockerfile
+++ b/image/scanner/rhel/Dockerfile
@@ -34,7 +34,7 @@ COPY ./THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 RUN dnf upgrade -y && \
     dnf install -y ca-certificates xz && \
     dnf clean all && \
-    # (Optional) Remove line below to keep package management utilities other than rpm
+    # (Optional) Remove line below to keep package management utilities
     # We don't uninstall rpm because scanner uses it to get packages installed in scanned images.
     rpm -e --nodeps $(rpm -qa curl '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf && \

--- a/testimages/package-removal/Dockerfile.centos
+++ b/testimages/package-removal/Dockerfile.centos
@@ -1,3 +1,3 @@
 FROM centos
 
-RUN rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')
+RUN rpm -e --nodeps curl yum rpm rpm-libs rpm-build-libs

--- a/testimages/package-removal/Dockerfile.rhel
+++ b/testimages/package-removal/Dockerfile.rhel
@@ -1,3 +1,3 @@
 FROM registry.access.redhat.com/ubi7/ubi
 
-RUN rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')
+RUN rpm -e --nodeps curl yum yum-utils yum-plugin-ovl subscription-manager rpm rpm-libs rpm-build-libs rpm-python subscription-manager-rhsm


### PR DESCRIPTION
This PR is a follow-up to the following tickets:
- https://stack-rox.atlassian.net/browse/RS-239
- https://stack-rox.atlassian.net/browse/RS-301

It unifies the command used to uninstall undesired packages from the Docker image.
The unified command was proposed as `rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')` with **exception** for `scanner` to not remove `rpm`.

Additionally, it was discussed in Slack (link to the discussion in the ticket https://stack-rox.atlassian.net/browse/RS-322) that we should not remove `subscription-manager` as it cannot be used to install potentially malicious components.

## How tested

~~Did `docker build` and `docker run` afterwards and manually confirmed that package managers are removed but `rpm` and `subscription-manager` kept.~~ 

Unable to build this image locally 
```
➜ make scanner-image
env: Studio: No such file or directory
...
env: Studio: No such file or directory
make: *** [scanner-image-builder] Error 127
```

so I trust that CI would complain if, for example, `rpm` binary would be missing.