### PR TITLE
Enable local builds on M1 Macs with custom builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ db-image: $(CURDIR)/image/db/rhel/bundle.tar.gz
 db-image-slim: $(CURDIR)/image/db/rhel/bundle.tar.gz
 	@echo "+ $@"
 	@test -f image/db/dump/definitions.sql.gz || { echo "FATAL: No definitions dump found in image/dump/definitions.sql.gz. Exiting..."; exit 1; }
-	@docker build -t scanner-db-slim:$(TAG) -f image/db/rhel/Dockerfile.slim image/db/rhel
+	@docker build -t scanner-db-slim:$(TAG) --build-arg POSTGRESQL_ARCH=${ARCH} -f image/db/rhel/Dockerfile.slim image/db/rhel
 
 .PHONY: deploy
 deploy: clean-helm-rendered

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,20 @@ DEFAULT_IMAGE_REGISTRY := quay.io/stackrox-io
 BUILD_IMAGE_VERSION=$(shell sed 's/\s*\#.*//' BUILD_IMAGE_VERSION)
 BUILD_IMAGE := $(DEFAULT_IMAGE_REGISTRY)/apollo-ci:$(BUILD_IMAGE_VERSION)
 
+ifeq ($(shell uname -ms),Darwin arm64)
+	# TODO(ROX-12064) build these images in the CI pipeline
+	BUILD_IMAGE = quay.io/rhacs-eng/sandbox:apollo-ci-scanner-build-0.3.44-arm64
+	ARCH := aarch64
+	GOARCH := arm64
+else
+	ARCH := x86_64
+	GOARCH := amd64
+endif
+
 LOCAL_VOLUME_ARGS := -v$(CURDIR):/src:delegated -v $(GOPATH):/go:delegated
 GOPATH_WD_OVERRIDES := -w /src -e GOPATH=/go
-IMAGE_BUILD_FLAGS := -e CGO_ENABLED=1,GOOS=linux,GOARCH=amd64
-BUILD_FLAGS := CGO_ENABLED=1 GOOS=linux GOARCH=amd64
+IMAGE_BUILD_FLAGS := -e CGO_ENABLED=1,GOOS=linux,GOARCH=${GOARCH}
+BUILD_FLAGS := CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH}
 BUILD_CMD := go build -trimpath -ldflags="-linkmode=external -X github.com/stackrox/scanner/pkg/version.Version=$(TAG)" -o image/scanner/bin/scanner ./cmd/clair
 
 #####################################################################
@@ -205,7 +215,7 @@ scanner-image-slim: scanner-build-dockerized ossls-notice $(CURDIR)/image/scanne
 db-image: $(CURDIR)/image/db/rhel/bundle.tar.gz
 	@echo "+ $@"
 	@test -f image/db/dump/definitions.sql.gz || { echo "FATAL: No definitions dump found in image/dump/definitions.sql.gz. Exiting..."; exit 1; }
-	@docker build -t scanner-db:$(TAG) -f image/db/rhel/Dockerfile image/db/rhel
+	@docker build -t scanner-db:$(TAG) --build-arg POSTGRESQL_ARCH=${ARCH} -f image/db/rhel/Dockerfile image/db/rhel
 
 .PHONY: db-image-slim
 db-image-slim: $(CURDIR)/image/db/rhel/bundle.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ deploy-local: clean-helm-rendered
 	kubectl apply -R -f rendered-chart
 
 .PHONY: ossls-notice
-ossls-notice: deps
+ossls-notice: deps $(OSSLS_BIN)
 	ossls version
 	ossls audit --export image/scanner/rhel/THIRD_PARTY_NOTICES
 

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -23,12 +23,14 @@ ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/" \
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 COPY --from=extracted_bundle /bundle/etc/postgresql.conf /bundle/etc/pg_hba.conf /etc/
 
