### PR TITLE
Fix vulnerability and package relationship for RHEL

### DIFF
--- a/database/pgsql/migrations/00010_rhelv2_vulns.go
+++ b/database/pgsql/migrations/00010_rhelv2_vulns.go
@@ -35,6 +35,7 @@ func init() {
 		CREATE TABLE IF NOT EXISTS vuln_package (
 			id               BIGSERIAL PRIMARY KEY,
 			hash             BYTEA NOT NULL,
+			vuln_hash        BYTEA NOT NULL,
 			name             TEXT,
 			package_name     TEXT,
 			package_module   TEXT,

--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -223,16 +223,16 @@ const (
 	insertRHELv2VulnPackage = `
 		INSERT INTO vuln_package (
 			hash,
-			name,
+			vuln_hash, name,
 			package_name, package_module, package_arch,
 			cpe,
 			fixed_in_version, arch_operation
 		) VALUES (
 			$1,
-			$2,
-			$3, $4, $5,
-			$6,
-			$7, $8
+			$2, $3,
+			$4, $5, $6,
+			$7,
+			$8, $9
 		)
 		ON CONFLICT (hash) DO NOTHING;`
 
@@ -255,7 +255,7 @@ const (
 		FROM
 			vuln_package
 			LEFT JOIN vuln ON
-				vuln_package.name = vuln.name
+				vuln_package.vuln_hash = vuln.hash
 		WHERE
 			vuln_package.package_name = $1
 				AND vuln_package.package_module = $2

--- a/database/pgsql/rhelv2_vulnerability.go
+++ b/database/pgsql/rhelv2_vulnerability.go
@@ -67,10 +67,10 @@ func (pgSQL *pgSQL) insertRHELv2Vulnerability(vulnStatement, vulnPackageStatemen
 	for _, pkgInfo := range vuln.PackageInfos {
 		for _, pkg := range pkgInfo.Packages {
 			for _, cpe := range vuln.CPEs {
-				pkgHash := md5VulnPackage(vuln.Name, pkg, cpe, pkgInfo)
+				pkgHash := md5VulnPackage(vulnHash, pkg, cpe, pkgInfo)
 				_, err := vulnPackageStatement.Exec(
 					pkgHash,
-					vuln.Name,
+					vulnHash, vuln.Name,
 					pkg.Name, pkg.Module, pkg.Arch,
 					cpe,
 					pkgInfo.FixedInVersion, pkgInfo.ArchOperation,
@@ -170,9 +170,9 @@ func md5Vuln(v *database.RHELv2Vulnerability) []byte {
 
 // md5VulnPackage creates an md5 hash from the members of the given
 // arguments to represent a unique identifier for a vulnerable package.
-func md5VulnPackage(vulnName string, p *database.RHELv2Package, cpe string, pkgInfo *database.RHELv2PackageInfo) []byte {
+func md5VulnPackage(vulnHash []byte, p *database.RHELv2Package, cpe string, pkgInfo *database.RHELv2PackageInfo) []byte {
 	var b bytes.Buffer
-	b.WriteString(vulnName)
+	b.WriteString(string(vulnHash))
 	b.WriteString(p.Name)
 	b.WriteString(p.Module)
 	b.WriteString(p.Arch)

--- a/database/pgsql/rhelv2_vulnerability_test.go
+++ b/database/pgsql/rhelv2_vulnerability_test.go
@@ -3,12 +3,11 @@
 package pgsql
 
 import (
-	"testing"
-
-	"github.com/stackrox/scanner/pkg/archop"
 	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/pkg/archop"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestRHELv2Vulnerability(t *testing.T) {
@@ -186,6 +185,78 @@ func TestRHELv2Vulnerability(t *testing.T) {
 	assert.Len(t, vulns, 2)
 	assert.Len(t, vulns[0], 2)
 	assert.Len(t, vulns[1], 1)
+}
+
+func TestRHELv2Vulnerability_CVEWithMultipleSeverities(t *testing.T) {
+	datastore, err := openDatabaseForTest("TestRHELv2Vulnerability_CVEWithMultipleSeverities", false)
+	require.NoError(t, err)
+	defer datastore.Close()
+
+	v1 := &database.RHELv2Vulnerability{
+		Name: "CVE-2022-1650",
+		Description: "DOCUMENTATION: A flaw was found in the EventSource NPM Package. The description from the source states the following message: \"Exposure of Sensitive Information to an Unauthorized Actor.\" This flaw allows an attacker to steal the user's credentials and then use the credentials to access the legitimate website.",
+		Link: "https://access.redhat.com/security/cve/CVE-2022-1650",
+		Severity: "Important",
+		CVSSv3: "8.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N",
+		CPEs: []string{
+			"cpe:/a:redhat:enterprise_linux:8::appstream",
+			"cpe:/o:redhat:enterprise_linux:8::baseos",
+		},
+		PackageInfos: []*database.RHELv2PackageInfo{
+			{
+				Packages: []*database.RHELv2Package{
+					{
+						Name: "something",
+						Version: "6.0.6-1.el8_6",
+						Arch: "x86_64",
+					},
+				},
+			},
+		},
+	}
+
+	v2 := &database.RHELv2Vulnerability{
+		Name: "CVE-2022-1650",
+		Description: "DOCUMENTATION: A flaw was found in the EventSource NPM Package. The description from the source states the following message: \"Exposure of Sensitive Information to an Unauthorized Actor.\" This flaw allows an attacker to steal the user's credentials and then use the credentials to access the legitimate website.",
+		Link: "https://access.redhat.com/security/cve/CVE-2022-1650",
+		Severity: "Moderate",
+		CVSSv3: "8.1/CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N",
+		CPEs: []string{
+			"cpe:/a:redhat:enterprise_linux:8::appstream",
+			"cpe:/o:redhat:enterprise_linux:8::baseos",
+		},
+		PackageInfos: []*database.RHELv2PackageInfo{
+			{
+				Packages: []*database.RHELv2Package{
+					{
+						Name: "aspnetcore-runtime-6.0",
+						Version: "6.0.6-1.el8_6",
+						Arch: "x86_64",
+					},
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, datastore.InsertRHELv2Vulnerabilities([]*database.RHELv2Vulnerability{v1, v2}))
+
+	records := []*database.RHELv2Record{
+		{
+			Pkg: &database.RHELv2Package{
+				Name: "aspnetcore-runtime-6.0",
+				Version: "6.0.6-1.el8_6",
+				Arch: "x86_64",
+			},
+			CPE: "cpe:/o:redhat:enterprise_linux:8::baseos",
+		},
+	}
+
+	vulns, err := datastore.GetRHELv2Vulnerabilities(records)
+	assert.NoError(t, err)
+	assert.Len(t, vulns, 1)
+	assert.Len(t, vulns[0], 1)
+	vuln := vulns[0][0]
+	assert.Equal(t, "Moderate", vuln.Severity)
 }
 
 func TestRHELv2VulnerabilityCVERemoval(t *testing.T) {

--- a/database/pgsql/rhelv2_vulnerability_test.go
+++ b/database/pgsql/rhelv2_vulnerability_test.go
@@ -208,7 +208,6 @@ func TestRHELv2Vulnerability_CVEWithMultipleSeverities(t *testing.T) {
 				Packages: []*database.RHELv2Package{
 					{
 						Name: "something",
-						Version: "6.0.6-1.el8_6",
 						Arch: "x86_64",
 					},
 				},
@@ -231,7 +230,6 @@ func TestRHELv2Vulnerability_CVEWithMultipleSeverities(t *testing.T) {
 				Packages: []*database.RHELv2Package{
 					{
 						Name: "aspnetcore-runtime-6.0",
-						Version: "6.0.6-1.el8_6",
 						Arch: "x86_64",
 					},
 				},

--- a/database/pgsql/rhelv2_vulnerability_test.go
+++ b/database/pgsql/rhelv2_vulnerability_test.go
@@ -3,11 +3,12 @@
 package pgsql
 
 import (
+	"testing"
+
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/pkg/archop"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestRHELv2Vulnerability(t *testing.T) {

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3421,7 +3421,7 @@ var testCases = []testCase{
 						},
 					},
 				},
-				AddedBy: "",
+				AddedBy: "sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723",
 			},
 			{
 				Name:          "dotnet-runtime-6.0",
@@ -3453,7 +3453,7 @@ var testCases = []testCase{
 						},
 					},
 				},
-				AddedBy: "",
+				AddedBy: "sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723",
 			},
 		},
 	},

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3382,4 +3382,79 @@ var testCases = []testCase{
 			},
 		},
 	},
+	{
+		image:                   "quay.io/rhacs-eng/qa:sandbox-dotnet-60-runtime-6.0-15.20220620151726",
+		registry:                "https://quay.io",
+		username:                os.Getenv("QUAY_RHACS_ENG_RO_USERNAME"),
+		password:                os.Getenv("QUAY_RHACS_ENG_RO_PASSWORD"),
+		source:                  "Red Hat",
+		onlyCheckSpecifiedVulns: true,
+		namespace:               "rhel:8",
+		expectedFeatures: []apiV1.Feature{
+			{
+				Name:          "aspnetcore-runtime-6.0",
+				NamespaceName: "rhel:8",
+				VersionFormat: "rpm",
+				Version:       "6.0.6-1.el8_6.x86_64",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:          "CVE-2022-1650",
+						NamespaceName: "rhel:8",
+						Description:   "DOCUMENTATION: A flaw was found in the EventSource NPM Package. The description from the source states the following message: \"Exposure of Sensitive Information to an Unauthorized Actor.\" This flaw allows an attacker to steal the user's credentials and then use the credentials to access the legitimate website.",
+						Link:          "https://access.redhat.com/security/cve/CVE-2022-1650",
+						Severity:      "Moderate",
+						Metadata: map[string]interface{}{
+							"Red Hat": map[string]interface{}{
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 2.8,
+									"ImpactScore":         5.2,
+									"Score":               8.1,
+									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N",
+								},
+							},
+						},
+					},
+				},
+				AddedBy: "",
+			},
+			{
+				Name:          "dotnet-runtime-6.0",
+				NamespaceName: "rhel:8",
+				VersionFormat: "rpm",
+				Version:       "6.0.6-1.el8_6.x86_64",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:          "CVE-2022-1650",
+						NamespaceName: "rhel:8",
+						Description:   "DOCUMENTATION: A flaw was found in the EventSource NPM Package. The description from the source states the following message: \"Exposure of Sensitive Information to an Unauthorized Actor.\" This flaw allows an attacker to steal the user's credentials and then use the credentials to access the legitimate website.",
+						Link:          "https://access.redhat.com/security/cve/CVE-2022-1650",
+						Severity:      "Moderate",
+						Metadata: map[string]interface{}{
+							"Red Hat": map[string]interface{}{
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 2.8,
+									"ImpactScore":         5.2,
+									"Score":               8.1,
+									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N",
+								},
+							},
+						},
+					},
+				},
+				AddedBy: "",
+			},
+		},
+	},
 }


### PR DESCRIPTION
To reduce disk utilization, we separated vulnerabilities from the related packages, and we related them via the vulnerability's name (ex: [CVE-2022-1650](https://access.redhat.com/security/cve/cve-2022-1650)). However, when a vulnerability (for example [CVE-2022-1650](https://access.redhat.com/security/cve/cve-2022-1650)) has a different severity for different packages/environments, this becomes a problem, as multiple entries from the `vuln` table will be returned. We just simply took the first entry, which means for something like `dotnet`, the vulnerability entry we returned could have been attributed with severity `Important` instead of the correct severity, `Moderate`.

This PR fixes the relationship between `vuln` and `vuln_package` by using the vulnerability's hash as the "foreign key" instead of just the name. That way, we attribute the package to the correct vulnerability entry, which will give us the correct severity.

Creating a migration for this would have been a headache, as we need to correctly align the entries in `vuln_package` to `vuln`, as they are not correct now. This does not seem very easy to do with pure SQL. However, ScannerDB is currently *not* persisted, so we can get away with not performing a DB migration.

These changes will *not* affect live Scanners, as those Scanners come with their own already-made genesis dump and any diff we perform comparing the genesis dumps with the most up-to-date data do not involve the Postgres tables, but rather the Go struct `RHELv2Vulnerability`, which it not affected.