### PR TITLE
ROX-8830: Bump ci-image to test recent changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 defaultImage: &defaultImage
-  image: "quay.io/rhacs-eng/apollo-ci:snapshot-0.3.21-28-g58a71b043d" # TODO(do not merge): After upstream PR is merged, cut a tag and update this
+  image: "quay.io/rhacs-eng/apollo-ci:snapshot-0.3.22-10-gb5ac40be83" # TODO(do not merge): After upstream PR is merged, cut a tag and update this
   auth:
     username: $QUAY_RHACS_ENG_RO_USERNAME
     password: $QUAY_RHACS_ENG_RO_PASSWORD


### PR DESCRIPTION
This PR exists to make sure that the changes from https://github.com/stackrox/rox-ci-image/pull/99 are not breaking anything.

The fix (applies mainly to stackrox and scanner) introduced in:
- https://github.com/stackrox/rox-ci-image/pull/99
- and https://github.com/stackrox/rox-ci-image/pull/102

Brother-PRs:
- https://github.com/stackrox/stackrox/pull/190/ && https://github.com/stackrox/stackrox/pull/241
- https://github.com/stackrox/collector/pull/537