### PR TITLE
Add runAsNonRoot to pod's security context

### DIFF
--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -32,9 +32,6 @@ spec:
         - name: scanner-db-password
           mountPath: /run/secrets/stackrox.io/secrets
           readOnly: true
-        securityContext:
-          runAsUser: 70
-          runAsGroup: 70
       containers:
       - name: db
         image: {{.Values.scannerDBImage}}:{{.Values.tag}}
@@ -55,11 +52,11 @@ spec:
         - name: scanner-db-tls-volume
           mountPath: /run/secrets/stackrox.io/certs
           readOnly: true
-        securityContext:
-          runAsUser: 70
-          runAsGroup: 70
       securityContext:
         fsGroup: 70
+        runAsGroup: 70
+        runAsNonRoot: true
+        runAsUser: 70
       volumes:
       - name: config
         configMap:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -34,8 +34,6 @@ spec:
           requests:
             cpu: 200m
             memory: 200Mi
-        securityContext:
-          runAsUser: 65534
         readinessProbe:
           httpGet:
             scheme: HTTPS
@@ -57,6 +55,9 @@ spec:
         - name: scanner-db-password
           mountPath: /run/secrets/stackrox.io/secrets
           readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       volumes:
       - name: config
         configMap:

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -40,7 +40,8 @@ RUN groupadd -g 70 postgres && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir /docker-entrypoint-initdb.d
 
-# This cannot be postgres:postgres, as the pod's security context sets `runAsNonRoot: true`,
+# This is equivalent to postgres:postgres. This remains unnamed, \
+# as the pod's security context sets `runAsNonRoot: true`,
 # and the Kubelet does not recognize named users.
 USER 70:70
 

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -40,7 +40,9 @@ RUN groupadd -g 70 postgres && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir /docker-entrypoint-initdb.d
 
-USER postgres:postgres
+# This cannot be postgres:postgres, as the pod's security context sets `runAsNonRoot: true`,
+# and the Kubelet does not recognize named users.
+USER 70:70
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -40,7 +40,7 @@ RUN groupadd -g 70 postgres && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir /docker-entrypoint-initdb.d
 
-# This is equivalent to postgres:postgres. This remains unnamed, \
+# This is equivalent to postgres:postgres. This remains unnamed,
 # as the pod's security context sets `runAsNonRoot: true`,
 # and the Kubelet does not recognize named users.
 USER 70:70

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -40,9 +40,7 @@ RUN groupadd -g 70 postgres && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir /docker-entrypoint-initdb.d
 
-# This is equivalent to postgres:postgres. This remains unnamed,
-# as the pod's security context sets `runAsNonRoot: true`,
-# and the Kubelet does not recognize named users.
+# This is equivalent to postgres:postgres.
 USER 70:70
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/image/scanner/rhel/Dockerfile
+++ b/image/scanner/rhel/Dockerfile
@@ -44,9 +44,7 @@ ENV REPO_TO_CPE_DIR="/repo2cpe"
 COPY --chown=65534:65534 --from=extracted_bundle "/bundle${REPO_TO_CPE_DIR}/" ".${REPO_TO_CPE_DIR}/"
 COPY --from=extracted_bundle /bundle/genesis_manifests.json ./
 
-# This is equivalent to nobody:nobody. This remains unnamed,
-# as the pod's security context sets `runAsNonRoot: true`,
-# and the Kubelet does not recognize named users.
+# This is equivalent to nobody:nobody.
 USER 65534:65534
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/image/scanner/rhel/Dockerfile
+++ b/image/scanner/rhel/Dockerfile
@@ -44,13 +44,13 @@ ENV REPO_TO_CPE_DIR="/repo2cpe"
 COPY --chown=65534:65534 --from=extracted_bundle "/bundle${REPO_TO_CPE_DIR}/" ".${REPO_TO_CPE_DIR}/"
 COPY --from=extracted_bundle /bundle/genesis_manifests.json ./
 
+USER 65534:65534
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 FROM base AS scanner-slim
 
 ENV ROX_SLIM_MODE="true"
-
-USER 65534:65534
 
 FROM base AS scanner
 
@@ -61,5 +61,3 @@ ENV K8S_DEFINITIONS_DIR="/k8s_definitions"
 
 COPY --chown=65534:65534 --from=extracted_bundle "/bundle${NVD_DEFINITIONS_DIR}/" ".${NVD_DEFINITIONS_DIR}/"
 COPY --chown=65534:65534 --from=extracted_bundle "/bundle${K8S_DEFINITIONS_DIR}/" ".${K8S_DEFINITIONS_DIR}/"
-
-USER 65534:65534

--- a/image/scanner/rhel/Dockerfile
+++ b/image/scanner/rhel/Dockerfile
@@ -44,7 +44,7 @@ ENV REPO_TO_CPE_DIR="/repo2cpe"
 COPY --chown=65534:65534 --from=extracted_bundle "/bundle${REPO_TO_CPE_DIR}/" ".${REPO_TO_CPE_DIR}/"
 COPY --from=extracted_bundle /bundle/genesis_manifests.json ./
 
-# This is equivalent to nobody:nobody. This remains unnamed, \
+# This is equivalent to nobody:nobody. This remains unnamed,
 # as the pod's security context sets `runAsNonRoot: true`,
 # and the Kubelet does not recognize named users.
 USER 65534:65534

--- a/image/scanner/rhel/Dockerfile
+++ b/image/scanner/rhel/Dockerfile
@@ -44,6 +44,9 @@ ENV REPO_TO_CPE_DIR="/repo2cpe"
 COPY --chown=65534:65534 --from=extracted_bundle "/bundle${REPO_TO_CPE_DIR}/" ".${REPO_TO_CPE_DIR}/"
 COPY --from=extracted_bundle /bundle/genesis_manifests.json ./
 
+# This is equivalent to nobody:nobody. This remains unnamed, \
+# as the pod's security context sets `runAsNonRoot: true`,
+# and the Kubelet does not recognize named users.
 USER 65534:65534
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Let the kubelet validate the image does not run as UID 0 (root). Putting this in the pod's security context means it applies to all containers in the pod (anything in a specific container's security context will take precedence).

By adding this, we cannot use named user/group for the `USER` field in the Dockerfiles, so this also reverts `USER postgres:postgres` back to `USER 70:70`

Also move the `runAsGroup` and `runAsUser` to the pod-level, as the two containers have the same security context, otherwise.