### PR TITLE
Create `/docker-entrypoint-initdb.d` in the scanner-db-slim container

### DIFF
--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -49,6 +49,11 @@ FROM base AS scanner-db-slim
 
 ENV ROX_SLIM_MODE="true"
 
+# The entrypoint script requires the init directory to exist, so we create it
+# here even though scanner slim does not ship any definitions.
+
+RUN mkdir /docker-entrypoint-initdb.d
+
 USER 70:70
 
 FROM base AS scanner-db

--- a/image/db/rhel/scripts/docker-entrypoint.sh
+++ b/image/db/rhel/scripts/docker-entrypoint.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-### STACKROX MODIFIED - This file is from https://github.com/docker-library/postgres/blob/master/12/bullseye/docker-entrypoint.sh
+
+### STACKROX MODIFIED - This file was copied from [the PostgreSQL Docker
+### Community][1].  Any stackrox modification or comments are tagged with this
+### comment.
+###
+### [1]: https://github.com/docker-library/postgres/blob/master/12/bullseye/docker-entrypoint.sh
+
 set -Eeo pipefail
 # TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
@@ -304,8 +310,9 @@ _main() {
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
-		  ### STACKROX MODIFIED - gosu is not installed in our image, but we use the postgres user,
-		  ### STACKROX MODIFIED - so this line will not be reached.
+			### STACKROX MODIFIED - gosu is not installed in our
+			### image, but we use the postgres user, so this line
+			### will not be reached.
 			# then restart script as postgres user
 			exec gosu postgres "$BASH_SOURCE" "$@"
 		fi


### PR DESCRIPTION
## Description

Create an empty `/docker-entrypoint-initdb.d` in the scanner-db-slim container.

Scanner-db-slim will fail otherwise. In the PSQL community entry point script we "re-use", there is a check for the existence of that directory. We create the directory empty in the container, rather than modifying the script -- the more pristine the script is, the easier it will be for us to pull from upstream in the future.

## Test

Deployed to Openshift manually.
