### PR TITLE
stop pushing to stackrox.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ commands:
           name: Push images
           command: |
             source scripts/ci/lib.sh
-            push_images "${CIRCLE_TAG:-}"
+            push_images
 
   run-e2e-tests:
     parameters:
@@ -1046,7 +1046,6 @@ workflows:
       - build:
           <<: *runOnAllTags
           context:
-            - stackrox-io-push
             - quay-rhacs-eng-readwrite
             - quay-rhacs-eng-readonly
             - quay-stackrox-io-readwrite
@@ -1123,7 +1122,6 @@ workflows:
     - build:
         <<: *runOnAllTags
         context:
-          - stackrox-io-push
           - quay-rhacs-eng-readonly
           - quay-rhacs-eng-readwrite
           - quay-stackrox-io-readwrite

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -32,10 +32,6 @@ ci_export() {
 push_images() {
     info "Pushing images"
 
-    if [[ "$#" -ne 1 ]]; then
-        die "missing arg. usage: push_images <ci_tag>"
-    fi
-
     require_environment "QUAY_RHACS_ENG_RW_USERNAME"
     require_environment "QUAY_RHACS_ENG_RW_PASSWORD"
     require_environment "QUAY_STACKROX_IO_RW_USERNAME"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -41,7 +41,6 @@ push_images() {
     require_environment "QUAY_STACKROX_IO_RW_USERNAME"
     require_environment "QUAY_STACKROX_IO_RW_PASSWORD"
 
-    local ci_tag="$1"
     local tag
     tag="$(make --quiet --no-print-directory tag)"
     local image_set=("scanner" "scanner-db" "scanner-slim" "scanner-db-slim")
@@ -77,15 +76,6 @@ push_images() {
     docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" --password-stdin <<<"$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
     _tag_image_set "quay.io/stackrox-io" "$tag"
     _push_image_set "quay.io/stackrox-io" "$tag"
-
-    if [[ -n "$ci_tag" ]]; then
-        require_environment "STACKROX_IO_PUSH_USERNAME"
-        require_environment "STACKROX_IO_PUSH_PASSWORD"
-        docker login -u "$STACKROX_IO_PUSH_USERNAME" --password-stdin <<<"$STACKROX_IO_PUSH_PASSWORD" stackrox.io
-
-        _tag_image_set "stackrox.io" "$tag"
-        _push_image_set "stackrox.io" "$tag"
-    fi
 }
 
 poll_for_system_test_images() {


### PR DESCRIPTION
This registry is no longer used, so let's stop pushing to it.