### PR TITLE
Do not attempt to retrieve ELF metadata for small files

### DIFF
--- a/pkg/elf/elf.go
+++ b/pkg/elf/elf.go
@@ -25,8 +25,8 @@ type Metadata struct {
 func GetExecutableMetadata(r io.ReaderAt) (*Metadata, error) {
 	elfFile, err := elf.NewFile(r)
 	if err != nil {
-		// Do not return error if it is not in ELF format
-		if _, ok := err.(*elf.FormatError); ok {
+		// Do not return error if it is not in ELF format.
+		if _, isFormatError := err.(*elf.FormatError); isFormatError {
 			err = nil
 		}
 		return nil, err

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -43,6 +43,9 @@ const (
 	// DefaultMaxLazyReaderBufferSizeMB is the default maximum lazy reader buffer size. Any file data beyond this
 	// limit is backed by temporary files on disk.
 	DefaultMaxLazyReaderBufferSizeMB = 100
+
+	// elfHeaderSize is the size of an ELF header based on https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html.
+	elfHeaderSize = 16
 )
 
 var (
@@ -163,7 +166,7 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 
 			if hdr.Size > maxELFExecutableFileSize {
 				log.Warnf("Skipping ELF executable check for file %q (%d bytes) because it is larger than the configured maxELFExecutableFileSizeMB of %d", filename, hdr.Size, maxELFExecutableFileSize/1024/1024)
-			} else if hdr.Size > 0 { // Do not bother attempting to get ELF metadata if the file is empty.
+			} else if hdr.Size >= elfHeaderSize { // Only bother attempting to get ELF metadata if the file is large enough for the ELF header.
 				fileData.ELFMetadata, err = elf.GetExecutableMetadata(contents)
 				if err != nil {
 					log.Errorf("Failed to get dependencies for %s: %v", filename, err)


### PR DESCRIPTION
Noticed this when I was scanning an image with whiteout files. I kept seeing logs like these:

```
ERRO[0026] Failed to get dependencies for usr/lib/ssl/misc/.wh.CA.sh: EOF 
ERRO[0026] Failed to get dependencies for usr/lib/ssl/misc/.wh.c_hash: EOF 
ERRO[0026] Failed to get dependencies for usr/lib/ssl/misc/.wh.c_info: EOF 
```

as well as for other empty files:

```
ERRO[0026] Failed to get dependencies for usr/bin/perlthanks: EOF 
ERRO[0026] Failed to get dependencies for usr/bin/pstruct: EOF 
ERRO[0026] Failed to get dependencies for usr/bin/s2p: EOF 
```