### PR TITLE
ROX-11037: Add manual entry for CVE-2017-5638

### DIFF
--- a/pkg/vulnloader/nvdloader/manual.go
+++ b/pkg/vulnloader/nvdloader/manual.go
@@ -454,4 +454,309 @@ var manuallyEnrichedVulns = map[string]*schema.NVDCVEFeedJSON10DefCVEItem{
 		LastModifiedDate: "2022-03-31T00:00Z",
 		PublishedDate:    "2022-03-31T00:00Z",
 	},
+	"CVE-2017-5638": {
+		CVE: &schema.CVEJSON40{
+			CVEDataMeta: &schema.CVEJSON40CVEDataMeta{
+				ASSIGNER: "security@apache.org",
+				ID:       "CVE-2017-5638",
+			},
+			DataFormat:  "MITRE",
+			DataType:    "CVE",
+			DataVersion: "4.0",
+			Description: &schema.CVEJSON40Description{
+				DescriptionData: []*schema.CVEJSON40LangString{
+					{
+						Lang:  "en",
+						Value: "The Jakarta Multipart parser in Apache Struts 2 2.3.x before 2.3.32 and 2.5.x before 2.5.10.1 has incorrect exception handling and error-message generation during file-upload attempts, which allows remote attackers to execute arbitrary commands via a crafted Content-Type, Content-Disposition, or Content-Length HTTP header, as exploited in the wild in March 2017 with a Content-Type header containing a #cmd= string.",
+					},
+				},
+			},
+			References: &schema.CVEJSON40References{
+				ReferenceData: []*schema.CVEJSON40Reference{
+					{
+						Name:      "https://isc.sans.edu/diary/22169",
+						Refsource: "MISC",
+						Tags: []string{
+							"Technical Description",
+							"Third Party Advisory",
+						},
+						URL: "https://isc.sans.edu/diary/22169",
+					},
+					{
+						Name:      "https://github.com/rapid7/metasploit-framework/issues/8064",
+						Refsource: "MISC",
+						Tags: []string{
+							"Exploit",
+						},
+						URL: "https://github.com/rapid7/metasploit-framework/issues/8064",
+					},
+					{
+						Name:      "https://git1-us-west.apache.org/repos/asf?p=struts.git;a=commit;h=6b8272ce47160036ed120a48345d9aa884477228",
+						Refsource: "CONFIRM",
+						Tags: []string{
+							"Patch",
+						},
+						URL: "https://git1-us-west.apache.org/repos/asf?p=struts.git;a=commit;h=6b8272ce47160036ed120a48345d9aa884477228",
+					},
+					{
+						Name:      "https://git1-us-west.apache.org/repos/asf?p=struts.git;a=commit;h=352306493971e7d5a756d61780d57a76eb1f519a",
+						Refsource: "CONFIRM",
+						Tags: []string{
+							"Patch",
+						},
+						URL: "https://git1-us-west.apache.org/repos/asf?p=struts.git;a=commit;h=352306493971e7d5a756d61780d57a76eb1f519a",
+					},
+					{
+						Name:      "https://cwiki.apache.org/confluence/display/WW/S2-045",
+						Refsource: "CONFIRM",
+						Tags: []string{
+							"Mitigation",
+							"Vendor Advisory",
+						},
+						URL: "https://cwiki.apache.org/confluence/display/WW/S2-045",
+					},
+					{
+						Name:      "http://blog.trendmicro.com/trendlabs-security-intelligence/cve-2017-5638-apache-struts-vulnerability-remote-code-execution/",
+						Refsource: "MISC",
+						Tags: []string{
+							"Technical Description",
+							"Third Party Advisory",
+						},
+						URL: "http://blog.trendmicro.com/trendlabs-security-intelligence/cve-2017-5638-apache-struts-vulnerability-remote-code-execution/",
+					},
+					{
+						Name:      "http://blog.talosintelligence.com/2017/03/apache-0-day-exploited.html",
+						Refsource: "MISC",
+						Tags: []string{
+							"Technical Description",
+							"Third Party Advisory",
+						},
+						URL: "http://blog.talosintelligence.com/2017/03/apache-0-day-exploited.html",
+					},
+					{
+						Name:      "https://packetstormsecurity.com/files/141494/S2-45-poc.py.txt",
+						Refsource: "MISC",
+						Tags: []string{
+							"Exploit",
+							"VDB Entry",
+						},
+						URL: "https://packetstormsecurity.com/files/141494/S2-45-poc.py.txt",
+					},
+					{
+						Name:      "https://nmap.org/nsedoc/scripts/http-vuln-cve2017-5638.html",
+						Refsource: "MISC",
+						Tags: []string{
+							"Third Party Advisory",
+						},
+						URL: "https://nmap.org/nsedoc/scripts/http-vuln-cve2017-5638.html",
+					},
+					{
+						Name:      "https://github.com/mazen160/struts-pwn",
+						Refsource: "MISC",
+						Tags: []string{
+							"Exploit",
+						},
+						URL: "https://github.com/mazen160/struts-pwn",
+					},
+					{
+						Name:      "41570",
+						Refsource: "EXPLOIT-DB",
+						Tags: []string{
+							"Exploit",
+							"VDB Entry",
+						},
+						URL: "https://exploit-db.com/exploits/41570",
+					},
+					{
+						Name:      "https://twitter.com/theog150/status/841146956135124993",
+						Refsource: "MISC",
+						Tags: []string{
+							"Third Party Advisory",
+						},
+						URL: "https://twitter.com/theog150/status/841146956135124993",
+					},
+					{
+						Name:      "https://arstechnica.com/security/2017/03/critical-vulnerability-under-massive-attack-imperils-high-impact-sites/",
+						Refsource: "MISC",
+						Tags: []string{
+							"Press/Media Coverage",
+						},
+						URL: "https://arstechnica.com/security/2017/03/critical-vulnerability-under-massive-attack-imperils-high-impact-sites/",
+					},
+					{
+						Name:      "96729",
+						Refsource: "BID",
+						Tags: []string{
+							"Third Party Advisory",
+							"VDB Entry",
+						},
+						URL: "http://www.securityfocus.com/bid/96729",
+					},
+					{
+						Name:      "http://www.eweek.com/security/apache-struts-vulnerability-under-attack.html",
+						Refsource: "MISC",
+						Tags: []string{
+							"Press/Media Coverage",
+						},
+						URL: "http://www.eweek.com/security/apache-struts-vulnerability-under-attack.html",
+					},
+					{
+						Name:      "https://www.imperva.com/blog/2017/03/cve-2017-5638-new-remote-code-execution-rce-vulnerability-in-apache-struts-2/",
+						Refsource: "MISC",
+						URL:       "https://www.imperva.com/blog/2017/03/cve-2017-5638-new-remote-code-execution-rce-vulnerability-in-apache-struts-2/",
+					},
+					{
+						Name:      "https://support.lenovo.com/us/en/product_security/len-14200",
+						Refsource: "CONFIRM",
+						URL:       "https://support.lenovo.com/us/en/product_security/len-14200",
+					},
+					{
+						Name:      "https://h20566.www2.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03723en_us",
+						Refsource: "CONFIRM",
+						URL:       "https://h20566.www2.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbhf03723en_us",
+					},
+					{
+						Name:      "https://h20566.www2.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbgn03733en_us",
+						Refsource: "CONFIRM",
+						URL:       "https://h20566.www2.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbgn03733en_us",
+					},
+					{
+						Name:      "https://h20566.www2.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbgn03749en_us",
+						Refsource: "CONFIRM",
+						URL:       "https://h20566.www2.hpe.com/hpsc/doc/public/display?docLocale=en_US&docId=emr_na-hpesbgn03749en_us",
+					},
+					{
+						Name:      "1037973",
+						Refsource: "SECTRACK",
+						URL:       "http://www.securitytracker.com/id/1037973",
+					},
+					{
+						Name:      "http://www.oracle.com/technetwork/security-advisory/cpujul2017-3236622.html",
+						Refsource: "CONFIRM",
+						URL:       "http://www.oracle.com/technetwork/security-advisory/cpujul2017-3236622.html",
+					},
+					{
+						Name:      "41614",
+						Refsource: "EXPLOIT-DB",
+						URL:       "https://www.exploit-db.com/exploits/41614/",
+					},
+					{
+						Name:      "https://www.symantec.com/security-center/network-protection-security-advisories/SA145",
+						Refsource: "CONFIRM",
+						URL:       "https://www.symantec.com/security-center/network-protection-security-advisories/SA145",
+					},
+					{
+						Name:      "https://struts.apache.org/docs/s2-046.html",
+						Refsource: "CONFIRM",
+						URL:       "https://struts.apache.org/docs/s2-046.html",
+					},
+					{
+						Name:      "https://struts.apache.org/docs/s2-045.html",
+						Refsource: "CONFIRM",
+						URL:       "https://struts.apache.org/docs/s2-045.html",
+					},
+					{
+						Name:      "https://cwiki.apache.org/confluence/display/WW/S2-046",
+						Refsource: "CONFIRM",
+						URL:       "https://cwiki.apache.org/confluence/display/WW/S2-046",
+					},
+					{
+						Name:      "VU#834067",
+						Refsource: "CERT-VN",
+						URL:       "https://www.kb.cert.org/vuls/id/834067",
+					},
+					{
+						Name:      "https://security.netapp.com/advisory/ntap-20170310-0001/",
+						Refsource: "CONFIRM",
+						URL:       "https://security.netapp.com/advisory/ntap-20170310-0001/",
+					},
+					{
+						Name:      "http://www.arubanetworks.com/assets/alert/ARUBA-PSA-2017-002.txt",
+						Refsource: "CONFIRM",
+						URL:       "http://www.arubanetworks.com/assets/alert/ARUBA-PSA-2017-002.txt",
+					},
+					{
+						Name:      "[announce] 20200131 Apache Software Foundation Security Report: 2019",
+						Refsource: "MLIST",
+						URL:       "https://lists.apache.org/thread.html/r6d03e45b81eab03580cf7f8bb51cb3e9a1b10a2cc0c6a2d3cc92ed0c@%3Cannounce.apache.org%3E",
+					},
+					{
+						Name:      "[announce] 20210125 Apache Software Foundation Security Report: 2020",
+						Refsource: "MLIST",
+						URL:       "https://lists.apache.org/thread.html/r90890afea72a9571d666820b2fe5942a0a5f86be406fa31da3dd0922@%3Cannounce.apache.org%3E",
+					},
+					{
+						Name:      "[announce] 20210223 Re: Apache Software Foundation Security Report: 2020",
+						Refsource: "MLIST",
+						URL:       "https://lists.apache.org/thread.html/r1125f3044a0946d1e7e6f125a6170b58d413ebd4a95157e4608041c7@%3Cannounce.apache.org%3E",
+					},
+				},
+			},
+		},
+		Configurations: &schema.NVDCVEFeedJSON10DefConfigurations{
+			CVEDataVersion: "4.0",
+			Nodes: []*schema.NVDCVEFeedJSON10DefNode{
+				{
+					CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
+						{
+							Cpe23Uri:              "cpe:2.3:a:apache:struts:*:*:*:*:*:*:*:*",
+							Vulnerable:            true,
+							VersionStartIncluding: "2.3.5",
+							VersionEndExcluding:   "2.3.32",
+						},
+						{
+							Cpe23Uri:              "cpe:2.3:a:apache:struts:*:*:*:*:*:*:*:*",
+							Vulnerable:            true,
+							VersionStartIncluding: "2.5",
+							VersionEndExcluding:   "2.5.10.1",
+						},
+					},
+					Operator: "OR",
+				},
+			},
+		},
+		Impact: &schema.NVDCVEFeedJSON10DefImpact{
+			BaseMetricV2: &schema.NVDCVEFeedJSON10DefImpactBaseMetricV2{
+				AcInsufInfo: false,
+				CVSSV2: &schema.CVSSV20{
+					AccessComplexity:      "LOW",
+					AccessVector:          "NETWORK",
+					Authentication:        "NONE",
+					AvailabilityImpact:    "COMPLETE",
+					BaseScore:             10,
+					ConfidentialityImpact: "COMPLETE",
+					IntegrityImpact:       "COMPLETE",
+					VectorString:          "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+					Version:               "2.0",
+				},
+				ExploitabilityScore:     10,
+				ImpactScore:             10,
+				ObtainAllPrivilege:      false,
+				ObtainOtherPrivilege:    false,
+				ObtainUserPrivilege:     false,
+				Severity:                "HIGH",
+				UserInteractionRequired: false,
+			},
+			BaseMetricV3: &schema.NVDCVEFeedJSON10DefImpactBaseMetricV3{
+				CVSSV3: &schema.CVSSV30{
+					AttackComplexity:      "LOW",
+					AttackVector:          "NETWORK",
+					AvailabilityImpact:    "HIGH",
+					BaseScore:             10,
+					BaseSeverity:          "CRITICAL",
+					ConfidentialityImpact: "HIGH",
+					IntegrityImpact:       "HIGH",
+					PrivilegesRequired:    "NONE",
+					Scope:                 "CHANGED",
+					UserInteraction:       "NONE",
+					VectorString:          "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+					Version:               "3.0",
+				},
+				ExploitabilityScore: 3.9,
+				ImpactScore:         6,
+			},
+		},
+		LastModifiedDate: "2021-02-24T12:15Z",
+		PublishedDate:    "2017-03-11T02:59Z",
+	},
 }


