### PR TITLE
Print the tag CI pushes

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -93,6 +93,7 @@ push_image_set() {
 
     local tag
     tag="$(make --quiet --no-print-directory tag)"
+    info "PUSHING IMAGES WITH TAG: ${tag}"
     for registry in "${destination_registries[@]}"; do
         registry_rw_login "$registry"
 


### PR DESCRIPTION
This makes it easier to find the tag for the images for periodic runs. I think just printing is fine. No need to put this in a Slack channel or anything