### PR TITLE
Support stale Debian 9 vulns

### DIFF
--- a/ext/vulnsrc/stackrox/stackrox.go
+++ b/ext/vulnsrc/stackrox/stackrox.go
@@ -68,22 +68,24 @@ func (u *updater) Update(_ vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, err 
 	if err != nil {
 		return resp, errors.Wrap(err, "could not create GCS client")
 	}
-	bucketHandle := client.Bucket(bucketName)
-	feeds, err := u.listAllFeeds(bucketHandle)
-	if err != nil {
-		return resp, err
-	}
-
-	var vulnerabilities []database.Vulnerability
-	for _, feed := range feeds {
-		feedVulns, err := u.downloadFeed(bucketHandle.Object(feed))
+	for _, bucket := range []string{bucketName, "scanner-stackrox-feed-test-debian9"} {
+		bucketHandle := client.Bucket(bucket)
+		feeds, err := u.listAllFeeds(bucketHandle)
 		if err != nil {
 			return resp, err
 		}
-		vulnerabilities = append(vulnerabilities, feedVulns...)
-	}
 
-	resp.Vulnerabilities = vulnerabilities
+		var vulnerabilities []database.Vulnerability
+		for _, feed := range feeds {
+			feedVulns, err := u.downloadFeed(bucketHandle.Object(feed))
+			if err != nil {
+				return resp, err
+			}
+			vulnerabilities = append(vulnerabilities, feedVulns...)
+		}
+
+		resp.Vulnerabilities = vulnerabilities
+	}
 	return
 }
 

--- a/ext/vulnsrc/stackrox/stackrox.go
+++ b/ext/vulnsrc/stackrox/stackrox.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	bucketName = "scanner-stackrox-feed-test-debian9"
+	bucketName = "stackrox-scanner-feed"
 
 	requestTimeout = 1 * time.Minute
 )

--- a/pkg/wellknownnamespaces/set.go
+++ b/pkg/wellknownnamespaces/set.go
@@ -6,6 +6,7 @@ var (
 	// KnownStaleNamespaces is the set of base namespaces we know have stale vulnerabilities.
 	KnownStaleNamespaces = set.NewFrozenStringSet(
 		"debian:8",
+		"debian:9",
 		"ubuntu:12.04",
 		"ubuntu:12.10",
 		"ubuntu:13.04",
@@ -49,7 +50,6 @@ var (
 		"centos:6",
 		"centos:7",
 		"centos:8",
-		"debian:9",
 		"debian:10",
 		"debian:11",
 		"debian:unstable",


### PR DESCRIPTION
Debian 9 has reached EOL, which means Debian maintainers deleted all traces of it from the security tracker. Since we are not deprecating support yet, we stored the latest Debian 9 vulns in a GCP bucket like we did for Debian 8.

This PR adds support for reading from the Debian 9 vulns bucket and also adds the proper scan note