### PR TITLE
Add test cases for Fedora

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3021,4 +3021,18 @@ var testCases = []testCase{
 			},
 		},
 	},
+	{
+		image:                   "fedora:33",
+		registry:                "https://registry-1.docker.io",
+		source:                  "Red Hat",
+		onlyCheckSpecifiedVulns: true,
+		namespace:               "fedora:33",
+	},
+	{
+		image:                   "fedora:35",
+		registry:                "https://registry-1.docker.io",
+		source:                  "Red Hat",
+		onlyCheckSpecifiedVulns: true,
+		namespace:               "fedora:33",
+	},
 }


### PR DESCRIPTION
Since we do not officially support it, as there are no vulnerability feeds, just ensuring we detect Fedora