### PR TITLE
Update rox-ci-image to 0.3.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 defaultImage: &defaultImage
-  image: "quay.io/rhacs-eng/apollo-ci:snapshot-0.3.20-6-gd7f3289019" # TODO(do not merge): After upstream PR is merged, cut a tag and update this
+  image: "quay.io/rhacs-eng/apollo-ci:0.3.21"
   auth:
     username: $QUAY_RHACS_ENG_RO_USERNAME
     password: $QUAY_RHACS_ENG_RO_PASSWORD


### PR DESCRIPTION
This PR exists to ensure that changes introduced in https://github.com/stackrox/rox-ci-image/pull/96 do not break anything in scanner. 

This is a brother-PR for https://github.com/stackrox/stackrox/pull/84 and https://github.com/stackrox/collector/pull/527

Want to update? See what's new in release notes [rox-ci-image/releases](https://github.com/stackrox/rox-ci-image/releases)