### PR TITLE
ROX-7520: Add Busybox namespace detector 

### DIFF
--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -59,6 +59,7 @@ import (
 	_ "github.com/stackrox/scanner/ext/featurefmt/rpm"
 	_ "github.com/stackrox/scanner/ext/featurens/alpinerelease"
 	_ "github.com/stackrox/scanner/ext/featurens/aptsources"
+	_ "github.com/stackrox/scanner/ext/featurens/busybox"
 	_ "github.com/stackrox/scanner/ext/featurens/lsbrelease"
 	_ "github.com/stackrox/scanner/ext/featurens/osrelease"
 	_ "github.com/stackrox/scanner/ext/featurens/redhatrelease"

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3021,4 +3021,10 @@ var testCases = []testCase{
 			},
 		},
 	},
+	{
+		image:     "docker.io/busybox:1.35.0",
+		registry:  "https://registry-1.docker.io",
+		source:    "NVD",
+		namespace: "busybox:1.35.0",
+	},
 }

--- a/ext/featurens/busybox/busybox.go
+++ b/ext/featurens/busybox/busybox.go
@@ -1,0 +1,97 @@
+// Package busybox implements a featurens.Detector for container images
+// layers based on busybox[1].
+//
+// [1]: https://www.busybox.net/FAQ.html
+//
+// The detector assumes a Busybox image has the following attributes:
+//
+// 1. Does not contain any freedesktop standard release file (os-release, lsb-release).
+//
+// 2. `/bin/[` and `/bin/busybox` are hard-links.
+//
+// 3. The busybox binary contains a version string on the form "BusyBox vX.Y.Z"
+//
+package busybox
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+
+	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/ext/featurens"
+	"github.com/stackrox/scanner/ext/versionfmt/language"
+	"github.com/stackrox/scanner/pkg/tarutil"
+)
+
+type detector struct{}
+
+var (
+	busyboxVersionMatcher = regexp.MustCompile(`BusyBox v(\d)+\.(\d)+\.(\d)+`)
+	blockedFiles          = []string{
+		"etc/os-release",
+		"etc/lsb-release",
+		"usr/lib/os-release",
+		"usr/lib/lsb-release",
+	}
+)
+
+const (
+	busyboxPath = "bin/busybox"
+	sbPath      = "bin/["
+)
+
+func init() {
+	featurens.RegisterDetector("busybox", &detector{})
+}
+
+func parseBusyBoxVersion(contents []byte) string {
+	matches := busyboxVersionMatcher.FindAllString(string(contents), -1)
+	for _, match := range matches {
+		parts := strings.Split(match, " ")
+		version := strings.ReplaceAll(parts[1], "v", "")
+		return version
+	}
+	return ""
+}
+
+func (detector) Detect(files tarutil.LayerFiles, options *featurens.DetectorOptions) *database.Namespace {
+	for _, filePath := range blockedFiles {
+		if _, hasFile := files.Get(filePath); hasFile {
+			return nil
+		}
+	}
+
+	busyboxData, ok := files.Get(busyboxPath)
+	if !ok {
+		return nil
+	}
+	sbData, ok := files.Get(sbPath)
+	if !ok {
+		return nil
+	}
+
+	// Guarding against the odds of an image shipping different coreutils being
+	// classified as busybox.
+	if !bytes.Equal(busyboxData.Contents, sbData.Contents) {
+		return nil
+	}
+
+	// Validate busybox binary and extract version.
+	var version = parseBusyBoxVersion(busyboxData.Contents)
+	if version == "" {
+		return nil
+	}
+
+	return &database.Namespace{
+		Name:          "busybox" + ":" + version,
+		VersionFormat: language.ParserName,
+	}
+}
+
+func (detector) RequiredFilenames() []string {
+	// FIXME Currently we cannot extract contents of hard links unless we explicitly
+	//       whitelist its target; In tar that's a previously archived file, which
+	//       we observed to be ``/bin/[``.
+	return []string{sbPath, busyboxPath}
+}