+ARG POSTGRESQL_ARCH=aarch64
+
 RUN groupadd -g 70 postgres && \
     adduser postgres -u 70 -g 70 -d /var/lib/postgresql -s /bin/sh && \
     dnf upgrade -y && \
     dnf install -y \
         ca-certificates libicu systemd-sysv glibc-locale-source glibc-langpack-en \
-        https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm && \
+        https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${POSTGRESQL_ARCH}/pgdg-redhat-repo-latest.noarch.rpm && \
     dnf install -y postgresql12-server && \
     dnf clean all && \
     rpm -e --nodeps $(rpm -qa 'pgdg-redhat-repo*') && \

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -23,7 +23,7 @@ ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/" \
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 COPY --from=extracted_bundle /bundle/etc/postgresql.conf /bundle/etc/pg_hba.conf /etc/
 
-ARG POSTGRESQL_ARCH=aarch64
+ARG POSTGRESQL_ARCH=x86_64
 
 RUN groupadd -g 70 postgres && \
     adduser postgres -u 70 -g 70 -d /var/lib/postgresql -s /bin/sh && \

--- a/image/db/rhel/Dockerfile.slim
+++ b/image/db/rhel/Dockerfile.slim
@@ -23,12 +23,14 @@ ENV PATH="$PATH:/usr/pgsql-$PG_MAJOR/bin/" \
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 COPY --from=extracted_bundle /bundle/etc/postgresql.conf /bundle/etc/pg_hba.conf /etc/
 
+ARG POSTGRESQL_ARCH=x86_64
+
 RUN groupadd -g 70 postgres && \
     adduser postgres -u 70 -g 70 -d /var/lib/postgresql -s /bin/sh && \
     dnf upgrade -y && \
     dnf install -y \
         ca-certificates libicu systemd-sysv glibc-locale-source glibc-langpack-en \
-        https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm && \
+        https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${POSTGRESQL_ARCH}/pgdg-redhat-repo-latest.noarch.rpm && \
     dnf install -y postgresql12-server && \
     dnf clean all && \
     rpm -e --nodeps $(rpm -qa 'pgdg-redhat-repo*') && \

--- a/image/db/rhel/create-bundle.sh
+++ b/image/db/rhel/create-bundle.sh
@@ -40,11 +40,11 @@ cp -p "${INPUT_ROOT}"/*.conf "${bundle_root}/etc/"
 if tar --version | grep -q "gnu" ; then
   tar_chown_args=("--owner=root:0" "--group=root:0")
 else
-  tar_chown_args=("--uid=root:0" "--gid=root:0")
+  tar_chown_args=("--uid=0" "--uname=root" "--gid=0" "--gname=root")
 fi
 
 # Create output bundle of all files in $bundle_root
-tar cz "${tar_chown_args[@]}" --file "$OUTPUT_BUNDLE" --directory "${bundle_root}" .
+tar cz --file "$OUTPUT_BUNDLE" --directory "${bundle_root}" .
 
 # Create checksum
 sha512sum "${OUTPUT_BUNDLE}" > "${OUTPUT_BUNDLE}.sha512"

--- a/image/scanner/rhel/create-bundle.sh
+++ b/image/scanner/rhel/create-bundle.sh
@@ -59,7 +59,7 @@ cp -pr "${INPUT_ROOT}/rhel/THIRD_PARTY_NOTICES"           "${bundle_root}/"
 if tar --version | grep -q "gnu" ; then
   tar_chown_args=("--owner=root:0" "--group=root:0")
 else
-  tar_chown_args=("--uid=root:0" "--gid=root:0")
+  tar_chown_args=("--uid=0" "--uname=root" "--gid=0" "--gname=root")
 fi
 
 # Create output bundle of all files in $bundle_root


### PR DESCRIPTION
To test this, run `make image` on your MacBook with Apple silicon, and set the `SCANNER_IMAGE` and `SCANNER_DB_IMAGE` env variables to match the images built by `make`.

Then run `./deploy/k8s/deploy-local.sh` and check that scanner and scanner-db are running.

As a prerequisite, the main image has to be built locally as well, because we do not yet have arm64 images in the repository.

