### PR TITLE
Bump CI images to latest scanner-test-0.3.45

### DIFF
--- a/.openshift-ci/build/Dockerfile.build-bundle
+++ b/.openshift-ci/build/Dockerfile.build-bundle
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.43
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.45
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/.openshift-ci/build/Dockerfile.build-db-bundle
+++ b/.openshift-ci/build/Dockerfile.build-db-bundle
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.43
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.45
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/.openshift-ci/build/Dockerfile.generate-db-dump
+++ b/.openshift-ci/build/Dockerfile.generate-db-dump
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.43
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.45
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/.openshift-ci/build/Dockerfile.generate-genesis-dump
+++ b/.openshift-ci/build/Dockerfile.generate-genesis-dump
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.43
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.45
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner


### PR DESCRIPTION
## Purpose

Onboard UBI9 to all CI images by bumping the base image to the latest.

## Tests

Relying on CI
