### PR TITLE
Remove CCI unit-tests, style-checks, and db-integration-tests from build steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1113,12 +1113,6 @@ workflows:
         requires:
           - create-postgres-dump-from-genesis-dump
           - upload-dumps-for-embedding-into-image
-    - unit-tests:
-        <<: *runOnAllTagsWithQuayPullCtx
-    - style-checks:
-        <<: *runOnAllTagsWithQuayPullCtx
-    - db-integration-tests:
-        <<: *runOnAllTagsWithQuayPullCtx
     - build:
         <<: *runOnAllTags
         context:


### PR DESCRIPTION
CCI unit-tests and style-checks are no longer required, either. Instead, the prow versions are.

Not deleting yet because the hourly versions have yet to migrate