### PR TITLE
Update Debian name mappings

### DIFF
--- a/database/namespace_mapping.go
+++ b/database/namespace_mapping.go
@@ -25,13 +25,14 @@ var DebianReleasesMapping = map[string]string{
 	"stretch":  "9",
 	"buster":   "10",
 	"bullseye": "11",
+	"bookworm": "12",
 	"sid":      "unstable",
 
 	// Class names
-	"oldoldstable": "8",
-	"oldstable":    "9",
-	"stable":       "10",
-	"testing":      "11",
+	"oldoldstable": "9",
+	"oldstable":    "10",
+	"stable":       "11",
+	"testing":      "12",
 	"unstable":     "unstable",
 }
 


### PR DESCRIPTION
Debian 11 is "stable". See https://www.debian.org/releases/, https://www.debian.org/releases/testing/releasenotes, and https://deb.debian.org/debian/dists/