### PR TITLE
Ensure Scanner binary isn't "dirty"

### DIFF
--- a/.openshift-ci/build/build-bundle.sh
+++ b/.openshift-ci/build/build-bundle.sh
@@ -49,6 +49,11 @@ get_genesis_dump() {
 }
 
 build_bundle() {
+    # avoid a -dirty tag
+    info "Reset to remove Dockerfile modification by OpenShift CI"
+    git restore .
+    git status
+
     info "Building Scanner binary"
     make scanner-build-nodeps
 


### PR DESCRIPTION
Without this, we inject `blahblah-dirty` into the Scanner binary, which means Scanner will print "Running Scanner version: blahblah-dirty", which will confuse non-devs