### PR TITLE
Separate DB integration tests to a separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,6 +582,8 @@ jobs:
     docker:
       - *defaultImage
       - image: postgres:12-bullseye
+        environment:
+          POSTGRES_PASSWORD: password
     working_directory: *defaultWorkingDirectory
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,7 +582,7 @@ jobs:
     docker:
       - *defaultImage
       - image: postgres:12-bullseye
-      working_directory: *defaultWorkingDirectory
+    working_directory: *defaultWorkingDirectory
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,27 +406,7 @@ commands:
             .circleci/collect-service-logs.sh kube-system
           when: always
 
-      - run:
-          name: Verify the scanner did not restart
-          command: |
-            if [[ "$(ls /tmp/k8s-service-logs/stackrox/*-previous.log | wc -l)" != 0 ]]; then
-                ls /tmp/k8s-service-logs/stackrox/*-previous.log
-                exit 1
-            fi
-            cat nohup.out || true
-          when: always
-
       - fetch-and-upload-scanner-metrics
-
-      - run-db-integration-tests:
-          is-slim: << parameters.is-slim >>
-
-      - run:
-          name: Collect k8s logs
-          command: |
-            .circleci/collect-service-logs.sh stackrox
-            .circleci/collect-service-logs.sh kube-system
-          when: always
 
       - ci-artifacts/store:
           path: /tmp/k8s-service-logs
@@ -460,21 +440,6 @@ commands:
           when: always
 
       - teardown-gke
-
-  run-db-integration-tests:
-    parameters:
-      is-slim:
-        type: boolean
-    steps:
-      - scanner-db-pf
-      - run:
-          name: Run db integration tests
-          command: |
-            if [[ "<< parameters.is-slim >>" == "true" ]]; then
-              make slim-db-integration-tests
-            else
-              make db-integration-tests
-            fi
 
   run-scale-tests:
     parameters:
@@ -613,6 +578,20 @@ jobs:
           name: Run style checks
           command: make style
 
+  db-integration-tests:
+    docker:
+      - *defaultImage
+      - image: postgres:12-bullseye
+      working_directory: *defaultWorkingDirectory
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: make deps
+      - run:
+          name: Run db integration tests (slim tests are a subset of the full tests)
+          command: make db-integration-tests
+
   generate-genesis-dump:
     <<: *defaults
     steps:
@@ -652,7 +631,7 @@ jobs:
   create-postgres-dump-from-genesis-dump:
     docker:
       - *defaultImage
-      - image: postgres:12.0-alpine
+      - image: postgres:12-bullseye
     working_directory: *defaultWorkingDirectory
     steps:
       - checkout
@@ -1058,6 +1037,8 @@ workflows:
           <<: *runOnAllTagsWithQuayPullCtx
       - style-checks:
           <<: *runOnAllTagsWithQuayPullCtx
+      - db-integration-tests:
+          <<: *runOnAllTagsWithQuayPullCtx
       - build:
           <<: *runOnAllTags
           context:
@@ -1132,6 +1113,8 @@ workflows:
     - unit-tests:
         <<: *runOnAllTagsWithQuayPullCtx
     - style-checks:
+        <<: *runOnAllTagsWithQuayPullCtx
+    - db-integration-tests:
         <<: *runOnAllTagsWithQuayPullCtx
     - build:
         <<: *runOnAllTags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,6 +634,8 @@ jobs:
     docker:
       - *defaultImage
       - image: postgres:12-bullseye
+        environment:
+          POSTGRES_PASSWORD: password
     working_directory: *defaultWorkingDirectory
     steps:
       - checkout


### PR DESCRIPTION
There is no need to run the DB integration tests using a live Scanner DB, so might as well move the tests elsewhere so they do not depend on a pre-existing deployment.

Also use the postgres:12-bullseye image instead of postgres:12.0-alpine for two reasons:
1. Let's us use the latest version of PostgreSQL 12
2. We took the docker-entrypoint.sh from the [Debian version](https://github.com/docker-library/postgres/blob/master/12/bullseye/docker-entrypoint.sh), so this gives us a sense of consistency (kind of)