### PR TITLE
add pipefail to tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,26 +252,31 @@ test-prep:
 .PHONY: unit-tests
 unit-tests: deps test-prep
 	@echo "+ $@"
+	set -o pipefail ; \
 	go test -race -v ./... | tee test-output/test.log
 
 .PHONY: e2e-tests
 e2e-tests: deps test-prep
 	@echo "+ $@"
+	set -o pipefail ; \
 	go test -tags e2e -count=1 -timeout=20m -v ./e2etests/... | tee test-output/test.log
 
 .PHONY: slim-e2e-tests
 slim-e2e-tests: deps test-prep
 	@echo "+ $@"
+	set -o pipefail ; \
 	go test -tags slim_e2e -count=1 -timeout=20m -v ./e2etests/... | tee test-output/test.log
 
 .PHONY: db-integration-tests
 db-integration-tests: deps test-prep
 	@echo "+ $@"
+	set -o pipefail ; \
 	go test -tags db_integration -count=1 -v ./database/pgsql | tee test-output/test.log
 
 .PHONY: slim-db-integration-tests
 slim-db-integration-tests: deps test-prep
 	@echo "+ $@"
+	set -o pipefail ; \
 	go test -tags slim_db_integration -count=1 -v ./database/pgsql | tee test-output/test.log
 
 .PHONY: scale-tests


### PR DESCRIPTION
Introducing the `| tee whatever` meant the exit code would be `0` because the `tee` succeeded. Add `set -o pipefail` to ensure the exist code is returned properly