### PR TITLE
ROX-9497: Make use of the injected CA bundle

### DIFF
--- a/image/scanner/scripts/import-additional-cas
+++ b/image/scanner/scripts/import-additional-cas
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 copy_existing () {
-    src=$1
+    src="$1"
     if [ -d "$src" ] && [ "$(ls -A -I "..*" "$src")" ]; then
         cp -v -L "$src"/* /etc/pki/ca-trust/source/anchors
     else
@@ -14,4 +14,4 @@ copy_existing () {
 copy_existing /usr/local/share/ca-certificates
 copy_existing /etc/pki/injected-ca-trust
 
-update-ca-trust
+update-ca-trust extract

--- a/image/scanner/scripts/import-additional-cas
+++ b/image/scanner/scripts/import-additional-cas
@@ -5,8 +5,8 @@ set -euo pipefail
 lines=$(for d in /usr/local/share/ca-certificates /etc/pki/injected-ca-trust
 do
     if [ -d "$d" ]; then
-        find "$d" -maxdepth 1 -type f \
-         -print -exec cp -L {} /etc/pki/ca-trust/source/anchors \;
+        find "$d" -maxdepth 1 -type f -print0 | \
+            xargs --no-run-if-empty -0 cp -t /etc/pki/ca-trust/source/anchors
     fi
 done | wc -l)
 

--- a/image/scanner/scripts/import-additional-cas
+++ b/image/scanner/scripts/import-additional-cas
@@ -2,7 +2,10 @@
 
 set -euo pipefail
 
-[ -d /usr/local/share/ca-certificates ] || exit 0
-[ "$(find /usr/local/share/ca-certificates -maxdepth 1 -name '*.crt' | wc -l)" -gt 0 ] || exit 0
-cp -L /usr/local/share/ca-certificates/* /etc/pki/ca-trust/source/anchors
-update-ca-trust
+lines=$(for d in /usr/local/share/ca-certificates /etc/pki/injected-ca-trust
+do
+    [ -d "$d" ] && find "$d" -maxdepth 1 -name '*.crt' -o -name '*.pem' \
+         -print -exec cp -L {} /etc/pki/ca-trust/source/anchors \;
+done | wc -l)
+
+[ "$lines" -gt 0 ] && update-ca-trust

--- a/image/scanner/scripts/import-additional-cas
+++ b/image/scanner/scripts/import-additional-cas
@@ -2,15 +2,5 @@
 
 set -euo pipefail
 
-lines=$(for d in /usr/local/share/ca-certificates /etc/pki/injected-ca-trust
-do
-    if [ -d "$d" ]; then
-        find "$d" -maxdepth 1 -type f -print0 | \
-            xargs --no-run-if-empty -0 cp -t /etc/pki/ca-trust/source/anchors
-    fi
-done | wc -l)
-
-if (( lines )); then
-    update-ca-trust extract
-fi
-
+cp -L /usr/local/share/ca-certificates/* /etc/pki/injected-ca-trust \
+    /etc/pki/ca-trust/source/anchors && update-ca-trust || echo "No custom certificates"

--- a/image/scanner/scripts/import-additional-cas
+++ b/image/scanner/scripts/import-additional-cas
@@ -4,8 +4,13 @@ set -euo pipefail
 
 lines=$(for d in /usr/local/share/ca-certificates /etc/pki/injected-ca-trust
 do
-    [ -d "$d" ] && find "$d" -maxdepth 1 -name '*.crt' -o -name '*.pem' \
+    if [ -d "$d" ]; then
+        find "$d" -maxdepth 1 -type f \
          -print -exec cp -L {} /etc/pki/ca-trust/source/anchors \;
+    fi
 done | wc -l)
 
-[ "$lines" -gt 0 ] && update-ca-trust
+if (( lines )); then
+    update-ca-trust extract
+fi
+

--- a/image/scanner/scripts/import-additional-cas
+++ b/image/scanner/scripts/import-additional-cas
@@ -1,6 +1,17 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 
-cp -L /usr/local/share/ca-certificates/* /etc/pki/injected-ca-trust/* \
-    /etc/pki/ca-trust/source/anchors && update-ca-trust || echo "No custom certificates"
+copy_existing () {
+    src=$1
+    if [ -d "$src" ] && [ "$(ls -A -I "..*" "$src")" ]; then
+        cp -v -L "$src"/* /etc/pki/ca-trust/source/anchors
+    else
+        echo "No certificates found in $src"
+    fi
+}
+
+copy_existing /usr/local/share/ca-certificates
+copy_existing /etc/pki/injected-ca-trust
+
+update-ca-trust

--- a/image/scanner/scripts/import-additional-cas
+++ b/image/scanner/scripts/import-additional-cas
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-cp -L /usr/local/share/ca-certificates/* /etc/pki/injected-ca-trust \
+cp -L /usr/local/share/ca-certificates/* /etc/pki/injected-ca-trust/* \
     /etc/pki/ca-trust/source/anchors && update-ca-trust || echo "No custom certificates"


### PR DESCRIPTION
Update the `import-additional-cas` to copy the injected CA bundle to the common location before calling `update-ca-trust`.

> Cluster administrators can configure additional trusted CAs in OpenShift. The combined set of trusted CAs (from a cluster perspective) can be obtained by creating an empty ConfigMap with a special label attached to it. An operator will then inject the trusted CAs into a well-defined field of the configmap.

Related PR to stackrox: https://github.com/stackrox/stackrox/pull/174