### PR TITLE
Update UID and PATH for generate-db-dump

### DIFF
--- a/.openshift-ci/build/generate-db-dump.sh
+++ b/.openshift-ci/build/generate-db-dump.sh
@@ -16,7 +16,7 @@ generate_db_dump() {
     adduser pg -u 1001 -g 1001 -d /var/lib/postgresql -s /bin/sh
 
     # The PATH is not completely preserved, so set the PATH here to ensure postgres-related commands can be found.
-    runuser -l pg -c "PATH=$PATH:/usr/pgsql-$PG_MAJOR/bin/ $ROOT/scripts/ci/postgres.sh start_postgres"
+    runuser -l pg -c "PATH=$PATH $ROOT/scripts/ci/postgres.sh start_postgres"
 
     "$ROOT/bin/updater" load-dump --postgres-host 127.0.0.1 --postgres-port 5432 --dump-file /tmp/genesis-dump/genesis-dump.zip
 

--- a/.openshift-ci/build/generate-db-dump.sh
+++ b/.openshift-ci/build/generate-db-dump.sh
@@ -12,10 +12,10 @@ gate_job generate-db-dump
 generate_db_dump() {
     info "Generating DB dump"
 
-    groupadd -g 71 pg
-    adduser pg -u 71 -g 71 -d /var/lib/postgresql -s /bin/sh
+    groupadd -g 1001 pg
+    adduser pg -u 1001 -g 1001 -d /var/lib/postgresql -s /bin/sh
 
-    runuser -l pg -c "$ROOT/scripts/ci/postgres.sh start_postgres"
+    runuser -l pg -c "PATH=$PATH:/usr/pgsql-$PG_MAJOR/bin/ $ROOT/scripts/ci/postgres.sh start_postgres"
 
     "$ROOT/bin/updater" load-dump --postgres-host 127.0.0.1 --postgres-port 5432 --dump-file /tmp/genesis-dump/genesis-dump.zip
 

--- a/.openshift-ci/build/generate-db-dump.sh
+++ b/.openshift-ci/build/generate-db-dump.sh
@@ -15,6 +15,7 @@ generate_db_dump() {
     groupadd -g 1001 pg
     adduser pg -u 1001 -g 1001 -d /var/lib/postgresql -s /bin/sh
 
+    # The PATH is not completely preserved, so set the PATH here to ensure postgres-related commands can be found.
     runuser -l pg -c "PATH=$PATH:/usr/pgsql-$PG_MAJOR/bin/ $ROOT/scripts/ci/postgres.sh start_postgres"
 
     "$ROOT/bin/updater" load-dump --postgres-host 127.0.0.1 --postgres-port 5432 --dump-file /tmp/genesis-dump/genesis-dump.zip

--- a/scripts/ci/postgres.sh
+++ b/scripts/ci/postgres.sh
@@ -2,6 +2,9 @@
 
 # Adapted from https://github.com/stackrox/stackrox/blob/master/scripts/ci/jobs/go-postgres-tests.sh
 
+SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+source "$SCRIPTS_ROOT/scripts/lib.sh"
+
 set -euo pipefail
 
 start_postgres() {


### PR DESCRIPTION
Received a warning about using a UID out of range: `adduser warning: pg's uid 71 outside of the UID_MIN 1000 and UID_MAX 60000 range.`

This step fails on `initdb`, though, because it cannot find it in the path. That's because it's no longer in `/usr/bin` as it used to be. So, let's update the `PATH` used by the `pg` user. The error message is:
```
/go/src/github.com/stackrox/scanner/scripts/ci/postgres.sh: line 10: initdb: command not found
```

Also, forgot to source lib.sh in postgres.sh, so I can see `info: No menu item 'Starting Postgres' in node '(dir)Top'`

Tested this via the following:

1. `docker run -it quay.io/stackrox-io/apollo-ci:scanner-test-0.3.45 bash`
2. `git clone https://github.com/stackrox/scanner && cd scanner`
3. Update the .openshift-ci/build/generate-db-dump.sh to comment out `openshift_ci_mods` and `gate_job generate-db-dump`, as they are not necessary and will prevent the test from working
4. Commented out anything under the `runuser` line as well inside the `generate_db_dump` function because they are not needed for the test
5. Run `./.openshift-ci/build/generate-db-dump.sh`