--- a/ext/featurens/busybox/busybox_test.go
+++ b/ext/featurens/busybox/busybox_test.go
@@ -1,0 +1,100 @@
+package busybox
+
+import (
+	"testing"
+
+	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/ext/featurens"
+	"github.com/stackrox/scanner/ext/versionfmt/language"
+	"github.com/stackrox/scanner/pkg/tarutil"
+)
+
+func Test_detector_Detect(t *testing.T) {
+	const (
+		bbContent               = "yadda yadda BusyBox v1.2.3.git yadda"
+		bbContentBadVersion     = "foo Busybox vbar"
+		bbContentNoVersion      = "busybox"
+		bbContentPartialVersion = "foo Busybox v1.2"
+		expectedName            = "busybox:1.2.3"
+	)
+	testData := []featurens.TestData{
+		{
+			// Happy Case.
+			ExpectedNamespace: &database.Namespace{
+				Name:          expectedName,
+				VersionFormat: language.ParserName,
+			},
+			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+				"bin/busybox": {Contents: []byte(bbContent)},
+				"bin/[":       {Contents: []byte(bbContent)},
+			}),
+		},
+		// Invalid busybox version strings.
+		{
+			ExpectedNamespace: nil,
+			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+				"bin/busybox": {Contents: []byte(bbContentNoVersion)},
+				"bin/[":       {Contents: []byte(bbContentNoVersion)},
+			}),
+		},
+		{
+			ExpectedNamespace: nil,
+			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+				"bin/busybox": {Contents: []byte(bbContentBadVersion)},
+				"bin/[":       {Contents: []byte(bbContentBadVersion)},
+			}),
+		},
+		{
+			ExpectedNamespace: nil,
+			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+				"bin/busybox": {Contents: []byte(bbContentPartialVersion)},
+				"bin/[":       {Contents: []byte(bbContentPartialVersion)},
+			}),
+		},
+		// Unexpected coreutils or unnexpected files.
+		{
+			ExpectedNamespace: nil,
+			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+				"bin/busybox": {Contents: []byte("something else")},
+				"bin/[":       {Contents: []byte(bbContent)},
+			}),
+		},
+		{
+			ExpectedNamespace: nil,
+			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+				"bin/busybox": {Contents: []byte(bbContent)},
+				"bin/[":       {Contents: []byte("something else")},
+			}),
+		},
+		{
+			ExpectedNamespace: nil,
+			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+				"bin/busybox": {Contents: []byte(bbContent)},
+			}),
+		},
+		{
+			ExpectedNamespace: nil,
+			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+				"bin/[": {Contents: []byte(bbContent)},
+			}),
+		},
+		// Blocked files.
+		{
+			ExpectedNamespace: nil,
+			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+				"etc/os-release": {},
+				"bin/busybox":    {Contents: []byte(bbContent)},
+				"bin/[":          {Contents: []byte(bbContent)},
+			}),
+		},
+		{
+			ExpectedNamespace: nil,
+			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+				"etc/lsb-release": {},
+				"bin/busybox":     {Contents: []byte(bbContent)},
+				"bin/[":           {Contents: []byte(bbContent)},
+			}),
+		},
+	}
+	featurens.TestDetector(t, &detector{}, testData)
+}

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -131,24 +131,29 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 			}
 
 			executable, _ := executableMatcher.Match(filename, hdr.FileInfo(), contents)
-			if !extractContents || hdr.Typeflag != tar.TypeReg {
-				fileData.Executable = executable
-				files.data[filename] = fileData
-				continue
-			}
 
-			d := make([]byte, hdr.Size)
-			if nRead, err := contents.ReadAt(d, 0); err != nil {
-				log.Errorf("error reading %q: %v", hdr.Name, err)
-				d = d[:nRead]
-			}
+			if extractContents {
+				if hdr.Typeflag == tar.TypeLink {
+					// A hard-link necessarily points to a previous absolute path in the
+					// archive which we look if it was already extracted.
+					linkedFile, ok := files.data[hdr.Linkname]
+					if ok {
+						fileData.Contents = linkedFile.Contents
+					}
+				} else {
+					d := make([]byte, hdr.Size)
+					if nRead, err := contents.ReadAt(d, 0); err != nil {
+						log.Errorf("error reading %q: %v", hdr.Name, err)
+						d = d[:nRead]
+					}
 
-			// Put the file directly
-			fileData.Contents = d
+					// Put the file directly
+					fileData.Contents = d
+					numExtractedContentBytes += len(d)
+				}
+			}
 			fileData.Executable = executable
 			files.data[filename] = fileData
-
-			numExtractedContentBytes += len(d)
 		case tar.TypeSymlink:
 			files.links[filename] = path.Clean(path.Join(path.Dir(filename), hdr.Linkname))
 		case tar.TypeDir:


### PR DESCRIPTION
## What is this change

Introduce a namespace detector to identify container images based on [busybox](https://hub.docker.com/_/busybox).

## Why the change

Customers want to identify that the OS is busybox instead of "unknown".

## Tests

- [x] Detector unit tests.
- [x] End-to-end tests
