### PR TITLE
Add buffer pool

### DIFF
--- a/pkg/ioutils/buffer_pool.go
+++ b/pkg/ioutils/buffer_pool.go
@@ -8,9 +8,13 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 )
 
+var (
+	ErrBufferPoolStopped = errors.New("buffer pool was stopped")
+)
+
 type reservationResponse struct {
-	buf *Buffer
-	err error
+	indexesReleased []int
+	err             error
 }
 
 type reservationRequest struct {
@@ -20,7 +24,7 @@ type reservationRequest struct {
 }
 
 type freeRequest struct {
-	buf *Buffer
+	indexesToFree []int
 }
 
 type BufferPool struct {
@@ -37,7 +41,6 @@ type BufferPool struct {
 	denominationBytes int
 
 	stopSig concurrency.Signal
-	stopped concurrency.Flag
 }
 
 func NewBufferPool(totalSizeBytes, denominationBytes int) (*BufferPool, error) {
@@ -62,14 +65,56 @@ func NewBufferPool(totalSizeBytes, denominationBytes int) (*BufferPool, error) {
 	return b, nil
 }
 
-func (b *BufferPool) cleanupCanceledReservations() {
+func (b *BufferPool) fulfillRequestIfPossible(resReq *reservationRequest) (requestProcessed bool) {
+	// If the request was canceled, remove it.
+	if resReq.cancelSig.IsDone() {
+		close(resReq.responseChan)
+		return true
+	}
+
+	numBuffersRequired := resReq.bytesRequested / b.denominationBytes
+	if resReq.bytesRequested%b.denominationBytes != 0 {
+		numBuffersRequired++
+	}
+	// We cannot fill the request, unfortunately.
+	if b.freeBufferIndexes.Len() < numBuffersRequired {
+		return false
+	}
+	indexesForBuffer := make([]int, 0, numBuffersRequired)
+	elem := b.freeBufferIndexes.Front()
+	for i := 0; i < numBuffersRequired; i++ {
+		indexesForBuffer = append(indexesForBuffer, elem.Value.(int))
+		nextElem := elem.Next()
+		b.freeBufferIndexes.Remove(elem)
+		elem = nextElem
+	}
+	select {
+	case resReq.responseChan <- &reservationResponse{indexesReleased: indexesForBuffer}:
+		return true
+	case <-resReq.cancelSig.Done():
+		close(resReq.responseChan)
+		// Return the indexes to the free list.
+		for _, index := range indexesForBuffer {
+			b.freeBufferIndexes.PushBack(index)
+		}
+		return true
+	case <-b.stopSig.Done():
+		return false
+	}
+}
+
+func (b *BufferPool) fulfillAsManyRequestsAsPossible() {
 	elem := b.reservationQueue.Front()
 	for elem != nil {
-		nextElem := elem.Next()
 		resReq := elem.Value.(*reservationRequest)
-		if resReq.cancelSig.IsDone() {
-			b.reservationQueue.Remove(elem)
+		requestProcessed := b.fulfillRequestIfPossible(resReq)
+		// Couldn't process this request, because there isn't enough space in the queue.
+		// We can't jump to the next request since we are following strict FIFO priority.
+		if !requestProcessed {
+			return
 		}
+		nextElem := elem.Next()
+		b.reservationQueue.Remove(elem)
 		elem = nextElem
 	}
 }
@@ -78,37 +123,15 @@ func (b *BufferPool) manageReservations() {
 	for {
 		select {
 		case <-b.stopSig.Done():
-			b.stopped.Set(true)
 			return
 		case resReq := <-b.reservationChan:
-			b.cleanupCanceledReservations()
-			// If there are reservations, just add this one to the queue
-			if b.reservationQueue.Len() > 0 {
-				b.reservationQueue.PushBack(resReq)
-				continue
-			}
-			numBuffersRequired := resReq.bytesRequested / b.denominationBytes
-			if resReq.bytesRequested%b.denominationBytes != 0 {
-				numBuffersRequired++
-			}
-			// Great, we can fill the request!
-			if b.freeBufferIndexes.Len() > numBuffersRequired {
-				indexesForBuffer := make([]int, 0, numBuffersRequired)
-				elem := b.freeBufferIndexes.Front()
-				for i := 0; i < numBuffersRequired; i++ {
-					indexesForBuffer = append(indexesForBuffer, elem.Value.(int))
-					nextElem := elem.Next()
-					b.freeBufferIndexes.Remove(elem)
-					elem = nextElem
-				}
-				buf := &Buffer{pool: b, heldBufferIndexes: indexesForBuffer}
-				select {
-				case resReq.responseChan <- &reservationResponse{buf: buf}:
-				case <-resReq.cancelSig.Done():
-				}
-			}
+			b.reservationQueue.PushBack(resReq)
+			b.fulfillAsManyRequestsAsPossible()
 		case freeReq := <-b.freeChan:
-			_ = freeReq
+			for _, index := range freeReq.indexesToFree {
+				b.freeBufferIndexes.PushBack(index)
+			}
+			b.fulfillAsManyRequestsAsPossible()
 		}
 	}
 }
@@ -117,28 +140,45 @@ func (b *BufferPool) Stop() {
 	b.stopSig.Signal()
 }
 
-func (b *BufferPool) Make(ctx context.Context, capacity int) (*Buffer, error) {
+func (b *BufferPool) Alloc(ctx context.Context, capacity int) ([]int, error) {
+	if capacity > b.totalSizeBytes {
+		return nil, errors.Errorf("requested capacity (%d) exceeds the total capacity in the pool (%d)", capacity, b.totalSizeBytes)
+	}
 	responseChan := make(chan *reservationResponse)
 	cancelSig := concurrency.NewSignal()
 	select {
 	case b.reservationChan <- &reservationRequest{bytesRequested: capacity, responseChan: responseChan, cancelSig: &cancelSig}:
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	case <-b.stopSig.Done():
+		return nil, ErrBufferPoolStopped
 	}
 	select {
 	case <-ctx.Done():
-		// TODO: clean up request
+		go func() {
+			// Wait until the context closing is acknowledged by closing the channel.
+			// In case there's a race, and the other goroutine sent us buffers before they realized
+			// our context was closed, relinquish those buffers.
+			select {
+			case resp, ok := <-responseChan:
+				if ok && resp.err == nil {
+					b.Free(resp.indexesReleased)
+				}
+			case <-b.stopSig.Done():
+			}
+		}()
 		return nil, ctx.Err()
 	case resp := <-responseChan:
-		return resp.buf, resp.err
+		return resp.indexesReleased, resp.err
+	case <-b.stopSig.Done():
+		return nil, ErrBufferPoolStopped
 	}
 }
 
-func (b *BufferPool) Free(ctx context.Context, buffer *Buffer) {
+func (b *BufferPool) Free(indexes []int) {
 	select {
-	case b.freeChan <- &freeRequest{buffer}:
-	case <-ctx.Done():
-		return
+	case b.freeChan <- &freeRequest{indexesToFree: indexes}:
+	case <-b.stopSig.Done():
 	}
 }
 

--- a/pkg/ioutils/buffer_pool.go
+++ b/pkg/ioutils/buffer_pool.go
@@ -235,6 +235,10 @@ func (b *Buffer) Grow(ctx context.Context, additionalCapacity int64) error {
 	if b.finished {
 		return errBufferFreed
 	}
+	if b.Cap()+additionalCapacity > b.pool.totalSizeBytes {
+		return errors.Errorf("cannot grow buffer of cap %d"+
+			" by %d: total size would exceed max capacity of the buffer pool (%d)", b.Cap(), additionalCapacity, b.pool.totalSizeBytes)
+	}
 	additionalIndexes, err := b.pool.alloc(ctx, additionalCapacity)
 	if err != nil {
 		return err

--- a/pkg/ioutils/buffer_pool.go
+++ b/pkg/ioutils/buffer_pool.go
@@ -3,7 +3,6 @@ package ioutils
 import (
 	"container/list"
 	"context"
-	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -299,12 +298,6 @@ func (b *Buffer) Copy(destination []byte, startingOff int64) int {
 // ReadFullFromReader is like calling io.ReadFull(r, buf[startingOff:readUptoOff]), except that
 // it works on this Buffer.
 func (b *Buffer) ReadFullFromReader(r io.Reader, startingOff, readUptoOff int64) (int, error) {
-	defer func() {
-		if r := recover(); r != nil {
-			fmt.Printf("Caught panic: %+v, %d, %d", b, startingOff, readUptoOff)
-			panic(r)
-		}
-	}()
 	if b.finished {
 		return 0, errBufferFreed
 	}
@@ -330,7 +323,7 @@ func (b *Buffer) ReadFullFromReader(r io.Reader, startingOff, readUptoOff int64)
 		}
 		curBufIdx++
 		curIdxWithinBuf = 0
-		if curBufIdx > len(b.heldBufferIndexes) || curBufIdx > finalBufIdx {
+		if curBufIdx >= len(b.heldBufferIndexes) || curBufIdx > finalBufIdx {
 			break
 		}
 	}

--- a/pkg/ioutils/buffer_pool.go
+++ b/pkg/ioutils/buffer_pool.go
@@ -3,6 +3,7 @@ package ioutils
 import (
 	"container/list"
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -298,6 +299,12 @@ func (b *Buffer) Copy(destination []byte, startingOff int64) int {
 // ReadFullFromReader is like calling io.ReadFull(r, buf[startingOff:readUptoOff]), except that
 // it works on this Buffer.
 func (b *Buffer) ReadFullFromReader(r io.Reader, startingOff, readUptoOff int64) (int, error) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("Caught panic: %+v, %d, %d", b, startingOff, readUptoOff)
+			panic(r)
+		}
+	}()
 	if b.finished {
 		return 0, errBufferFreed
 	}

--- a/pkg/ioutils/buffer_pool.go
+++ b/pkg/ioutils/buffer_pool.go
@@ -1,0 +1,148 @@
+package ioutils
+
+import (
+	"container/list"
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
+)
+
+type reservationResponse struct {
+	buf *Buffer
+	err error
+}
+
+type reservationRequest struct {
+	bytesRequested int
+	responseChan   chan<- *reservationResponse
+	cancelSig      *concurrency.Signal
+}
+
+type freeRequest struct {
+	buf *Buffer
+}
+
+type BufferPool struct {
+	underlyingBuffers [][]byte
+
+	reservationQueue list.List // list of *reservationRequest
+
+	reservationChan chan *reservationRequest
+	freeChan        chan *freeRequest
+
+	freeBufferIndexes *list.List // will be a list of int
+
+	totalSizeBytes    int
+	denominationBytes int
+
+	stopSig concurrency.Signal
+	stopped concurrency.Flag
+}
+
+func NewBufferPool(totalSizeBytes, denominationBytes int) (*BufferPool, error) {
+	if totalSizeBytes <= 0 || denominationBytes <= 0 {
+		return nil, errors.New("total size and denomination must both be >0")
+	}
+	if totalSizeBytes%denominationBytes != 0 {
+		return nil, errors.New("total size must be an exact multiple of the denomination")
+	}
+
+	numBuffers := totalSizeBytes / denominationBytes
+	b := &BufferPool{
+		denominationBytes: denominationBytes,
+		underlyingBuffers: make([][]byte, numBuffers),
+		freeBufferIndexes: list.New(),
+	}
+	for i := 0; i < numBuffers; i++ {
+		b.underlyingBuffers[i] = make([]byte, denominationBytes)
+		b.freeBufferIndexes.PushBack(i)
+	}
+	go b.manageReservations()
+	return b, nil
+}
+
+func (b *BufferPool) cleanupCanceledReservations() {
+	elem := b.reservationQueue.Front()
+	for elem != nil {
+		nextElem := elem.Next()
+		resReq := elem.Value.(*reservationRequest)
+		if resReq.cancelSig.IsDone() {
+			b.reservationQueue.Remove(elem)
+		}
+		elem = nextElem
+	}
+}
+
+func (b *BufferPool) manageReservations() {
+	for {
+		select {
+		case <-b.stopSig.Done():
+			b.stopped.Set(true)
+			return
+		case resReq := <-b.reservationChan:
+			b.cleanupCanceledReservations()
+			// If there are reservations, just add this one to the queue
+			if b.reservationQueue.Len() > 0 {
+				b.reservationQueue.PushBack(resReq)
+				continue
+			}
+			numBuffersRequired := resReq.bytesRequested / b.denominationBytes
+			if resReq.bytesRequested%b.denominationBytes != 0 {
+				numBuffersRequired++
+			}
+			// Great, we can fill the request!
+			if b.freeBufferIndexes.Len() > numBuffersRequired {
+				indexesForBuffer := make([]int, 0, numBuffersRequired)
+				elem := b.freeBufferIndexes.Front()
+				for i := 0; i < numBuffersRequired; i++ {
+					indexesForBuffer = append(indexesForBuffer, elem.Value.(int))
+					nextElem := elem.Next()
+					b.freeBufferIndexes.Remove(elem)
+					elem = nextElem
+				}
+				buf := &Buffer{pool: b, heldBufferIndexes: indexesForBuffer}
+				select {
+				case resReq.responseChan <- &reservationResponse{buf: buf}:
+				case <-resReq.cancelSig.Done():
+				}
+			}
+		case freeReq := <-b.freeChan:
+			_ = freeReq
+		}
+	}
+}
+
+func (b *BufferPool) Stop() {
+	b.stopSig.Signal()
+}
+
+func (b *BufferPool) Make(ctx context.Context, capacity int) (*Buffer, error) {
+	responseChan := make(chan *reservationResponse)
+	cancelSig := concurrency.NewSignal()
+	select {
+	case b.reservationChan <- &reservationRequest{bytesRequested: capacity, responseChan: responseChan, cancelSig: &cancelSig}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case <-ctx.Done():
+		// TODO: clean up request
+		return nil, ctx.Err()
+	case resp := <-responseChan:
+		return resp.buf, resp.err
+	}
+}
+
+func (b *BufferPool) Free(ctx context.Context, buffer *Buffer) {
+	select {
+	case b.freeChan <- &freeRequest{buffer}:
+	case <-ctx.Done():
+		return
+	}
+}
+
+type Buffer struct {
+	pool              *BufferPool
+	heldBufferIndexes []int
+}

--- a/pkg/ioutils/lazy_reader_buffer_pool.go
+++ b/pkg/ioutils/lazy_reader_buffer_pool.go
@@ -16,11 +16,16 @@ type lazyReaderAtWithBufferPool struct {
 	buffer *Buffer
 }
 
+// LazyReaderAtWithBufferPool is like LazyReaderAt, but uses a passed BufferPool under the hood to derive its buffer.
 type LazyReaderAtWithBufferPool interface {
 	io.ReaderAt
+	// FreeBuffer frees the buffer associated with this reader. After this, reads from the buffer will fail.
+	// It is the caller's responsibility to call this when it no longer needs the leader; otherwise, the buffer space
+	// will not be freed up for future callers.
 	FreeBuffer()
 }
 
+// NewLazyReaderAtWithBufferPool returns a ready-to-use LazyReaderAtWithBufferPool with the given bufferPool.
 func NewLazyReaderAtWithBufferPool(reader io.Reader, size int64, bufferPool *BufferPool) (LazyReaderAtWithBufferPool, error) {
 	buf, err := bufferPool.MakeBuffer()
 	if err != nil {

--- a/pkg/ioutils/lazy_reader_buffer_pool.go
+++ b/pkg/ioutils/lazy_reader_buffer_pool.go
@@ -1,0 +1,110 @@
+package ioutils
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+type lazyReaderAtWithBufferPool struct {
+	reader io.Reader
+	size   int64
+
+	mutex sync.RWMutex
+	err   error
+
+	buffer *Buffer
+}
+
+type LazyReaderAtWithBufferPool interface {
+	io.ReaderAt
+	FreeBuffer()
+}
+
+func NewLazyReaderAtWithBufferPool(reader io.Reader, size int64, bufferPool *BufferPool) (LazyReaderAtWithBufferPool, error) {
+	buf, err := bufferPool.MakeBuffer()
+	if err != nil {
+		return nil, err
+	}
+	return &lazyReaderAtWithBufferPool{
+		reader: reader,
+		size:   size,
+		buffer: buf,
+	}, nil
+}
+
+func (r *lazyReaderAtWithBufferPool) FreeBuffer() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.buffer.Free()
+}
+
+func (r *lazyReaderAtWithBufferPool) ReadAt(p []byte, off int64) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if off >= r.size {
+		return 0, io.EOF
+	}
+	n, err := r.tryReadAt(p, off)
+	if n != 0 || err != nil {
+		return n, err
+	}
+
+	if err := r.readUntil(off + int64(len(p))); err != nil {
+		return 0, err
+	}
+
+	return r.tryReadAt(p, off)
+}
+
+func (r *lazyReaderAtWithBufferPool) tryReadAt(p []byte, off int64) (int, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	pos := r.buffer.Len()
+	if off+int64(len(p)) <= pos {
+		return r.buffer.Copy(p, off), nil
+	}
+
+	if r.err != nil {
+		// If we are in error state, that means we have read as much as we could from the reader.
+		// Read whatever is left in the buffer, accompanied by the error.
+		if off >= r.buffer.Len() {
+			return 0, r.err
+		}
+		return r.buffer.Copy(p, off), r.err
+	}
+
+	return 0, nil
+}
+
+func (r *lazyReaderAtWithBufferPool) readUntil(pos int64) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if pos > r.size {
+		pos = r.size
+	}
+
+	if pos <= r.buffer.Len() {
+		return nil
+	}
+
+	if bufSize := r.buffer.Cap(); bufSize < pos {
+		// Grow the buffer to the size required
+		if err := r.buffer.Grow(context.Background(), pos-bufSize); err != nil {
+			return err
+		}
+	}
+
+	oldPos := r.buffer.Len()
+	_, err := r.buffer.ReadFullFromReader(r.reader, oldPos, pos)
+	if err != nil {
+		r.err = err
+	} else if pos == r.size {
+		r.err = io.EOF
+	}
+	return nil
+}

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -25,7 +25,6 @@ import (
 	"os/exec"
 	"path"
 	"strings"
-	"sync"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -58,8 +57,6 @@ var (
 // See comments on the maxExtractableFileSize variable for
 // more details on its purpose.
 func SetMaxExtractableFileSize(val int64) {
-	a := new(sync.Pool)
-	a.Get()
 	maxExtractableFileSize = val
 }
 

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -57,6 +58,8 @@ var (
 // See comments on the maxExtractableFileSize variable for
 // more details on its purpose.
 func SetMaxExtractableFileSize(val int64) {
+	a := new(sync.Pool)
+	a.Get()
 	maxExtractableFileSize = val
 }
 


### PR DESCRIPTION
Maintain one shared buffer pool in memory and read from files into that while extracting. The buffer pool is thread-safe and requests to allocate to it are queued up.