### PR TITLE
Bump Scanner to UBI9

### DIFF
--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -10,4 +10,4 @@
 # - `make update` and commit the results
 # - run `/test pj-rehearse-max` on the openshift/release PR to validate the change
 
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.43
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.45

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-scanner-build-0.3.43
+scanner-build-0.3.45

--- a/image/scanner/rhel/Dockerfile
+++ b/image/scanner/rhel/Dockerfile
@@ -1,12 +1,12 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
-ARG BASE_IMAGE=ubi8-minimal
-ARG BASE_TAG=8.6
+ARG BASE_IMAGE=ubi9-minimal
+ARG BASE_TAG=9.0.0
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 
 COPY bundle.tar.gz /
 WORKDIR /bundle
-RUN microdnf install tar gzip && tar -zxf /bundle.tar.gz
+RUN microdnf -y install tar gzip && tar -zxf /bundle.tar.gz
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS base
 
@@ -24,9 +24,9 @@ COPY --from=extracted_bundle /bundle/scanner ./
 
 COPY --from=extracted_bundle /bundle/THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 
-RUN microdnf upgrade && \
-    microdnf install xz && \
-    microdnf clean all && \
+RUN microdnf -y upgrade && \
+    microdnf -y install xz && \
+    microdnf -y clean all && \
     # (Optional) Remove line below to keep package management utilities
     # We don't uninstall rpm because scanner uses it to get packages installed in scanned images.
     rpm -e --nodeps $(rpm -qa curl '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \

--- a/image/scanner/rhel/Dockerfile.slim
+++ b/image/scanner/rhel/Dockerfile.slim
@@ -1,12 +1,12 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
-ARG BASE_IMAGE=ubi8-minimal
-ARG BASE_TAG=8.6
+ARG BASE_IMAGE=ubi9-minimal
+ARG BASE_TAG=9.0.0
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 
 COPY bundle.tar.gz /
 WORKDIR /bundle
-RUN microdnf install tar gzip && tar -zxf /bundle.tar.gz
+RUN microdnf -y install tar gzip && tar -zxf /bundle.tar.gz
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS base
 
@@ -24,9 +24,9 @@ COPY --from=extracted_bundle /bundle/scanner ./
 
 COPY --from=extracted_bundle /bundle/THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 
-RUN microdnf upgrade && \
-    microdnf install xz && \
-    microdnf clean all && \
+RUN microdnf -y upgrade && \
+    microdnf -y install xz && \
+    microdnf -y clean all && \
     # (Optional) Remove line below to keep package management utilities
     # We don't uninstall rpm because scanner uses it to get packages installed in scanned images.
     rpm -e --nodeps $(rpm -qa curl '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \

--- a/pkg/rpm/database.go
+++ b/pkg/rpm/database.go
@@ -143,6 +143,19 @@ func CreateDatabaseFromLayer(imageFiles tarutil.LayerFiles) (*rpmDatabase, error
 			return nil, commonerr.ErrFilesystem
 		}
 	}
+	// Rebuild the rpm database, it will recreate indexes and convert old formats
+	// to the latest supported by the current rpm version.
+	dbCmd := exec.Command(
+		"rpmdb",
+		"--dbpath", dbDir,
+		"--rebuilddb",
+	)
+	var errBuffer bytes.Buffer
+	dbCmd.Stderr = &errBuffer
+	if err := dbCmd.Run(); err != nil {
+		logrus.Warnf("failed to rebuild the rpm database: %s", errBuffer.String())
+		return nil, errors.Wrap(err, "failed to rebuild rpm database")
+	}
 	return &rpmDatabase{
 		dbPath: dbDir,
 	}, nil


### PR DESCRIPTION
## Description

1. Bump Scanner and Scanner Slim image to UBI9.
1. Re-build the rpm database when analyzing rpm packages.

The goal of (1.) is to get `rpm >= 4.16` to support RHEL9 scanning. The goal of (2.) is to ensure the rpm database format in the image is migrated to the latest to avoid issues with compatibility between the Scanner's rpm and the images'. In particular, Scanner's rpm (UBI9) only has `bdb_ro` mode enabled, [which doesn't support querying indexes in BDB-based databases](https://github.com/rpm-software-management/rpm/pull/1578).

## Tests

- Local deployment (`make deploy`) followed by E2E tests.
- OCI Rehearsal: https://github.com/openshift/release/pull/31088
- CI