### PR DESCRIPTION
## Description

Add a manual entry for CVE-2017-5638 that specifies `VersionEndExcluding` instead of individual cpe matches.

Without the `VersionEndExcluding` Scanner cannot determine which struts version fixes this vuln, which in turn will be shown in the UI as "not fixable":

![image](https://user-images.githubusercontent.com/291493/172518256-04b64639-4323-4a90-86c2-0001b94c4948.png)

ROX-11037

## Testing

Added `generate-dump-on-pr` label to this PR, forcing the generation of the vulnerability definitions bundle. Then, pulled the previous CVE-2017-5638 and diffed it with the new generated one:

```
% gsutil -m cp -r gs://roxci-artifacts/scanner/422053bd-4481-424c-8550-76b17d7c6248/276767-generate-genesis-dump/genesis-dump.zip .
% unzip genesis-dump.zip -d genesis-dump/
...
% cat genesis-dump/nvd/2017.json | jq '.CVE_Items[] | select(.cve.CVE_data_meta.ID == "CVE-2017-5638")' > /tmp/old.CVE-2017-5638.json
% cat image/scanner/dump/nvd/2017.json | jq '.CVE_Items[] | select(.cve.CVE_data_meta.ID == "CVE-2017-5638")' > /tmp/new.CVE-2017-5638.json
%
%
% diff -du /tmp/old.CVE-2017-5638.json /tmp/new.CVE-2017-5638.json
diff -du /tmp/old.CVE-2017-5638.json /tmp/new.CVE-2017-5638.json
--- /tmp/old.CVE-2017-5638.json	2022-06-07 19:20:42.995470874 -0700
+++ /tmp/new.CVE-2017-5638.json	2022-06-07 19:20:53.155507577 -0700
@@ -256,220 +256,15 @@
       {
         "cpe_match": [
           {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.11:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.12:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.15.1:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.15.2:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.19:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.20:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.20.1:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.24.1:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.24.2:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.29:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.30:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.10:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.14.3:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.15:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.16.3:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.17:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.23:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.24:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.28:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.28.1:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.8:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.9:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.13:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.14:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.15.3:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.16:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.20.2:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.20.3:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.24.3:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.25:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.31:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.5:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.14.1:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.14.2:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.16.1:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.16.2:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.21:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.22:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.26:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.27:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.6:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.3.7:*:*:*:*:*:*:*",
-            "vulnerable": true
-          }
-        ],
-        "operator": "OR"
-      },
-      {
-        "cpe_match": [
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5.4:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5.6:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5.7:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5.10:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5.3:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5.5:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5.8:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5.9:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5:*:*:*:*:*:*:*",
-            "vulnerable": true
-          },
-          {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5.1:*:*:*:*:*:*:*",
+            "cpe23Uri": "cpe:2.3:a:apache:struts:*:*:*:*:*:*:*:*",
+            "versionEndExcluding": "2.3.32",
+            "versionStartIncluding": "2.3.5",
             "vulnerable": true
           },
           {
-            "cpe23Uri": "cpe:2.3:a:apache:struts:2.5.2:*:*:*:*:*:*:*",
+            "cpe23Uri": "cpe:2.3:a:apache:struts:*:*:*:*:*:*:*:*",
+            "versionEndExcluding": "2.5.10.1",
+            "versionStartIncluding": "2.5",
             "vulnerable": true
           }
         ],
```

Also, pulled the `2d8ru/struts2` image, and run:

```
% go run localdev/main.go | grep CVE-2017-5638        

		 CVE-2017-5638 
% cp genesis-dump/nvd/2017.json image/scanner/dump/nvd 
% go run localdev/main.go | grep CVE-2017-5638        

		 CVE-2017-5638 2.3.32
%
```
