### PR TITLE
Allow configuration re-application

### DIFF
--- a/scripts/ci/gcp.sh
+++ b/scripts/ci/gcp.sh
@@ -24,10 +24,6 @@ setup_gcp() {
 
     require_executable "gcloud"
 
-    if [[ "$(gcloud config get-value core/project 2>/dev/null)" == "stackrox-ci" ]]; then
-        echo "Current project is already set to stackrox-ci. Assuming configuration already applied."
-        return
-    fi
     gcloud auth activate-service-account --key-file <(echo "$service_account")
     gcloud auth list
     gcloud config set project stackrox-ci


### PR DESCRIPTION
This is necessary when we want to log into different accounts within the same run