### PR TITLE
Revert "Adaptively allocate in lazy_reader (#591)"

### DIFF
--- a/pkg/ioutils/lazy_reader.go
+++ b/pkg/ioutils/lazy_reader.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/mathutil"
 )
 
 type lazyReaderAt struct {
@@ -105,11 +104,8 @@ func (r *lazyReaderAt) readUntil(pos int64) {
 		return
 	}
 
-	if bufSize := int64(cap(r.buf)); bufSize < pos {
-		// Adaptively size the buffer to limit the total number of allocations
-		// but allow for small reads to allocate less memory
-		newSize := mathutil.MinInt64(r.size, mathutil.MaxInt64(bufSize*2, pos))
-		newBuf := make([]byte, len(r.buf), newSize)
+	if int64(cap(r.buf)) < pos {
+		newBuf := make([]byte, len(r.buf), r.size)
 		copy(newBuf, r.buf)
 		r.buf = newBuf
 	}


### PR DESCRIPTION
This reverts commit 9044cc9b432d31acf52a856ee199a4eafb711337.