### PR TITLE
update hub comment

### DIFF
--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -44,7 +44,7 @@ comment_on_pr() {
     cat > "$tmpfile" <<- EOT
 Images are ready for the commit at {{.Env._SHA}}.
 
-To use with deploy scripts, first \`export MAIN_IMAGE_TAG={{.Env._TAG}}\`.
+To use the images, use the tag \`{{.Env._TAG}}\`.
 EOT
 
     hub-comment -type build -template-file "$tmpfile"


### PR DESCRIPTION
Blindly copying from the stackrox repo means we get the same comment, which doesn't make sense for Scanner. Updating it here