### PR TITLE
Update Genesis Manifest

### DIFF
--- a/image/scanner/dump/genesis_manifests.json
+++ b/image/scanner/dump/genesis_manifests.json
@@ -278,6 +278,14 @@
       "config": {
         "useLegacyUbuntuCVEURLPrefix": true
       }
+    },
+    {
+      "dumpLocationInGS": "gs://stackrox-scanner-ci-vuln-dump/genesis-20211215190451.zip",
+      "timestamp": "2021-12-15T19:04:51.213300844Z",
+      "uuid": "8d54d209-931c-47b2-a5ef-edc32d39b639",
+      "config": {
+        "useLegacyUbuntuCVEURLPrefix": true
+      }
     }
   ]
 }


### PR DESCRIPTION
Keeping the `useLegacyUbuntuCVEURLPrefix` until we make a new scanner release