### PR TITLE
ROX-11335: Move Scanner DB secret out of main Scanner DB container

### DIFF
--- a/.circleci/collect-service-logs.sh
+++ b/.circleci/collect-service-logs.sh
@@ -37,6 +37,10 @@ main() {
             kubectl -n "${namespace}" logs "po/${pod}" -c "$ctr" > "${log_dir}/${pod}-${ctr}.log"
             kubectl -n "${namespace}" logs "po/${pod}" -p -c "$ctr" > "${log_dir}/${pod}-${ctr}-previous.log"
         done
+        for ctr in $(kubectl -n "${namespace}" get po "$pod" -o jsonpath='{.status.initContainerStatuses[*].name}'); do
+            kubectl -n "${namespace}" logs "po/${pod}" -c "$ctr" > "${log_dir}/${pod}-${ctr}.log"
+            kubectl -n "${namespace}" logs "po/${pod}" -p -c "$ctr" > "${log_dir}/${pod}-${ctr}-previous.log"
+        done
     done
     find "${log_dir}" -type f -size 0 -delete
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,7 +650,10 @@ jobs:
             - updater-bin
 
   create-postgres-dump-from-genesis-dump:
-    <<: *defaults
+    docker:
+      - *defaultImage
+      - image: postgres:12-alpine
+    working_directory: *defaultWorkingDirectory
     steps:
       - checkout
       - check-label-to-run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,9 +652,7 @@ jobs:
   create-postgres-dump-from-genesis-dump:
     docker:
       - *defaultImage
-      - image: postgres:12-alpine
-        environment:
-          POSTGRES_PASSWORD: password
+      - image: postgres:12.0-alpine
     working_directory: *defaultWorkingDirectory
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,6 +653,8 @@ jobs:
     docker:
       - *defaultImage
       - image: postgres:12-alpine
+        environment:
+          POSTGRES_PASSWORD: password
     working_directory: *defaultWorkingDirectory
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,10 +650,7 @@ jobs:
             - updater-bin
 
   create-postgres-dump-from-genesis-dump:
-    docker:
-      - *defaultImage
-      - image: postgres:12.0-alpine
-    working_directory: *defaultWorkingDirectory
+    <<: *defaults
     steps:
       - checkout
       - check-label-to-run:

--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -26,7 +26,8 @@ spec:
         command:
         - /bin/sh
         - -c
-        - docker-entrypoint.sh postgres init
+        - sleep 300000
+        #- docker-entrypoint.sh postgres init
         volumeMounts:
         - name: scanner-db-data
           mountPath: /var/lib/postgresql/data

--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -20,6 +20,9 @@ spec:
       initContainers:
       - name: init-db
         image: {{.Values.scannerDBImage}}:{{.Values.tag}}
+        env:
+        - name: POSTGRES_PASSWORD_FILE
+          value: "/run/secrets/stackrox.io/secrets/password"
         command:
         - /bin/sh
         - -c

--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -73,7 +73,7 @@ spec:
         configMap:
           name: {{ .Values.appName }}-config
       - name: scanner-db-data
-      emptyDir: {}
+        emptyDir: {}
       - name: scanner-db-tls-volume
         secret:
           secretName: scanner-db-tls

--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -20,17 +20,10 @@ spec:
       initContainers:
       - name: init-db
         image: {{.Values.scannerDBImage}}:{{.Values.tag}}
-        env:
-        - name: PGDATA
-          value: "/var/lib/postgresql/data/pgdata"
         command:
         - /bin/sh
         - -c
-        - |
-          # Initialize DB if it does not exist
-          if [ ! -s "$PGDATA/PG_VERSION" ]; then
-            docker-entrypoint.sh initdb --pwfile /run/secrets/stackrox.io/secrets/password
-          fi
+        - docker-entrypoint.sh postgres init
         volumeMounts:
         - name: scanner-db-data
           mountPath: /var/lib/postgresql/data
@@ -43,9 +36,6 @@ spec:
       containers:
       - name: db
         image: {{.Values.scannerDBImage}}:{{.Values.tag}}
-        env:
-        - name: PGDATA
-          value: "/var/lib/postgresql/data/pgdata"
         ports:
         - name: postgresql
           protocol: TCP

--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -17,64 +17,74 @@ spec:
       labels:
         app: {{ .Values.appName }}-db
     spec:
+      initContainers:
+      - name: init-db
+        image: {{.Values.scannerDBImage}}:{{.Values.tag}}
+        env:
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/pgdata"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          # Initialize DB if it does not exist
+          if [ ! -s "$PGDATA/PG_VERSION" ]; then
+            docker-entrypoint.sh initdb --pwfile /run/secrets/stackrox.io/secrets/password
+          fi
+        volumeMounts:
+        - name: scanner-db-data
+          mountPath: /var/lib/postgresql/data
+        - name: scanner-db-password
+          mountPath: /run/secrets/stackrox.io/secrets
+          readOnly: true
+        securityContext:
+          runAsUser: 70
+          runAsGroup: 70
+      containers:
+      - name: db
+        image: {{.Values.scannerDBImage}}:{{.Values.tag}}
+        env:
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/pgdata"
+        ports:
+        - name: postgresql
+          protocol: TCP
+          containerPort: 5432
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 200m
+            memory: 200Mi
+        volumeMounts:
+        - name: scanner-db-data
+          mountPath: /var/lib/postgresql/data
+        - name: scanner-db-tls-volume
+          mountPath: /run/secrets/stackrox.io/certs
+          readOnly: true
+        securityContext:
+          runAsUser: 70
+          runAsGroup: 70
       securityContext:
         fsGroup: 70
-      initContainers:
-        - name: init-db
-          image: {{.Values.scannerDBImage}}:{{.Values.tag}}
-          command:
-          - /bin/sh
-          - -c
-          - |
-            mkdir -p /var/lib/postgresql/data
-            chmod 700 /var/lib/postgresql/data
-            chown -R postgres:postgres /var/lib/postgresql
-          volumeMounts:
-            - name: db-data
-              mountPath: /var/lib/postgresql/data
-          securityContext:
-            runAsUser: 0
-      containers:
-        - name: db
-          command: ["/usr/local/bin/docker-entrypoint.sh", "postgres", "-c", "config_file=/etc/postgresql.conf"]
-          ports:
-          - name: postgresql
-            containerPort: 5432
-          image: {{.Values.scannerDBImage}}:{{.Values.tag}}
-          resources:
-            limits:
-              cpu: 2
-              memory: 4Gi
-            requests:
-              cpu: 200m
-              memory: 200Mi
-          volumeMounts:
-            - name: db-data
-              mountPath: /var/lib/postgresql/data
-            - name: scanner-db-tls-volume
-              mountPath: /run/secrets/stackrox.io/certs
-            - name: scanner-db-password
-              mountPath: /run/secrets/stackrox.io/secrets
-          securityContext:
-            runAsUser: 70
-            runAsGroup: 70
       volumes:
-        - name: config
-          configMap:
-            name: {{ .Values.appName }}-config
-        - name: db-data
-          emptyDir: {}
-        - name: scanner-db-tls-volume
-          secret:
-            secretName: scanner-db-tls
-            defaultMode: 0640
-            items:
-            - key: cert.pem
-              path: server.crt
-            - key: key.pem
-              path: server.key
-            - key: ca.pem
-              path: root.crt
-        - name: scanner-db-password
-          secret:
-            secretName: scanner-db-password
+      - name: config
+        configMap:
+          name: {{ .Values.appName }}-config
+      - name: scanner-db-data
+      emptyDir: {}
+      - name: scanner-db-tls-volume
+        secret:
+          secretName: scanner-db-tls
+          defaultMode: 0640
+          items:
+          - key: cert.pem
+            path: server.crt
+          - key: key.pem
+            path: server.key
+          - key: ca.pem
+            path: root.crt
+      - name: scanner-db-password
+        secret:
+          secretName: scanner-db-password

--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -23,11 +23,6 @@ spec:
         env:
         - name: POSTGRES_PASSWORD_FILE
           value: "/run/secrets/stackrox.io/secrets/password"
-        command:
-        - /bin/sh
-        - -c
-        - sleep 300000
-        #- docker-entrypoint.sh postgres init
         volumeMounts:
         - name: scanner-db-data
           mountPath: /var/lib/postgresql/data

--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -23,9 +23,13 @@ spec:
         env:
         - name: POSTGRES_PASSWORD_FILE
           value: "/run/secrets/stackrox.io/secrets/password"
+        command: ["sleep", "20000"]
         volumeMounts:
         - name: scanner-db-data
           mountPath: /var/lib/postgresql/data
+        - name: scanner-db-tls-volume
+          mountPath: /run/secrets/stackrox.io/certs
+          readOnly: true
         - name: scanner-db-password
           mountPath: /run/secrets/stackrox.io/secrets
           readOnly: true

--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -23,7 +23,6 @@ spec:
         env:
         - name: POSTGRES_PASSWORD_FILE
           value: "/run/secrets/stackrox.io/secrets/password"
-        command: ["sleep", "20000"]
         volumeMounts:
         - name: scanner-db-data
           mountPath: /var/lib/postgresql/data

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
         configMap:
           name: {{ .Values.appName }}-config
       - name: vuln-temp-db
-      emptyDir: {}
+        emptyDir: {}
       - name: scanner-tls-volume
         secret:
           secretName: scanner-tls

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -18,53 +18,54 @@ spec:
         app: {{ .Values.appName }}
     spec:
       containers:
-        - name: scanner
-          image:  {{ .Values.scannerImage}}:{{ .Values.tag }}
-          env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: ROX_SKIP_PEER_VALIDATION
-            value: "true"
-          resources:
-            limits:
-              cpu: 2
-              memory: 4Gi
-            requests:
-              cpu: 200m
-              memory: 200Mi
-          securityContext:
-            runAsUser: 65534
-          readinessProbe:
-            httpGet:
-              scheme: HTTPS
-              path: /clairify/ping
-              port: 8080
-            timeoutSeconds: 10
-            periodSeconds: 10
-            failureThreshold: 3
-            successThreshold: 1
-          volumeMounts:
-            - name: config
-              mountPath: /etc/scanner
-              readOnly: true
-            - name: scanner-tls-volume
-              mountPath: /run/secrets/stackrox.io/certs/
-              readOnly: true
-            - name: vuln-temp-db
-              mountPath: /var/lib/stackrox
-            - name: scanner-db-password
-              mountPath: /run/secrets/stackrox.io/secrets
-      volumes:
+      - name: scanner
+        image: {{ .Values.scannerImage}}:{{ .Values.tag }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ROX_SKIP_PEER_VALIDATION
+          value: "true"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 200m
+            memory: 200Mi
+        securityContext:
+          runAsUser: 65534
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /clairify/ping
+            port: 8080
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        volumeMounts:
         - name: config
-          configMap:
-            name: {{ .Values.appName }}-config
-        - name: vuln-temp-db
-          emptyDir: {}
+          mountPath: /etc/scanner
+          readOnly: true
         - name: scanner-tls-volume
-          secret:
-            secretName: scanner-tls
+          mountPath: /run/secrets/stackrox.io/certs/
+          readOnly: true
+        - name: vuln-temp-db
+          mountPath: /var/lib/stackrox
         - name: scanner-db-password
-          secret:
-            secretName: scanner-db-password
+          mountPath: /run/secrets/stackrox.io/secrets
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: {{ .Values.appName }}-config
+      - name: vuln-temp-db
+      emptyDir: {}
+      - name: scanner-tls-volume
+        secret:
+          secretName: scanner-tls
+      - name: scanner-db-password
+        secret:
+          secretName: scanner-db-password

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -38,28 +38,22 @@ RUN groupadd -g 70 postgres && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     chown postgres:postgres /usr/local/bin/docker-entrypoint.sh && \
-    chmod +x /usr/local/bin/docker-entrypoint.sh
+    chmod +x /usr/local/bin/docker-entrypoint.sh && \
+    mkdir /docker-entrypoint-initdb.d
+
+USER postgres:postgres
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 5432
-CMD ["postgres"]
+CMD ["postgres", "-c", "config_file=/etc/postgresql.conf"]
 
 FROM base AS scanner-db-slim
 
 ENV ROX_SLIM_MODE="true"
-
-# The entrypoint script requires the init directory to exist, so we create it
-# here even though scanner slim does not ship any definitions.
-
-RUN mkdir /docker-entrypoint-initdb.d
-
-USER 70:70
 
 FROM base AS scanner-db
 
 ENV ROX_SLIM_MODE="false"
 
 COPY --from=extracted_bundle /bundle/docker-entrypoint-initdb.d/definitions.sql.gz /docker-entrypoint-initdb.d/
-
-USER 70:70

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -17,9 +17,7 @@ LABEL name="scanner-db" \
       description="This image supports image scanning in the StackRox Kubernetes Security Platform."
 
 ENV PG_MAJOR=12
-ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/" \
-    PGDATA="/var/lib/postgresql/data" \
-    POSTGRES_PASSWORD_FILE="/run/secrets/stackrox.io/secrets/password"
+ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/"
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 COPY --from=extracted_bundle /bundle/etc/postgresql.conf /bundle/etc/pg_hba.conf /etc/

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -18,6 +18,8 @@ LABEL name="scanner-db" \
 
 ENV PG_MAJOR=12
 ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/"
+    PGDATA="/var/lib/postgresql/data/pgdata" \
+    POSTGRES_PASSWORD_FILE="/run/secrets/stackrox.io/secrets/password"
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 COPY --from=extracted_bundle /bundle/etc/postgresql.conf /bundle/etc/pg_hba.conf /etc/

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -17,7 +17,7 @@ LABEL name="scanner-db" \
       description="This image supports image scanning in the StackRox Kubernetes Security Platform."
 
 ENV PG_MAJOR=12
-ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/"
+ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/" \
     PGDATA="/var/lib/postgresql/data/pgdata" \
     POSTGRES_PASSWORD_FILE="/run/secrets/stackrox.io/secrets/password"
 

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -18,8 +18,7 @@ LABEL name="scanner-db" \
 
 ENV PG_MAJOR=12
 ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/" \
-    PGDATA="/var/lib/postgresql/data/pgdata" \
-    POSTGRES_PASSWORD_FILE="/run/secrets/stackrox.io/secrets/password"
+    PGDATA="/var/lib/postgresql/data/pgdata"
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 COPY --from=extracted_bundle /bundle/etc/postgresql.conf /bundle/etc/pg_hba.conf /etc/

--- a/image/db/rhel/scripts/docker-entrypoint.sh
+++ b/image/db/rhel/scripts/docker-entrypoint.sh
@@ -347,6 +347,7 @@ _main() {
 			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
 			echo
 		fi
+		### STACKROX MODIFIED - Exit once DB is initialized.
 		exit 0
 	fi
 

--- a/image/db/rhel/scripts/docker-entrypoint.sh
+++ b/image/db/rhel/scripts/docker-entrypoint.sh
@@ -299,42 +299,6 @@ _pg_want_help() {
 	return 1
 }
 
-### STACKROX MODIFIED - This allows us to initialize the database
-### with vulnerability data from within the initContainer.
-### This just copy/pasted and moved from the original source.
-postgres_initialize() {
-	ls /var/lib/postgresql/data/pgdata
-	# only run initialization on an empty data directory
-	if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
-		docker_verify_minimum_env
-
-		# check dir permissions to reduce likelihood of half-initialized database
-		ls /docker-entrypoint-initdb.d/ > /dev/null
-
-		docker_init_database_dir
-		pg_setup_hba_conf "$@"
-
-		# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
-		# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
-		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-		docker_temp_server_start "$@"
-
-		docker_setup_db
-		docker_process_init_files /docker-entrypoint-initdb.d/*
-
-		docker_temp_server_stop
-		unset PGPASSWORD
-
-		echo
-		echo 'PostgreSQL init process complete; ready for start up.'
-		echo
-	else
-		echo
-		echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
-		echo
-	fi
-}
-
 _main() {
 	# if first arg looks like a flag, assume we want to run postgres server
 	if [ "${1:0:1}" = '-' ]; then
@@ -353,13 +317,37 @@ _main() {
 			exec gosu postgres "$BASH_SOURCE" "$@"
 		fi
 
-		### STACKROX MODIFIED - This allows us to initialize the database
-		### with vulnerability data from within the initContainer.
-		### The original code was moved to postgres_initialize.
-		if [ "$2" = 'init' ]; then
-			postgres_initialize "$@"
-			exit $?
+		### STACKROX MODIFIED - If there is no data, initialize and exit.
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+
+			# check dir permissions to reduce likelihood of half-initialized database
+			ls /docker-entrypoint-initdb.d/ > /dev/null
+
+			docker_init_database_dir
+			pg_setup_hba_conf "$@"
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
 		fi
+		exit 0
 	fi
 
 	exec "$@"

--- a/image/db/rhel/scripts/docker-entrypoint.sh
+++ b/image/db/rhel/scripts/docker-entrypoint.sh
@@ -342,13 +342,14 @@ _main() {
 			echo
 			echo 'PostgreSQL init process complete; ready for start up.'
 			echo
+
+			### STACKROX MODIFIED - Exit once DB is initialized.
+			exit 0
 		else
 			echo
 			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
 			echo
 		fi
-		### STACKROX MODIFIED - Exit once DB is initialized.
-		exit 0
 	fi
 
 	exec "$@"

--- a/image/db/rhel/scripts/docker-entrypoint.sh
+++ b/image/db/rhel/scripts/docker-entrypoint.sh
@@ -303,7 +303,7 @@ _pg_want_help() {
 ### with vulnerability data from within the initContainer.
 ### This just copy/pasted and moved from the original source.
 postgres_initialize() {
-	echo "here: $DATABASE_ALREADY_EXISTS"
+	ls /var/lib/postgresql/data/pgdata
 	# only run initialization on an empty data directory
 	if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 		docker_verify_minimum_env

--- a/image/db/rhel/scripts/docker-entrypoint.sh
+++ b/image/db/rhel/scripts/docker-entrypoint.sh
@@ -303,6 +303,7 @@ _pg_want_help() {
 ### with vulnerability data from within the initContainer.
 ### This just copy/pasted and moved from the original source.
 postgres_initialize() {
+	echo "here: $DATABASE_ALREADY_EXISTS"
 	# only run initialization on an empty data directory
 	if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 		docker_verify_minimum_env

--- a/image/db/rhel/scripts/docker-entrypoint.sh
+++ b/image/db/rhel/scripts/docker-entrypoint.sh
@@ -303,35 +303,35 @@ _pg_want_help() {
 ### with vulnerability data from within the initContainer.
 ### This just copy/pasted and moved from the original source.
 postgres_initialize() {
-  # only run initialization on an empty data directory
-  if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
-    docker_verify_minimum_env
+	# only run initialization on an empty data directory
+	if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+		docker_verify_minimum_env
 
-    # check dir permissions to reduce likelihood of half-initialized database
-    ls /docker-entrypoint-initdb.d/ > /dev/null
+		# check dir permissions to reduce likelihood of half-initialized database
+		ls /docker-entrypoint-initdb.d/ > /dev/null
 
-    docker_init_database_dir
-    pg_setup_hba_conf "$@"
+		docker_init_database_dir
+		pg_setup_hba_conf "$@"
 
-    # PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
-    # e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
-    export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
-    docker_temp_server_start "$@"
+		# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+		# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+		docker_temp_server_start "$@"
 
-    docker_setup_db
-    docker_process_init_files /docker-entrypoint-initdb.d/*
+		docker_setup_db
+		docker_process_init_files /docker-entrypoint-initdb.d/*
 
-    docker_temp_server_stop
-    unset PGPASSWORD
+		docker_temp_server_stop
+		unset PGPASSWORD
 
-    echo
-    echo 'PostgreSQL init process complete; ready for start up.'
-    echo
-  else
-    echo
-    echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
-    echo
-  fi
+		echo
+		echo 'PostgreSQL init process complete; ready for start up.'
+		echo
+	else
+		echo
+		echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+		echo
+	fi
 }
 
 _main() {
@@ -352,12 +352,12 @@ _main() {
 			exec gosu postgres "$BASH_SOURCE" "$@"
 		fi
 
-    ### STACKROX MODIFIED - This allows us to initialize the database
-    ### with vulnerability data from within the initContainer.
-    ### The original code was moved to postgres_initialize.
-    if [ "$2" = 'init' ]; then
-		  postgres_initialize "$@"
-		  exit $?
+		### STACKROX MODIFIED - This allows us to initialize the database
+		### with vulnerability data from within the initContainer.
+		### The original code was moved to postgres_initialize.
+		if [ "$2" = 'init' ]; then
+			postgres_initialize "$@"
+			exit $?
 		fi
 	fi
 


### PR DESCRIPTION
This PR makes a few PostgreSQL-related updates:

* Move Scanner DB's secret out of the main Scanner DB container
    * This moves the secret into the init container, as it is only needed there
* Some Dockerfile cleanup

We also start looking at initContainer logs