### PR TITLE
Remove need for service account for StackRox GCP vuln source

### DIFF
--- a/ext/vulnsrc/stackrox/stackrox.go
+++ b/ext/vulnsrc/stackrox/stackrox.go
@@ -4,7 +4,6 @@ package stackrox
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"time"
 
 	googleStorage "cloud.google.com/go/storage"
@@ -13,7 +12,6 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/vulnsrc"
 	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 )
 
 const (
@@ -62,15 +60,10 @@ func (u *updater) downloadFeed(objectHandle *googleStorage.ObjectHandle) ([]data
 	return vulnerabilities, nil
 }
 
-func (u *updater) Update(datastore vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {
+func (u *updater) Update(_ vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {
 	log.WithField("package", "Stackrox").Info("Start fetching vulnerabilities")
 
-	serviceAccount := os.Getenv("GOOGLE_SA_CIRCLECI_SCANNER")
-	if serviceAccount == "" {
-		return resp, errors.New("StackRox updater cannot be run without a service account")
-	}
-
-	client, err := googleStorage.NewClient(context.Background(), option.WithCredentialsJSON([]byte(serviceAccount)))
+	client, err := googleStorage.NewClient(context.Background())
 	if err != nil {
 		return resp, errors.Wrap(err, "could not create GCS client")
 	}

--- a/ext/vulnsrc/stackrox/stackrox.go
+++ b/ext/vulnsrc/stackrox/stackrox.go
@@ -62,9 +62,9 @@ func (u *updater) downloadFeed(objectHandle *googleStorage.ObjectHandle) ([]data
 }
 
 func (u *updater) Update(_ vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {
-	log.WithField("package", "Stackrox").Info("Start fetching vulnerabilities")
+	log.WithField("package", "StackRox").Info("Start fetching vulnerabilities")
 
-	client, err := googleStorage.NewClient(context.Background(), option.WithoutAuthentication())
+	client, err := googleStorage.NewClient(context.Background(), option.WithoutAuthentication(), option.WithScopes(googleStorage.ScopeReadOnly))
 	if err != nil {
 		return resp, errors.Wrap(err, "could not create GCS client")
 	}

--- a/ext/vulnsrc/stackrox/stackrox.go
+++ b/ext/vulnsrc/stackrox/stackrox.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/vulnsrc"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -63,7 +64,7 @@ func (u *updater) downloadFeed(objectHandle *googleStorage.ObjectHandle) ([]data
 func (u *updater) Update(_ vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err error) {
 	log.WithField("package", "Stackrox").Info("Start fetching vulnerabilities")
 
-	client, err := googleStorage.NewClient(context.Background())
+	client, err := googleStorage.NewClient(context.Background(), option.WithoutAuthentication())
 	if err != nil {
 		return resp, errors.Wrap(err, "could not create GCS client")
 	}


### PR DESCRIPTION
This is now publicly available, so no need to have special permissions to access it.