### PR TITLE
ROX-9497: Copy custom trusted CA bundles injected by OpenShift Network Operator

### DIFF
--- a/image/scanner/scripts/import-additional-cas
+++ b/image/scanner/scripts/import-additional-cas
@@ -19,4 +19,4 @@ copy_existing /usr/local/share/ca-certificates
 # Copy the custom trusted CA bundles injected by the Openshift Network Operator.
 copy_existing /etc/pki/injected-ca-trust
 
-update-ca-trust
+update-ca-trust extract

--- a/image/scanner/scripts/import-additional-cas
+++ b/image/scanner/scripts/import-additional-cas
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# The function copies everything that could be found under the path provided in
+# the first argument, ignoring files starting with '..' which are created by
+# kubernetes secret volume mount process.
 copy_existing () {
     src=$1
     if [ -d "$src" ] && [ "$(ls -A -I "..*" "$src")" ]; then
@@ -12,5 +15,8 @@ copy_existing () {
 }
 
 copy_existing /usr/local/share/ca-certificates
+
+# Copy the custom trusted CA bundles injected by the Openshift Network Operator.
+copy_existing /etc/pki/injected-ca-trust
 
 update-ca-trust


### PR DESCRIPTION
## Description

Update the system trusted CA bundle with the ones injected by the Openshift Network Operator and mounted as a kubernetes secret volume.

The script is copied from the stackrox repo and enriched with some comments and the `extract` parameter for verbosity. Once merged, the script will be copied back to stackrox for consistency.

This PR is a resurrection of #604.

## Testing Done

Tests performed previously when merging to the stackrox repository.