### PR TITLE
Remove diff-dump create/upload from build steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1093,21 +1093,10 @@ workflows:
         <<: *runOnAllTagsWithQuayPullCtx
         requires:
           - generate-genesis-dump
-    - create-diff-dumps:
-        <<: *runOnAllTagsWithQuayPullCtx
-        requires:
-          - generate-genesis-dump
     - upload-dumps-for-embedding-into-image:
         <<: *runOnAllTagsWithQuayPullCtx
         requires:
           - generate-genesis-dump
-    - upload-diff-dumps-and-offline-dumps:
-        <<: *runOnAllTags
-        context:
-          - quay-rhacs-eng-readonly
-          - scanner-support
-        requires:
-          - create-diff-dumps
     - upload-dumps-for-downstream-builds:
         <<: *runOnAllTagsWithQuayPullCtx
         requires:


### PR DESCRIPTION
This is now done on OpenShift CI, so there is no need to do this here anymore. Keeping this, will cause us to upload the diffs twice per commit/merge to master.

**Note**: I'm keeping the job definitions because I have yet to migrate the hourly job to OpenShift CI, so we will still need to keep this in CircleCI for the hourly and nightly runs.