### PR TITLE
use https instead of ssh for git

### DIFF
--- a/pkg/vulnloader/k8sloader/loader.go
+++ b/pkg/vulnloader/k8sloader/loader.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	k8sCVEsRepository = "https://github.com:stackrox/k8s-cves.git"
+	k8sCVEsRepository = "https://github.com/stackrox/k8s-cves.git"
 	k8sCVEsRefName    = "refs/heads/main"
 )
 

--- a/pkg/vulnloader/k8sloader/loader.go
+++ b/pkg/vulnloader/k8sloader/loader.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	k8sCVEsRepository = "git@github.com:stackrox/k8s-cves.git"
+	k8sCVEsRepository = "https://github.com:stackrox/k8s-cves.git"
 	k8sCVEsRefName    = "refs/heads/main"
 )
 

--- a/pkg/vulnloader/nvdloader/enricher.go
+++ b/pkg/vulnloader/nvdloader/enricher.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	nvdEnricherRepo = "https://github.com:stackrox/dotnet-scraper.git"
+	nvdEnricherRepo = "https://github.com/stackrox/dotnet-scraper.git"
 )
 
 // FileFormatWrapper is a wrapper around .NET vulnerability file.

--- a/pkg/vulnloader/nvdloader/enricher.go
+++ b/pkg/vulnloader/nvdloader/enricher.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	nvdEnricherRepo = "git@github.com:stackrox/dotnet-scraper.git"
+	nvdEnricherRepo = "https://github.com:stackrox/dotnet-scraper.git"
 )
 
 // FileFormatWrapper is a wrapper around .NET vulnerability file.


### PR DESCRIPTION
OSCI does not forward `SSH_AUTH_SOCK`, so I don't think we can use ssh creds anymore for this. Good news: these repos are open sourced, so we don't really need creds! So, let's switch to HTTPS auth instead