### PR TITLE
Add JUnit output to E2E test results

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,15 @@ updates:
     open-pull-requests-limit: 3
     reviewers:
       - 'stackrox/scanner-dep-updaters'
+
+  - package-ecosystem: 'gomod'
+    directory: '/tools/test/'
+    schedule:
+      interval: 'weekly'
+      day: 'wednesday'
+    open-pull-requests-limit: 3
+    reviewers:
+      - 'stackrox/scanner-dep-updaters'
       
   - package-ecosystem: 'docker'
     directory: 'image/scanner/rhel'

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 deps
 proto-generated-srcs
 protoc-*
+report.xml
+test.log
 /.proto/
 /.gobin/
 /genesis-dump/

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,10 @@ proto-generated-srcs
 protoc-*
 report.xml
 test.log
-/.proto/
 /.gobin/
+/.proto/
 /genesis-dump/
+/test-output/
 
 # nohup output when running port-forwards
 nohup.out

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ unit-tests: deps
 .PHONY: e2e-tests
 e2e-tests: deps
 	@echo "+ $@"
-	go test -tags e2e -count=1 -timeout=20m ./e2etests/... | tee test-output/test.log
+	go test -tags e2e -count=1 -timeout=20m ./e2etests/... | tee test.log
 	make report JUNIT_OUT=e2e-tests
 
 .PHONY: slim-e2e-tests

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ unit-tests: deps
 .PHONY: e2e-tests
 e2e-tests: deps
 	@echo "+ $@"
-	go test -tags e2e -count=1 -timeout=20m ./e2etests/... | tee test.log
+	go test -tags e2e -count=1 -timeout=20m ./e2etests/... | tee test-output/test.log
 	make report JUNIT_OUT=e2e-tests
 
 .PHONY: slim-e2e-tests

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ $(OSSLS_BIN): deps
 GO_JUNIT_REPORT_BIN := $(GOBIN)/go-junit-report
 $(GO_JUNIT_REPORT_BIN):
 	@echo "+ $@"
-	go install github.com/jstemmer/go-junit-report
+	@cd tools/test/ && go install github.com/jstemmer/go-junit-report
 
 #############
 ##  Tag  ##

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -1,0 +1,7 @@
+module github.com/stackrox/scanner/tools/test
+
+go 1.17
+
+require (
+	github.com/jstemmer/go-junit-report v1.0.0
+)

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -2,6 +2,4 @@ module github.com/stackrox/scanner/tools/test
 
 go 1.17
 
-require (
-	github.com/jstemmer/go-junit-report v1.0.0
-)
+require github.com/jstemmer/go-junit-report v1.0.0

--- a/tools/test/go.sum
+++ b/tools/test/go.sum
@@ -1,0 +1,2 @@
+github.com/jstemmer/go-junit-report v1.0.0 h1:8X1gzZpR+nVQLAht+L/foqOeX2l9DTZoaIPbEQHxsds=
+github.com/jstemmer/go-junit-report v1.0.0/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/tools/test/tools-import.go
+++ b/tools/test/tools-import.go
@@ -1,0 +1,13 @@
+//go:build tools
+// +build tools
+
+package tools
+
+// This file declares dependencies on tool for `go mod` purposes.
+// See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// for an explanation of the approach.
+
+import (
+	// Tool dependencies, not used anywhere in the code.
+	_ "github.com/jstemmer/go-junit-report"
+)


### PR DESCRIPTION
This is copied from https://github.com/stackrox/stackrox/blob/master/make/stackrox.mk.

This is meant to be used in OpenShift CI to get clearer test results. Once this is merged, I can update https://github.com/stackrox/scanner/pull/784 to add JUnit output to the E2E tests and I can add JUnit output to the already-migrated unit-tests.