### PR TITLE
ROX-10929: Add support for RHEL9 images

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -3,4 +3,6 @@ package features
 var (
 	// ContinueUnknownOS defines if scanning should continue upon detecting unknown OS.
 	ContinueUnknownOS = registerFeature("Enable continuation upon detecting unknown OS", "ROX_CONTINUE_UNKNOWN_OS", true)
+	// RHEL9Scanning enables support for scanning RHEL9-based images.
+	RHEL9Scanning = registerFeature("Enable support for scanning RHEL9 images", "ROX_RHEL9_SCANNING", false)
 )

--- a/pkg/rhelv2/rpm/rpm.go
+++ b/pkg/rhelv2/rpm/rpm.go
@@ -6,48 +6,22 @@
 package rpm
 
 import (
-	"bufio"
-	"bytes"
 	"encoding/json"
-	"fmt"
-	"io"
-	"os"
-	"os/exec"
 	"regexp"
-	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens/osrelease"
 	"github.com/stackrox/scanner/ext/featurens/redhatrelease"
-	"github.com/stackrox/scanner/pkg/commonerr"
 	"github.com/stackrox/scanner/pkg/metrics"
 	"github.com/stackrox/scanner/pkg/repo2cpe"
+	"github.com/stackrox/scanner/pkg/rpm"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
 const (
-	// This is the query format we're using to get data out of rpm.
-	queryFmt = `%{name}\n` +
-		`%{evr}\n` +
-		`%{ARCH}\n` +
-		`%{RPMTAG_MODULARITYLABEL}\n` +
-		`[%{FILENAMES}\n]` +
-		`.\n`
-
-	// Older versions of rpm do not have the `RPMTAG_MODULARITYLABEL` tag.
-	// Ignore it for testing.
-	queryFmtTest = `%{name}\n` +
-		`%{evr}\n` +
-		`%{ARCH}\n` +
-		`[%{FILENAMES}\n]` +
-		`.\n`
-
-	dbPath           = `var/lib/rpm/Packages`
 	contentManifests = `root/buildinfo/content_manifests`
 
 	pkgFmt = `rpmv2`
@@ -59,7 +33,6 @@ var contentManifestPattern = regexp.MustCompile(`^root/buildinfo/content_manifes
 var AllRHELRequiredFiles set.StringSet
 
 func init() {
-	AllRHELRequiredFiles.Add(dbPath)
 	AllRHELRequiredFiles.AddAll(RequiredFilenames()...)
 	AllRHELRequiredFiles.AddAll(redhatrelease.RequiredFilenames...)
 	AllRHELRequiredFiles.AddAll(osrelease.RequiredFilenames...)
@@ -69,139 +42,19 @@ func init() {
 // returns a slice of packages found via rpm and a slice of CPEs found in
 // /root/buildinfo/content_manifests.
 func ListFeatures(files tarutil.LayerFiles) ([]*database.RHELv2Package, []string, error) {
-	return listFeatures(files, queryFmt)
+	return listFeatures(files, false)
 }
 
-func listFeatures(files tarutil.LayerFiles, queryFmt string) ([]*database.RHELv2Package, []string, error) {
+func listFeatures(files tarutil.LayerFiles, testing bool) ([]*database.RHELv2Package, []string, error) {
 	cpes, err := getCPEsUsingEmbeddedContentSets(files)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	f, hasFile := files.Get(dbPath)
-	if !hasFile {
-		return nil, cpes, nil
-	}
-
-	defer metrics.ObserveListFeaturesTime(pkgFmt, "all", time.Now())
-
-	// Write the required "Packages" file to disk
-	tmpDir, err := os.MkdirTemp("", "rpm")
-	if err != nil {
-		log.WithError(err).Error("could not create temporary folder for RPM detection")
-		return nil, nil, commonerr.ErrFilesystem
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
-
-	err = os.WriteFile(tmpDir+"/Packages", f.Contents, 0700)
-	if err != nil {
-		log.WithError(err).Error("could not create temporary file for RPM detection")
-		return nil, nil, commonerr.ErrFilesystem
-	}
-
-	defer metrics.ObserveListFeaturesTime(pkgFmt, "cli+parse", time.Now())
-
-	cmd := exec.Command("rpm",
-		`--dbpath`, tmpDir,
-		`--query`, `--all`, `--queryformat`, queryFmt)
-	r, err := cmd.StdoutPipe()
+	pkgs, err := getFeaturesFromRPMDatabase(files, testing)
 	if err != nil {
 		return nil, nil, err
 	}
-	defer utils.IgnoreError(r.Close)
-
-	var errbuf bytes.Buffer
-	cmd.Stderr = &errbuf
-
-	if err := cmd.Start(); err != nil {
-		return nil, nil, err
-	}
-
-	pkgs, err := parsePackages(r, files)
-	if err != nil {
-		if errbuf.Len() != 0 {
-			log.Warnf("Error executing RPM command: %s", errbuf.String())
-		}
-		return nil, nil, errors.Errorf("rpm: error reading rpm output: %v", err)
-	}
-
-	if err := cmd.Wait(); err != nil {
-		return nil, nil, err
-	}
-
 	return pkgs, cpes, nil
-}
-
-func parsePackages(r io.Reader, files tarutil.LayerFiles) ([]*database.RHELv2Package, error) {
-	var pkgs []*database.RHELv2Package
-
-	p := &database.RHELv2Package{}
-	// execToDeps and execToDeps ensures only unique executables or libraries are stored per package.
-	execToDeps := make(database.StringToStringsMap)
-	libToDeps := make(database.StringToStringsMap)
-	s := bufio.NewScanner(r)
-	for i := 0; s.Scan(); i++ {
-		line := strings.TrimSpace(s.Text())
-		if line == "" || strings.HasPrefix(line, "(none)") {
-			continue
-		}
-		if line == "." {
-			// Reached package delimiter.
-
-			// Ensure the current package is well-formed.
-			// If it is, add it to the return slice.
-			if p.Name != "" && p.Version != "" && p.Arch != "" {
-				if len(execToDeps) > 0 {
-					p.ExecutableToDependencies = execToDeps
-				}
-				if len(libToDeps) > 0 {
-					p.LibraryToDependencies = libToDeps
-				}
-				pkgs = append(pkgs, p)
-			}
-
-			// Start a new package definition and reset 'i'.
-			p = &database.RHELv2Package{}
-			execToDeps = make(database.StringToStringsMap)
-			libToDeps = make(database.StringToStringsMap)
-			i = -1
-			continue
-		}
-
-		switch i {
-		case 0:
-			// This is not a real package. Skip it...
-			if line == "gpg-pubkey" {
-				continue
-			}
-			p.Name = line
-		case 1:
-			p.Version = line
-		case 2:
-			p.Arch = line
-		case 3:
-			moduleSplit := strings.Split(line, ":")
-			if len(moduleSplit) < 2 {
-				continue
-			}
-			moduleStream := fmt.Sprintf("%s:%s", moduleSplit[0], moduleSplit[1])
-			p.Module = moduleStream
-		default:
-			// i >= 4 is reserved for provided filenames.
-
-			// Rename to make it clear what the line represents.
-			filename := line
-			// The first character is always "/", which is removed when inserted into the layer files.
-			fileData, hasFile := files.Get(filename[1:])
-			if hasFile {
-				AddToDependencyMap(filename, fileData, execToDeps, libToDeps)
-			}
-		}
-	}
-
-	return pkgs, s.Err()
 }
 
 // AddToDependencyMap checks and adds files to executable and library dependency for RHEL package
@@ -258,7 +111,63 @@ func getContentManifestFileContents(files tarutil.LayerFiles) []byte {
 	return nil
 }
 
+func getFeaturesFromRPMDatabase(files tarutil.LayerFiles, testing bool) ([]*database.RHELv2Package, error) {
+	defer metrics.ObserveListFeaturesTime(pkgFmt, "all", time.Now())
+
+	rpmDB, err := rpm.CreateDatabaseFromLayer(files)
+	if err != nil {
+		return nil, err
+	}
+	if rpmDB == nil {
+		// No RPM database found in the layer files.
+		return nil, nil
+	}
+
+	defer utils.IgnoreError(rpmDB.Delete)
+	defer metrics.ObserveListFeaturesTime(pkgFmt, "cli+parse", time.Now())
+
+	var pkgs []*database.RHELv2Package
+
+	dbQuery, err := rpmDB.QueryAll(rpm.QueryOpts{Testing: testing})
+	if err != nil {
+		return nil, err
+	}
+
+	for dbQuery.Next() {
+		pkg := dbQuery.Package()
+		rhelPkg := &database.RHELv2Package{
+			Name:    pkg.Name,
+			Version: pkg.Version,
+			Arch:    pkg.Arch,
+			Module:  pkg.Module,
+		}
+
+		// execToDeps and libToDeps ensure only unique executables or libraries are stored per package.
+		execToDeps := make(database.StringToStringsMap)
+		libToDeps := make(database.StringToStringsMap)
+		for _, filename := range pkg.Filenames {
+			fileData, hasFile := files.Get(filename[1:])
+			if hasFile {
+				AddToDependencyMap(filename, fileData, execToDeps, libToDeps)
+			}
+		}
+		if len(execToDeps) > 0 {
+			rhelPkg.ExecutableToDependencies = execToDeps
+		}
+		if len(libToDeps) > 0 {
+			rhelPkg.LibraryToDependencies = libToDeps
+		}
+		pkgs = append(pkgs, rhelPkg)
+	}
+
+	if err := dbQuery.Err(); err != nil {
+		return nil, err
+	}
+
+	return pkgs, nil
+}
+
 // RequiredFilenames lists the files required to be present for analysis to be run.
 func RequiredFilenames() []string {
-	return []string{dbPath, contentManifests}
+	return append(rpm.DatabaseFiles(), contentManifests)
 }

--- a/pkg/rhelv2/rpm/rpm_language_analyzer.go
+++ b/pkg/rhelv2/rpm/rpm_language_analyzer.go
@@ -1,12 +1,9 @@
 package rpm
 
 import (
-	"os"
-	"os/exec"
-
-	log "github.com/sirupsen/logrus"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/scanner/pkg/component"
+	"github.com/stackrox/scanner/pkg/rpm"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
@@ -16,16 +13,14 @@ func AnnotateComponentsWithPackageManagerInfo(files tarutil.LayerFiles, componen
 	if len(components) == 0 {
 		return nil
 	}
-	f, hasFile := files.Get(dbPath)
-	if !hasFile {
-		return nil
-	}
-	matcher, finish, err := isProvidedByRPMPackageMatcher(f.Contents)
+	rpmDB, err := rpm.CreateDatabaseFromLayer(files)
 	if err != nil {
 		return err
 	}
-	defer finish()
-
+	if rpmDB == nil {
+		return nil
+	}
+	defer rpmDB.Delete()
 	locationAlreadyChecked := make(map[string]bool)
 	for _, c := range components {
 		// This handles jar-in-jar cases as the location is manually created so we only want
@@ -36,63 +31,8 @@ func AnnotateComponentsWithPackageManagerInfo(files tarutil.LayerFiles, componen
 			c.FromPackageManager = fromPackageManager
 			continue
 		}
-		c.FromPackageManager = matcher(normalizedLocation)
+		c.FromPackageManager = rpmDB.ProvidesFile(normalizedLocation)
 		locationAlreadyChecked[normalizedLocation] = c.FromPackageManager
 	}
 	return nil
-}
-
-// isProvidedByRPMPackageMatcher uses the given package contents (expected to be an RPM Berkeley DB)
-// to return:
-// * a function which returns if the given file path is provided by an RPM package.
-// * a function to be called once the package contents are no longer needed which cleans up any used resources.
-// * an error.
-func isProvidedByRPMPackageMatcher(packagesContents []byte) (func(string) bool, func(), error) {
-	if packagesContents == nil {
-		// Default return always says the given path is not provided by an RPM package.
-		return func(string) bool { return false }, func() {}, nil
-	}
-
-	// Write the required "Packages" file to disk
-	tmpDir, err := os.MkdirTemp("", "rpm")
-	if err != nil {
-		log.WithError(err).Error("could not create temporary folder for RPM detection")
-		return nil, nil, err
-	}
-
-	err = os.WriteFile(tmpDir+"/Packages", packagesContents, 0700)
-	if err != nil {
-		log.WithError(err).Error("could not create temporary file for RPM detection")
-		return nil, nil, err
-	}
-
-	finishFn := func() { _ = os.RemoveAll(tmpDir) }
-
-	return func(path string) bool {
-		// We need the full path of the file.
-		// When we originally extract the file, the `/` prefix is removed.
-		// Add it back here.
-		fullPath := "/" + path
-
-		cmd := exec.Command("rpm",
-			`--dbpath`, tmpDir,
-			`-q`, `--whatprovides`, fullPath)
-
-		if err := cmd.Run(); err != nil {
-			// When an RPM package does not provide a file, the expected output has
-			// status code 1.
-			if exitError, ok := err.(*exec.ExitError); ok && exitError.ExitCode() == 1 {
-				// RPM does NOT provide this package.
-				return false
-			}
-
-			log.WithError(err).Errorf("unexpected error when determining if %s belongs to an RPM package", fullPath)
-			// Upon error, say no RPM package provides this file.
-			return false
-		}
-
-		// The command exited properly, which implies the file IS provided by an RPM package.
-		return true
-
-	}, finishFn, nil
 }

--- a/pkg/rhelv2/rpm/rpm_test.go
+++ b/pkg/rhelv2/rpm/rpm_test.go
@@ -1,94 +1,296 @@
 package rpm
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/pkg/features"
 	"github.com/stackrox/scanner/pkg/tarutil"
 	"github.com/stackrox/scanner/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// ListFeaturesTest does the same as ListFeatures but should only be used for testing.
-func ListFeaturesTest(files tarutil.LayerFiles) ([]*database.RHELv2Package, []string, error) {
-	return listFeatures(files, queryFmtTest)
+var testDirectory string
+
+func init() {
+	_, filename, _, _ := runtime.Caller(0)
+	testDirectory = filepath.Dir(filename)
 }
 
-func TestRPMFeatureDetection(t *testing.T) {
-	sampleExpectedPkgs := []*database.RHELv2Package{
+// ListFeaturesTest does the same as ListFeatures but should only be used for testing.
+func ListFeaturesTest(files tarutil.LayerFiles) ([]*database.RHELv2Package, []string, error) {
+	return listFeatures(files, true)
+}
+
+func Test_listFeatures(t *testing.T) {
+	type args struct {
+		layerFiles tarutil.LayerFiles
+		queryFmt   string
+	}
+	tests := []struct {
+		name string
+		args args
+
+		// Add test layer files from a map of file data.
+		files map[string]tarutil.FileData
+		// Add test layer files from a map of files stored in the testdata/
+		// directory.
+		filesFromTestData map[string]string
+		// Sets the queryFmt to test base on active vulnerability flag.
+		isActiveVulnMgmt bool
+
+		// Expected values for assertion.
+		sampleExpectedPkgs []*database.RHELv2Package
+		unexpectedPkgs     []*database.RHELv2Package
+		expectedCPEs       []string
+		wantErr            assert.ErrorAssertionFunc
+		requireRHEL9       bool
+	}{
 		{
-			Name:    "zlib",
-			Version: "1.2.11-16.el8_2",
-			Arch:    "x86_64",
-			ExecutableToDependencies: database.StringToStringsMap{
-				"/usr/lib64/libz.so.1":      {},
-				"/usr/lib64/libz.so.1.2.11": {},
+			name: "TestRPMFeatureDetection with BerkeleyDB",
+			filesFromTestData: map[string]string{
+				"root/buildinfo/content_manifests/test.json": "test.json",
+				"var/lib/rpm/Packages":                       "Packages",
+			},
+			isActiveVulnMgmt: false,
+			wantErr:          assert.NoError,
+			sampleExpectedPkgs: []*database.RHELv2Package{
+				{
+					Name:    "zlib",
+					Version: "1.2.11-16.el8_2",
+					Arch:    "x86_64",
+				},
+				{
+					Name:    "dbus-common",
+					Version: "1:1.12.8-12.el8_3",
+					Arch:    "noarch",
+				},
+				{
+					Name:    "ncurses-libs",
+					Version: "6.1-7.20180224.el8",
+					Arch:    "x86_64",
+				},
+				{
+					Name:    "redhat-release",
+					Version: "8.3-1.0.el8",
+					Arch:    "x86_64",
+				},
+			},
+			unexpectedPkgs: []*database.RHELv2Package{
+				{
+					Name:    "gpg-pubkey",
+					Version: "d4082792-5b32db75",
+				},
+			},
+			expectedCPEs: []string{
+				"cpe:/o:redhat:enterprise_linux:8::baseos",
+				"cpe:/a:redhat:enterprise_linux:8::appstream",
 			},
 		},
 		{
-			Name:    "dbus-common",
-			Version: "1:1.12.8-12.el8_3",
-			Arch:    "noarch",
-		},
-		{
-			Name:    "ncurses-libs",
-			Version: "6.1-7.20180224.el8",
-			Arch:    "x86_64",
-			ExecutableToDependencies: database.StringToStringsMap{
-				"/usr/lib64/libform.so.6":       {},
-				"/usr/lib64/libncursesw.so.6.1": {},
-				"/usr/lib64/libpanelw.so.6":     {},
+			name: "TestRPMFeatureDetectionWithActiveVulnMgmt with BerkleyDB",
+			files: map[string]tarutil.FileData{
+				"usr/lib64/libz.so.1":          {Executable: true},
+				"usr/lib64/libz.so.1.2.11":     {Executable: true},
+				"usr/lib64/libform.so.6":       {Executable: true},
+				"usr/lib64/libncursesw.so.6.1": {Executable: true},
+				"usr/lib64/libpanelw.so.6":     {Executable: true},
+				"etc/redhat-release":           {Executable: true},
+				"etc/os-release":               {Executable: true},
+				"usr/lib/redhat-release":       {Executable: true},
+			},
+			filesFromTestData: map[string]string{
+				"root/buildinfo/content_manifests/test.json": "test.json",
+				"var/lib/rpm/Packages":                       "Packages",
+			},
+			isActiveVulnMgmt: true,
+			wantErr:          assert.NoError,
+			sampleExpectedPkgs: []*database.RHELv2Package{
+				{
+					Name:    "zlib",
+					Version: "1.2.11-16.el8_2",
+					Arch:    "x86_64",
+					ExecutableToDependencies: database.StringToStringsMap{
+						"/usr/lib64/libz.so.1":      {},
+						"/usr/lib64/libz.so.1.2.11": {},
+					},
+				},
+				{
+					Name:    "dbus-common",
+					Version: "1:1.12.8-12.el8_3",
+					Arch:    "noarch",
+				},
+				{
+					Name:    "ncurses-libs",
+					Version: "6.1-7.20180224.el8",
+					Arch:    "x86_64",
+					ExecutableToDependencies: database.StringToStringsMap{
+						"/usr/lib64/libform.so.6":       {},
+						"/usr/lib64/libncursesw.so.6.1": {},
+						"/usr/lib64/libpanelw.so.6":     {},
+					},
+				},
+				{
+					Name:    "redhat-release",
+					Version: "8.3-1.0.el8",
+					Arch:    "x86_64",
+				},
+			},
+			unexpectedPkgs: []*database.RHELv2Package{
+				{
+					Name:    "gpg-pubkey",
+					Version: "d4082792-5b32db75",
+				},
+			},
+			expectedCPEs: []string{
+				"cpe:/o:redhat:enterprise_linux:8::baseos",
+				"cpe:/a:redhat:enterprise_linux:8::appstream",
 			},
 		},
 		{
-			Name:    "redhat-release",
-			Version: "8.3-1.0.el8",
-			Arch:    "x86_64",
+			name: "TestRPMFeatureDetection with SQLite",
+			filesFromTestData: map[string]string{
+				"root/buildinfo/content_manifests/test.json": "test.json",
+				"var/lib/rpm/rpmdb.sqlite":                   "rpmdb.sqlite",
+			},
+			isActiveVulnMgmt: false,
+			requireRHEL9:     true,
+			wantErr:          assert.NoError,
+			sampleExpectedPkgs: []*database.RHELv2Package{
+				{
+					Name:    "zlib",
+					Version: "1.2.11-16.el8_2",
+					Arch:    "x86_64",
+				},
+				{
+					Name:    "dbus-common",
+					Version: "1:1.12.8-12.el8_3",
+					Arch:    "noarch",
+				},
+				{
+					Name:    "ncurses-libs",
+					Version: "6.1-7.20180224.el8",
+					Arch:    "x86_64",
+				},
+				{
+					Name:    "redhat-release",
+					Version: "8.3-1.0.el8",
+					Arch:    "x86_64",
+				},
+			},
+			unexpectedPkgs: []*database.RHELv2Package{
+				{
+					Name:    "gpg-pubkey",
+					Version: "d4082792-5b32db75",
+				},
+			},
+			expectedCPEs: []string{
+				"cpe:/o:redhat:enterprise_linux:8::baseos",
+				"cpe:/a:redhat:enterprise_linux:8::appstream",
+			},
 		},
-	}
-
-	unexpectedPkgs := []*database.RHELv2Package{
 		{
-			Name:    "gpg-pubkey",
-			Version: "d4082792-5b32db75",
+			name: "TestRPMFeatureDetectionWithActiveVulnMgmt with SQLite",
+			files: map[string]tarutil.FileData{
+				"usr/lib64/libz.so.1":          {Executable: true},
+				"usr/lib64/libz.so.1.2.11":     {Executable: true},
+				"usr/lib64/libform.so.6":       {Executable: true},
+				"usr/lib64/libncursesw.so.6.1": {Executable: true},
+				"usr/lib64/libpanelw.so.6":     {Executable: true},
+				"etc/redhat-release":           {Executable: true},
+				"etc/os-release":               {Executable: true},
+				"usr/lib/redhat-release":       {Executable: true},
+			},
+			filesFromTestData: map[string]string{
+				"root/buildinfo/content_manifests/test.json": "test.json",
+				"var/lib/rpm/rpmdb.sqlite":                   "rpmdb.sqlite",
+			},
+			isActiveVulnMgmt: true,
+			requireRHEL9:     true,
+			wantErr:          assert.NoError,
+			sampleExpectedPkgs: []*database.RHELv2Package{
+				{
+					Name:    "zlib",
+					Version: "1.2.11-16.el8_2",
+					Arch:    "x86_64",
+					ExecutableToDependencies: database.StringToStringsMap{
+						"/usr/lib64/libz.so.1":      {},
+						"/usr/lib64/libz.so.1.2.11": {},
+					},
+				},
+				{
+					Name:    "dbus-common",
+					Version: "1:1.12.8-12.el8_3",
+					Arch:    "noarch",
+				},
+				{
+					Name:    "ncurses-libs",
+					Version: "6.1-7.20180224.el8",
+					Arch:    "x86_64",
+					ExecutableToDependencies: database.StringToStringsMap{
+						"/usr/lib64/libform.so.6":       {},
+						"/usr/lib64/libncursesw.so.6.1": {},
+						"/usr/lib64/libpanelw.so.6":     {},
+					},
+				},
+				{
+					Name:    "redhat-release",
+					Version: "8.3-1.0.el8",
+					Arch:    "x86_64",
+				},
+			},
+			unexpectedPkgs: []*database.RHELv2Package{
+				{
+					Name:    "gpg-pubkey",
+					Version: "d4082792-5b32db75",
+				},
+			},
+			expectedCPEs: []string{
+				"cpe:/o:redhat:enterprise_linux:8::baseos",
+				"cpe:/a:redhat:enterprise_linux:8::appstream",
+			},
 		},
 	}
 
-	expectedCPEs := []string{
-		"cpe:/o:redhat:enterprise_linux:8::baseos",
-		"cpe:/a:redhat:enterprise_linux:8::appstream",
+	for _, tt := range tests {
+		if tt.requireRHEL9 && !features.RHEL9Scanning.Enabled() {
+			continue
+		}
+		// Initialize test arguments.
+		if tt.filesFromTestData != nil {
+			if tt.files == nil {
+				tt.files = make(map[string]tarutil.FileData)
+			}
+			for n, f := range tt.filesFromTestData {
+				c, err := os.ReadFile(filepath.Join(testDirectory, "testdata", f))
+				require.NoError(t, err)
+				tt.files[n] = tarutil.FileData{Contents: c}
+			}
+		}
+		tt.args.layerFiles = tarutil.CreateNewLayerFiles(tt.files)
+
+		// Run test.
+		t.Run(tt.name, func(t *testing.T) {
+			envIsolator := testutils.NewEnvIsolator(t)
+			defer envIsolator.RestoreAll()
+			envIsolator.Setenv("REPO_TO_CPE_DIR", filepath.Join(testDirectory, "/testdata"))
+			tt.args.layerFiles = tarutil.CreateNewLayerFiles(tt.files)
+
+			// Functions call.
+			pkgs, cpes, err := listFeatures(tt.args.layerFiles, true)
+
+			// Assertions.
+			if !tt.wantErr(t, err, fmt.Sprintf("listFeatures(%v, %v)", tt.args.layerFiles, tt.args.queryFmt)) {
+				return
+			}
+			assert.ElementsMatch(t, cpes, tt.expectedCPEs)
+			assert.Subset(t, pkgs, tt.sampleExpectedPkgs)
+			assert.NotSubset(t, pkgs, tt.unexpectedPkgs)
+		})
 	}
-
-	_, filename, _, _ := runtime.Caller(0)
-	d, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "/testdata/Packages"))
-	require.NoError(t, err)
-
-	manifest, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "/testdata/test.json"))
-	require.NoError(t, err)
-
-	envIsolator := testutils.NewEnvIsolator(t)
-	defer envIsolator.RestoreAll()
-	cpesDir := filepath.Join(filepath.Dir(filename), "/testdata")
-	envIsolator.Setenv("REPO_TO_CPE_DIR", cpesDir)
-
-	pkgs, cpes, err := ListFeaturesTest(tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
-		"var/lib/rpm/Packages":                       {Contents: d},
-		"root/buildinfo/content_manifests/test.json": {Contents: manifest},
-		"usr/lib64/libz.so.1":                        {Executable: true},
-		"usr/lib64/libz.so.1.2.11":                   {Executable: true},
-		"usr/lib64/libform.so.6":                     {Executable: true},
-		"usr/lib64/libncursesw.so.6.1":               {Executable: true},
-		"usr/lib64/libpanelw.so.6":                   {Executable: true},
-		"etc/redhat-release":                         {Executable: true},
-		"etc/os-release":                             {Executable: true},
-		"usr/lib/redhat-release":                     {Executable: true},
-	}))
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, cpes, expectedCPEs)
-	assert.Subset(t, pkgs, sampleExpectedPkgs)
-	assert.NotSubset(t, pkgs, unexpectedPkgs)
 }

--- a/pkg/rpm/database.go
+++ b/pkg/rpm/database.go
@@ -1,0 +1,285 @@
+package rpm
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/scanner/pkg/commonerr"
+	"github.com/stackrox/scanner/pkg/features"
+	"github.com/stackrox/scanner/pkg/tarutil"
+)
+
+const (
+	// This is the query format we're using to get data out of rpm.
+	queryFmt = `%{name}\n` +
+		`%{evr}\n` +
+		`%{ARCH}\n` +
+		`%{RPMTAG_MODULARITYLABEL}\n` +
+		`[%{FILENAMES}\n]` +
+		`.\n`
+
+	// FIXME Older versions of rpm do not have the `RPMTAG_MODULARITYLABEL` tag,
+	//       so we don't query for it when testing. Remove this when we ensure the same rpm
+	//       version for runtime, development and testing.
+	queryFmtTest = `%{name}\n` +
+		`%{evr}\n` +
+		`%{ARCH}\n` +
+		`[%{FILENAMES}\n]` +
+		`.\n`
+
+	// databaseDir is the directory where the RPM database is expected to be in
+	// the container filesystem.
+	databaseDir = "var/lib/rpm"
+)
+
+var (
+	// databaseFiles is a set with all the supported RPM database files.
+	databaseFiles = set.NewStringSet(
+		// BerkleyDB (rpm < 4.16)
+		"Packages",
+	)
+)
+
+// rpmDatabase represents an RPM database in the filesystem.
+type rpmDatabase struct {
+	// The path to the rpm database, can be used as --dbpath <dbPath> in rpm commands.
+	dbPath string
+}
+
+// rpmDatabaseQuery is the RPM query iterator object.
+type rpmDatabaseQuery struct {
+	// RPM sub-process management and scanning.
+	rpmWait        func() error
+	rpmScanStopped bool
+	rpmScanner     *bufio.Scanner
+	rpmStderr      *bytes.Buffer
+	rpmStdout      io.ReadCloser
+	// Query state.
+	err         error
+	nextPackage rpmPackage
+}
+
+// rpmPackage represents an RPM package information.
+type rpmPackage struct {
+	Name      string
+	Version   string
+	Arch      string
+	Module    string
+	Filenames []string
+}
+
+// QueryOpts is a set of options for database queries.
+type QueryOpts struct {
+	// Testing if true, performs a test query, which currently uses a different query
+	// format for compatibility with old rpm versions.
+	Testing bool
+}
+
+func init() {
+	if features.RHEL9Scanning.Enabled() {
+		// For RHEL9 we need to enable sqlite database (rpm >= 4.16)
+		databaseFiles.Add("rpmdb.sqlite")
+	}
+}
+
+// DatabaseFiles returns a slice containing full paths of all RPM database
+// files known for the different backend we support. The paths are relative to
+// root.
+func DatabaseFiles() []string {
+	paths := make([]string, 0, databaseFiles.Cardinality())
+	for filename := range databaseFiles {
+		paths = append(paths, path.Join(databaseDir, filename))
+	}
+	return paths
+}
+
+// CreateDatabaseFromLayer creates an RPM database in a temporary directory
+// from the RPM database found in the container image. All known RPM database
+// backend is supported (i.e. bdb, sqlite). If no database is found in the image,
+// returns nil.
+func CreateDatabaseFromLayer(imageFiles tarutil.LayerFiles) (*rpmDatabase, error) {
+	// Find all known RPM database models and their files. It is unlikely that the
+	// image will contain more than one model, but in that scenario we copy all files
+	// and rely on the fact that `rpm` will select the most up-to-date database
+	// model, instead of replicating that knowledge in the code.
+	dbFiles := make(map[string]tarutil.FileData)
+	for name := range databaseFiles {
+		if data, exists := imageFiles.Get(path.Join(databaseDir, name)); exists {
+			dbFiles[name] = data
+		}
+	}
+	if len(dbFiles) == 0 {
+		// Not rpm database was found.
+		return nil, nil
+	}
+	// Write the database files to the filesystem.
+	dbDir, err := os.MkdirTemp("", "rpm")
+	if err != nil {
+		logrus.WithError(err).Error("could not create temporary folder for the rpm database")
+		return nil, commonerr.ErrFilesystem
+	}
+	defer func() {
+		// Remove temporary directory if returning on errors.
+		if err != nil {
+			_ = os.RemoveAll(dbDir)
+		}
+	}()
+	for name, data := range dbFiles {
+		dbFilename := filepath.Join(dbDir, name)
+		err = os.WriteFile(dbFilename, data.Contents, 0700)
+		if err != nil {
+			logrus.WithError(err).Error("failed to create rpm database file")
+			return nil, commonerr.ErrFilesystem
+		}
+	}
+	return &rpmDatabase{
+		dbPath: dbDir,
+	}, nil
+}
+
+// QueryAll starts a query for all packages in the RPM database, returns a query
+// iterator. A query is actually performed by an underlying rpm sub-process, and
+// return is retrieved after parsing its output and status.
+func (d *rpmDatabase) QueryAll(opts QueryOpts) (*rpmDatabaseQuery, error) {
+	queryFormat := queryFmt
+	if opts.Testing {
+		queryFormat = queryFmtTest
+	}
+	cmd := exec.Command(
+		"rpm",
+		`--dbpath`, d.dbPath,
+		`--query`,
+		`--all`,
+		`--queryformat`, queryFormat,
+	)
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	var errBuffer bytes.Buffer
+	cmd.Stderr = &errBuffer
+	if err := cmd.Start(); err != nil {
+		utils.IgnoreError(stdoutPipe.Close)
+		return nil, err
+	}
+	return &rpmDatabaseQuery{
+		rpmWait:    cmd.Wait,
+		rpmStderr:  &errBuffer,
+		rpmStdout:  stdoutPipe,
+		rpmScanner: bufio.NewScanner(stdoutPipe),
+	}, nil
+}
+
+// ProvidesFile return true if a package provides the specified path in the RPM
+// database. If the path is relative, we assume its relative to the root
+// directory.
+func (d *rpmDatabase) ProvidesFile(path string) bool {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	cmd := exec.Command(
+		"rpm",
+		`--dbpath`, d.dbPath,
+		`--query`,
+		`--whatprovides`, path,
+	)
+	if err := cmd.Run(); err != nil {
+		// When rpm does not provide a file, the expected exit status is 1. On non-zero
+		// we always default to returning the file is not provided, but anything other
+		// than 1 is considered unexpected.
+		if exitError, ok := err.(*exec.ExitError); ok && exitError.ExitCode() != 1 {
+			logrus.WithError(err).Errorf(
+				"unexpected exit status when querying %s is provided by an RPM package", path)
+		}
+		return false
+	}
+	// The rpm exited properly, which implies the file IS provided by an RPM
+	// package.
+	return true
+}
+
+// Delete removes all the RPM database files.
+func (d *rpmDatabase) Delete() error {
+	return os.RemoveAll(d.dbPath)
+}
+
+// Next retrieves the next item in the query and make it available through the Package call.
+func (q *rpmDatabaseQuery) Next() bool {
+	if q.err != nil || q.rpmScanStopped {
+		return false
+	}
+	q.nextPackage = rpmPackage{}
+	for i := 0; q.rpmScanner.Scan(); i++ {
+		line := strings.TrimSpace(q.rpmScanner.Text())
+		if line == "" || strings.HasPrefix(line, "(none)") {
+			continue
+		}
+		if line == "." {
+			// Reached package delimiter. Ensure the current package is well-formed.
+			if q.nextPackage.Name != "" && q.nextPackage.Version != "" && q.nextPackage.Arch != "" {
+				return true
+			}
+			// Start a new package definition and reset 'i'.
+			q.nextPackage = rpmPackage{}
+			i = -1
+			continue
+		}
+		switch i {
+		case 0:
+			// This is not a real package. Skip it...
+			if line == "gpg-pubkey" {
+				continue
+			}
+			q.nextPackage.Name = line
+		case 1:
+			q.nextPackage.Version = line
+		case 2:
+			q.nextPackage.Arch = line
+		case 3:
+			moduleSplit := strings.Split(line, ":")
+			if len(moduleSplit) < 2 {
+				continue
+			}
+			moduleStream := fmt.Sprintf("%s:%s", moduleSplit[0], moduleSplit[1])
+			q.nextPackage.Module = moduleStream
+		default:
+			// i >= 4 is reserved for provided filenames.
+			q.nextPackage.Filenames = append(q.nextPackage.Filenames, line)
+		}
+	}
+	q.rpmScanStopped = true
+	// If we stopped due to pipe errors, parse it and return.
+	if err := q.rpmScanner.Err(); err != nil {
+		if q.rpmStderr.Len() != 0 {
+			logrus.Warnf("Error executing RPM rpm: %s", q.rpmStderr.String())
+		}
+		q.err = errors.Errorf("rpm: error reading rpm output: %v", err)
+		utils.IgnoreError(q.rpmStdout.Close)
+		return false
+	}
+	// Otherwise, let's Wait() to and set the rpm command status.
+	q.err = q.rpmWait()
+	return false
+}
+
+// Package returns the most recent package retrieved in a database query
+// iteration, available after a Next call.
+func (q *rpmDatabaseQuery) Package() rpmPackage {
+	return q.nextPackage
+}
+
+// Err returns the first error encountered when retrieving packages in a query.
+func (q *rpmDatabaseQuery) Err() error {
+	return q.err
+}

--- a/pkg/rpm/database_test.go
+++ b/pkg/rpm/database_test.go
@@ -1,0 +1,220 @@
+package rpm
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+type errorReader struct {
+	err error
+}
+
+func (r *errorReader) Read(p []byte) (n int, err error) {
+	return 0, r.err
+}
+
+func Test_rpmDatabaseQuery_Next(t *testing.T) {
+	type fields struct {
+		rpmWait        func() error
+		rpmStderr      *bytes.Buffer
+		rpmStdout      io.ReadCloser
+		rpmScanStopped bool
+		err            error
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		rpmOutput string
+
+		want             bool
+		wantPackage      rpmPackage
+		wantRPMError     error
+		wantRPMReadError error
+	}{
+		{
+			name: "when err is set, returns false",
+			fields: fields{
+				err: errors.Errorf("foobar"),
+			},
+		},
+		{
+			name: "when rpmScanStopped is set and no error, returns false",
+			fields: fields{
+				rpmScanStopped: true,
+			},
+		},
+		{
+			name: "when rpm output is the empty line, returns false",
+		},
+		{
+			name:      "when gpg package is listed, returns false",
+			rpmOutput: "gpg-pubkey",
+		},
+		{
+			name:             "when rpm command fails, returns false and error",
+			wantRPMReadError: errors.Errorf("foobar"),
+		},
+		{
+			name:         "when rpm exits with error, returns false with error",
+			wantRPMError: errors.Errorf("foobar"),
+		},
+		{
+			name: "when rpm output is one package, return true",
+			want: true,
+			wantPackage: rpmPackage{
+				Name:    "vim-enhanced",
+				Version: "2:8.0.1763-15.el8",
+				Arch:    "x86_64",
+				Filenames: []string{
+					"/etc/profile.d/vim.sh",
+					"/usr/bin/vim",
+					"/usr/bin/vimdiff",
+				},
+			},
+			rpmOutput: `vim-enhanced
+2:8.0.1763-15.el8
+x86_64
+(none)
+/etc/profile.d/vim.sh
+/usr/bin/vim
+/usr/bin/vimdiff
+.
+`,
+		},
+		{
+			name: "when rpm output is two package, return true and the first package",
+			want: true,
+			wantPackage: rpmPackage{
+				Name:    "vim-enhanced",
+				Version: "2:8.0.1763-15.el8",
+				Arch:    "x86_64",
+				Filenames: []string{
+					"/etc/profile.d/vim.sh",
+					"/usr/bin/vim",
+					"/usr/bin/vimdiff",
+				},
+			},
+			rpmOutput: `vim-enhanced
+2:8.0.1763-15.el8
+x86_64
+(none)
+/etc/profile.d/vim.sh
+/usr/bin/vim
+/usr/bin/vimdiff
+.
+sed
+4.5-2.el8
+x86_64
+(none)
+/usr/bin/sed
+/usr/share/doc/sed
+/usr/share/doc/sed/sedfaq.txt.gz
+/usr/share/info/sed.info.gz
+/usr/share/licenses/sed
+`,
+		},
+	}
+	for _, tt := range tests {
+		var r io.Reader
+		if tt.wantRPMReadError != nil {
+			r = &errorReader{err: tt.wantRPMReadError}
+		} else {
+			r = strings.NewReader(tt.rpmOutput)
+		}
+		tt.fields.rpmStdout = io.NopCloser(r)
+		rpmScanner := bufio.NewScanner(r)
+		tt.fields.rpmStderr = &bytes.Buffer{}
+		if tt.fields.rpmWait == nil {
+			tt.fields.rpmWait = func() error { return tt.wantRPMError }
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			q := &rpmDatabaseQuery{
+				rpmWait:        tt.fields.rpmWait,
+				rpmStderr:      tt.fields.rpmStderr,
+				rpmScanner:     rpmScanner,
+				rpmStdout:      tt.fields.rpmStdout,
+				rpmScanStopped: tt.fields.rpmScanStopped,
+				err:            tt.fields.err,
+			}
+			if got := q.Next(); got != tt.want {
+				t.Errorf("Next() = %v, want %v", got, tt.want)
+			}
+			if tt.want {
+				assert.NoError(t, q.Err())
+				assert.Equal(t, tt.wantPackage, q.Package())
+			}
+			if tt.wantRPMReadError != nil {
+				assert.ErrorContains(t, q.Err(), "rpm: error reading rpm output: foobar")
+			}
+			if tt.wantRPMError != nil {
+				assert.ErrorIs(t, q.Err(), tt.wantRPMError)
+			}
+		})
+	}
+}
+
+func Test_rpmDatabaseQuery_Next_MultipleCalls(t *testing.T) {
+	t.Run("when output has multiple packages, then return all of them", func(t *testing.T) {
+		r := strings.NewReader(`vim-enhanced
+2:8.0.1763-15.el8
+x86_64
+(none)
+/etc/profile.d/vim.sh
+/usr/bin/vim
+/usr/bin/vimdiff
+.
+sed
+4.5-2.el8
+x86_64
+(none)
+/usr/bin/sed
+/usr/share/doc/sed
+/usr/share/doc/sed/sedfaq.txt.gz
+/usr/share/info/sed.info.gz
+/usr/share/licenses/sed
+.
+`)
+		q := &rpmDatabaseQuery{
+			rpmWait:    func() error { return nil },
+			rpmScanner: bufio.NewScanner(r),
+			rpmStderr:  &bytes.Buffer{},
+			rpmStdout:  io.NopCloser(r),
+		}
+		assert.True(t, q.Next())
+		assert.Equal(t,
+			rpmPackage{
+				Name:    "vim-enhanced",
+				Version: "2:8.0.1763-15.el8",
+				Arch:    "x86_64",
+				Filenames: []string{
+					"/etc/profile.d/vim.sh",
+					"/usr/bin/vim",
+					"/usr/bin/vimdiff",
+				},
+			},
+			q.Package())
+		assert.True(t, q.Next())
+		assert.Equal(t,
+			rpmPackage{
+				Name:    "sed",
+				Version: "4.5-2.el8",
+				Arch:    "x86_64",
+				Filenames: []string{
+					"/usr/bin/sed",
+					"/usr/share/doc/sed",
+					"/usr/share/doc/sed/sedfaq.txt.gz",
+					"/usr/share/info/sed.info.gz",
+					"/usr/share/licenses/sed",
+				},
+			},
+			q.Package())
+		assert.False(t, q.Next())
+		assert.Nil(t, q.Err())
+	})
+}

--- a/tools/large-git-files/allowlist
+++ b/tools/large-git-files/allowlist
@@ -7,6 +7,7 @@ generated/scanner/api/v1/vulnerability.pb.go
 go.sum
 image/dump/cves_10222019.tar.gz
 pkg/rhelv2/rpm/testdata/Packages
+pkg/rhelv2/rpm/testdata/rpmdb.sqlite
 pkg/vulnloader/nvdloader/nvdloader_easyjson.go
 pkg/ziputil/testdata/test.zip
 tools/linters/go.sum


### PR DESCRIPTION
## Description

Add support for scanning images using `rpm` on top of SQLite database backend, which is the default RPM database backend for `>= 4.16`. The support is behind a feature flag that defaults to `false`.

RHEL images from release 9 onward are built on `rpm >= 4.16`. Supporting the SQLite database backend is a requirement to support these images in Stackrox Scanner. We will need to adopt UBI9 to enable RHEL9 support because Stackrox Scanner relies on the `rpm` binary in the container image to query the RPM database. 

ROX-10929

### Status of support of RHEL9 scanning

Due to an issue with CircleCI docker runtime that prevents UBI9 containers to execute, we cannot bump the Scanner image to it. The issue is that UBI9 requires a specific seccomp profile setup that is not currently available in CircleCI and cannot be modified when building images. **We expect these issues to disappear once OpenshiftCI is onboarded.**

Once Scanner is running on UBI9, we can set the feature flag added here to true, and perform final end-to-end testing and release RHEL9 support.
  
## Tests

- `go run localdev/main.go` over UBI8 and UBI9 images, both yielding features.                                      
