### PR TITLE
Check for ELF executables and scripts that start with shebang

### DIFF
--- a/ext/featurefmt/driver.go
+++ b/ext/featurefmt/driver.go
@@ -139,10 +139,14 @@ func TestLister(t *testing.T, l Lister, testData []TestData) {
 func AddToDependencyMap(filename string, fileData tarutil.FileData, execToDeps, libToDeps database.StringToStringsMap) {
 	if fileData.Executable {
 		deps := set.NewStringSet()
-		if fileData.ELFMetadata != nil {
-			deps.AddAll(fileData.ELFMetadata.ImportedLibraries...)
+		if elfMeta := fileData.ELFMetadata; elfMeta != nil {
+			deps.AddAll(fileData.elfMeta.ImportedLibraries...)
+			if !elfMeta.SharedObject {
+				execToDeps[filename] = deps
+			}
+		} else {
+			execToDeps[filename] = deps
 		}
-		execToDeps[filename] = deps
 	}
 	if fileData.ELFMetadata != nil {
 		for _, soname := range fileData.ELFMetadata.Sonames {

--- a/ext/featurefmt/driver.go
+++ b/ext/featurefmt/driver.go
@@ -140,7 +140,7 @@ func AddToDependencyMap(filename string, fileData tarutil.FileData, execToDeps, 
 	if fileData.Executable {
 		deps := set.NewStringSet()
 		if elfMeta := fileData.ELFMetadata; elfMeta != nil {
-			deps.AddAll(fileData.elfMeta.ImportedLibraries...)
+			deps.AddAll(elfMeta.ImportedLibraries...)
 			if !elfMeta.SharedObject {
 				execToDeps[filename] = deps
 			}

--- a/ext/featurefmt/driver.go
+++ b/ext/featurefmt/driver.go
@@ -141,12 +141,8 @@ func AddToDependencyMap(filename string, fileData tarutil.FileData, execToDeps, 
 		deps := set.NewStringSet()
 		if elfMeta := fileData.ELFMetadata; elfMeta != nil {
 			deps.AddAll(elfMeta.ImportedLibraries...)
-			if !elfMeta.SharedObject {
-				execToDeps[filename] = deps
-			}
-		} else {
-			execToDeps[filename] = deps
 		}
+		execToDeps[filename] = deps
 	}
 	if fileData.ELFMetadata != nil {
 		for _, soname := range fileData.ELFMetadata.Sonames {

--- a/pkg/elf/elf.go
+++ b/pkg/elf/elf.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
+const df1PIE = 0x08000000
+
 var (
 	allowedELFTypeList = set.NewFrozenIntSet(int(elf.ET_EXEC), int(elf.ET_DYN))
 )
@@ -19,6 +21,38 @@ type Metadata struct {
 	Sonames           []string
 	ImportedLibraries []string
 	SharedObject      bool
+}
+
+func isSharedObject(elfFile *elf.File) (bool, error) {
+	if elfFile.Type != elf.ET_DYN {
+		return false, nil
+	}
+	ds := elfFile.SectionByType(elf.SHT_DYNAMIC)
+	if ds == nil {
+		return true, nil
+	}
+	d, err := ds.Data()
+	if err != nil {
+		return false, err
+	}
+	for len(d) > 0 {
+		var t elf.DynTag
+		var v uint64
+		switch elfFile.Class {
+		case elf.ELFCLASS32:
+			t = elf.DynTag(elfFile.ByteOrder.Uint32(d[0:4]))
+			v = uint64(elfFile.ByteOrder.Uint32(d[4:8]))
+			d = d[8:]
+		case elf.ELFCLASS64:
+			t = elf.DynTag(elfFile.ByteOrder.Uint64(d[0:8]))
+			v = elfFile.ByteOrder.Uint64(d[8:16])
+			d = d[16:]
+		}
+		if t == elf.DT_FLAGS_1 {
+			return v != df1PIE, nil
+		}
+	}
+	return true, nil
 }
 
 // GetExecutableMetadata extracts and returns Metadata if the input is an executable ELF binary.
@@ -39,6 +73,11 @@ func GetExecutableMetadata(r io.ReaderAt) (*Metadata, error) {
 		return nil, nil
 	}
 
+	sharedObject, err := isSharedObject(elfFile)
+	if err != nil {
+		return nil, err
+	}
+
 	sonames, err := elfFile.DynString(elf.DT_SONAME)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get sonames from ELF executable")
@@ -50,6 +89,6 @@ func GetExecutableMetadata(r io.ReaderAt) (*Metadata, error) {
 	return &Metadata{
 		Sonames:           sonames,
 		ImportedLibraries: libraries,
-		SharedObject:      elfFile.Type == elf.ET_DYN,
+		SharedObject:      sharedObject,
 	}, nil
 }

--- a/pkg/elf/elf.go
+++ b/pkg/elf/elf.go
@@ -35,7 +35,7 @@ func GetExecutableMetadata(r io.ReaderAt) (*Metadata, error) {
 	defer utils.IgnoreError(elfFile.Close)
 
 	// Exclude core and other unknown ELF file.
-	if !allowedELFTypeList.Contains(elfFile.Type) {
+	if !allowedELFTypeList.Contains(int(elfFile.Type)) {
 		return nil, nil
 	}
 

--- a/pkg/elf/elf.go
+++ b/pkg/elf/elf.go
@@ -49,7 +49,7 @@ func isSharedObject(elfFile *elf.File) (bool, error) {
 			d = d[16:]
 		}
 		if t == elf.DT_FLAGS_1 {
-			return v != df1PIE, nil
+			return v&df1PIE == 0, nil
 		}
 	}
 	return true, nil

--- a/pkg/elf/elf.go
+++ b/pkg/elf/elf.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
-const df1PIE = 0x08000000
-
 var (
 	allowedELFTypeList = set.NewFrozenIntSet(int(elf.ET_EXEC), int(elf.ET_DYN))
 )
@@ -20,39 +18,6 @@ type Metadata struct {
 	// Sonames contains provided sonames for shared objects
 	Sonames           []string
 	ImportedLibraries []string
-	SharedObject      bool
-}
-
-func isSharedObject(elfFile *elf.File) (bool, error) {
-	if elfFile.Type != elf.ET_DYN {
-		return false, nil
-	}
-	ds := elfFile.SectionByType(elf.SHT_DYNAMIC)
-	if ds == nil {
-		return true, nil
-	}
-	d, err := ds.Data()
-	if err != nil {
-		return false, err
-	}
-	for len(d) > 0 {
-		var t elf.DynTag
-		var v uint64
-		switch elfFile.Class {
-		case elf.ELFCLASS32:
-			t = elf.DynTag(elfFile.ByteOrder.Uint32(d[0:4]))
-			v = uint64(elfFile.ByteOrder.Uint32(d[4:8]))
-			d = d[8:]
-		case elf.ELFCLASS64:
-			t = elf.DynTag(elfFile.ByteOrder.Uint64(d[0:8]))
-			v = elfFile.ByteOrder.Uint64(d[8:16])
-			d = d[16:]
-		}
-		if t == elf.DT_FLAGS_1 {
-			return v&df1PIE == 0, nil
-		}
-	}
-	return true, nil
 }
 
 // GetExecutableMetadata extracts and returns Metadata if the input is an executable ELF binary.
@@ -73,11 +38,6 @@ func GetExecutableMetadata(r io.ReaderAt) (*Metadata, error) {
 		return nil, nil
 	}
 
-	sharedObject, err := isSharedObject(elfFile)
-	if err != nil {
-		return nil, err
-	}
-
 	sonames, err := elfFile.DynString(elf.DT_SONAME)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get sonames from ELF executable")
@@ -89,6 +49,5 @@ func GetExecutableMetadata(r io.ReaderAt) (*Metadata, error) {
 	return &Metadata{
 		Sonames:           sonames,
 		ImportedLibraries: libraries,
-		SharedObject:      sharedObject,
 	}, nil
 }

--- a/pkg/elf/elf.go
+++ b/pkg/elf/elf.go
@@ -18,6 +18,7 @@ type Metadata struct {
 	// Sonames contains provided sonames for shared objects
 	Sonames           []string
 	ImportedLibraries []string
+	SharedObject      bool
 }
 
 // GetExecutableMetadata extracts and returns Metadata if the input is an executable ELF binary.
@@ -34,7 +35,7 @@ func GetExecutableMetadata(r io.ReaderAt) (*Metadata, error) {
 	defer utils.IgnoreError(elfFile.Close)
 
 	// Exclude core and other unknown ELF file.
-	if !allowedELFTypeList.Contains(int(elfFile.Type)) {
+	if !allowedELFTypeList.Contains(elfFile.Type) {
 		return nil, nil
 	}
 
@@ -49,5 +50,6 @@ func GetExecutableMetadata(r io.ReaderAt) (*Metadata, error) {
 	return &Metadata{
 		Sonames:           sonames,
 		ImportedLibraries: libraries,
+		SharedObject:      elfFile.Type == elf.ET_DYN,
 	}, nil
 }

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -60,11 +60,12 @@ var (
 	// limit is backed by temporary files on disk.
 	maxLazyReaderBufferSize int64 = DefaultMaxLazyReaderBufferSizeMB * 1024 * 1024
 
-	readLen       = 6 // max bytes to sniff
-	gzipHeader    = []byte{0x1f, 0x8b}
-	bzip2Header   = []byte{0x42, 0x5a, 0x68}
-	xzHeader      = []byte{0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00}
-	shebangHeader = []byte{0x23, 0x21}
+	readLen           = 6 // max bytes to sniff
+	gzipHeader        = []byte{0x1f, 0x8b}
+	bzip2Header       = []byte{0x42, 0x5a, 0x68}
+	xzHeader          = []byte{0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00}
+	shebangHeader     = []byte{0x23, 0x21}
+	shebangHeaderSize = len(shebangHeader)
 )
 
 // SetMaxExtractableFileSize sets the max extractable file size.
@@ -176,8 +177,8 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 					}
 				}
 				if executable && fileData.ELFMetadata == nil {
-					shebangBytes := make([]byte, 2)
-					if hdr.Size > 2 {
+					shebangBytes := make([]byte, shebangHeaderSize)
+					if hdr.Size > int64(shebangHeaderSize) {
 						_, err := contents.ReadAt(shebangBytes, 0)
 						if err != nil {
 							log.Errorf("unable to read first two bytes of file %s: %v", filename, err)

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -166,10 +166,6 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 			var fileData FileData
 
 			executable, _ := executableMatcher.Match(filename, hdr.FileInfo(), contents)
-			if executable {
-
-			}
-
 			if hdr.Size > maxELFExecutableFileSize {
 				log.Warnf("Skipping ELF executable check for file %q (%d bytes) because it is larger than the configured maxELFExecutableFileSizeMB of %d", filename, hdr.Size, maxELFExecutableFileSize/1024/1024)
 			} else {

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -167,26 +167,28 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 
 			executable, _ := executableMatcher.Match(filename, hdr.FileInfo(), contents)
 			if executable {
-				if hdr.Size > maxELFExecutableFileSize {
-					log.Warnf("Skipping ELF executable check for file %q (%d bytes) because it is larger than the configured maxELFExecutableFileSizeMB of %d", filename, hdr.Size, maxELFExecutableFileSize/1024/1024)
-				} else {
-					if hdr.Size >= elfHeaderSize { // Only bother attempting to get ELF metadata if the file is large enough for the ELF header.
-						fileData.ELFMetadata, err = elf.GetExecutableMetadata(contents)
+
+			}
+
+			if hdr.Size > maxELFExecutableFileSize {
+				log.Warnf("Skipping ELF executable check for file %q (%d bytes) because it is larger than the configured maxELFExecutableFileSizeMB of %d", filename, hdr.Size, maxELFExecutableFileSize/1024/1024)
+			} else {
+				if hdr.Size >= elfHeaderSize { // Only bother attempting to get ELF metadata if the file is large enough for the ELF header.
+					fileData.ELFMetadata, err = elf.GetExecutableMetadata(contents)
+					if err != nil {
+						log.Errorf("Failed to get dependencies for %s: %v", filename, err)
+					}
+				}
+				if executable && fileData.ELFMetadata == nil {
+					shebangBytes := make([]byte, 2)
+					if hdr.Size > 2 {
+						_, err := contents.ReadAt(shebangBytes, 0)
 						if err != nil {
-							log.Errorf("Failed to get dependencies for %s: %v", filename, err)
+							log.Errorf("unable to read first two bytes of file %s: %v", filename, err)
+							continue
 						}
 					}
-					if fileData.ELFMetadata != nil {
-						shebangBytes := make([]byte, 2)
-						if hdr.Size > 2 {
-							_, err := contents.ReadAt(shebangBytes, 0)
-							if err != nil {
-								log.Errorf("unable to read first two bytes of file %s: %v", filename, err)
-								continue
-							}
-						}
-						executable = bytes.Equal(shebangBytes, shebangHeader)
-					}
+					executable = bytes.Equal(shebangBytes, shebangHeader)
 				}
 			}
 

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -169,24 +169,23 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 			executable, _ := executableMatcher.Match(filename, hdr.FileInfo(), contents)
 			if hdr.Size > maxELFExecutableFileSize {
 				log.Warnf("Skipping ELF executable check for file %q (%d bytes) because it is larger than the configured maxELFExecutableFileSizeMB of %d", filename, hdr.Size, maxELFExecutableFileSize/1024/1024)
-			} else {
-				if hdr.Size >= elfHeaderSize { // Only bother attempting to get ELF metadata if the file is large enough for the ELF header.
-					fileData.ELFMetadata, err = elf.GetExecutableMetadata(contents)
+			} else if hdr.Size >= elfHeaderSize { // Only bother attempting to get ELF metadata if the file is large enough for the ELF header.
+				fileData.ELFMetadata, err = elf.GetExecutableMetadata(contents)
+				if err != nil {
+					log.Errorf("Failed to get dependencies for %s: %v", filename, err)
+				}
+			} else if executable && hdr.Typeflag != tar.TypeLink && fileData.ELFMetadata == nil {
+				// If the type is a hard link then we will not be able to read it.
+				// Keep it as an executable in order to not introduce false negatives.
+				shebangBytes := make([]byte, shebangHeaderSize)
+				if hdr.Size > int64(shebangHeaderSize) {
+					_, err := contents.ReadAt(shebangBytes, 0)
 					if err != nil {
-						log.Errorf("Failed to get dependencies for %s: %v", filename, err)
+						log.Errorf("unable to read first two bytes of file %s: %v", filename, err)
+						continue
 					}
 				}
-				if executable && fileData.ELFMetadata == nil {
-					shebangBytes := make([]byte, shebangHeaderSize)
-					if hdr.Size > int64(shebangHeaderSize) {
-						_, err := contents.ReadAt(shebangBytes, 0)
-						if err != nil {
-							log.Errorf("unable to read first two bytes of file %s: %v", filename, err)
-							continue
-						}
-					}
-					executable = bytes.Equal(shebangBytes, shebangHeader)
-				}
+				executable = bytes.Equal(shebangBytes, shebangHeader)
 			}
 
 			if extractContents {

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -169,23 +169,26 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 			executable, _ := executableMatcher.Match(filename, hdr.FileInfo(), contents)
 			if hdr.Size > maxELFExecutableFileSize {
 				log.Warnf("Skipping ELF executable check for file %q (%d bytes) because it is larger than the configured maxELFExecutableFileSizeMB of %d", filename, hdr.Size, maxELFExecutableFileSize/1024/1024)
-			} else if hdr.Size >= elfHeaderSize { // Only bother attempting to get ELF metadata if the file is large enough for the ELF header.
-				fileData.ELFMetadata, err = elf.GetExecutableMetadata(contents)
-				if err != nil {
-					log.Errorf("Failed to get dependencies for %s: %v", filename, err)
-				}
-			} else if executable && hdr.Typeflag != tar.TypeLink && fileData.ELFMetadata == nil {
-				// If the type is a hard link then we will not be able to read it.
-				// Keep it as an executable in order to not introduce false negatives.
-				shebangBytes := make([]byte, shebangHeaderSize)
-				if hdr.Size > int64(shebangHeaderSize) {
-					_, err := contents.ReadAt(shebangBytes, 0)
+			} else {
+				if hdr.Size >= elfHeaderSize { // Only bother attempting to get ELF metadata if the file is large enough for the ELF header.
+					fileData.ELFMetadata, err = elf.GetExecutableMetadata(contents)
 					if err != nil {
-						log.Errorf("unable to read first two bytes of file %s: %v", filename, err)
-						continue
+						log.Errorf("Failed to get dependencies for %s: %v", filename, err)
 					}
 				}
-				executable = bytes.Equal(shebangBytes, shebangHeader)
+				if executable && hdr.Typeflag != tar.TypeLink && fileData.ELFMetadata == nil {
+					// If the type is a hard link then we will not be able to read it.
+					// Keep it as an executable in order to not introduce false negatives.
+					shebangBytes := make([]byte, shebangHeaderSize)
+					if hdr.Size > int64(shebangHeaderSize) {
+						_, err := contents.ReadAt(shebangBytes, 0)
+						if err != nil {
+							log.Errorf("unable to read first two bytes of file %s: %v", filename, err)
+							continue
+						}
+					}
+					executable = bytes.Equal(shebangBytes, shebangHeader)
+				}
 			}
 
 			if extractContents {


### PR DESCRIPTION
gitlab EE image returned 6500 paths

Now it returns 1300 paths including .so's

TBD if we can remove .so from the path