### PR TITLE
ROX-12036: Add Kubernetes CVE published time

### DIFF
--- a/api/v1/convert/k8s_convert_test.go
+++ b/api/v1/convert/k8s_convert_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func TestConvertK8sVulnerabilities(t *testing.T) {
-	pieDay, err := time.Parse(validation.TimeFormat, "2020-03-14")
+	pieDay, err := time.Parse(validation.TimeLayout, "2020-03-14T00:00Z")
 	require.NoError(t, err)
-	taxDay, err := time.Parse(validation.TimeFormat, "2015-04-15")
+	taxDay, err := time.Parse(validation.TimeLayout, "2015-04-15T00:00Z")
 	require.NoError(t, err)
-	newYearsDay, err := time.Parse(validation.TimeFormat, "2022-01-01")
+	newYearsDay, err := time.Parse(validation.TimeLayout, "2022-01-01T00:00Z")
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -70,7 +70,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 							ExploitabilityScore: 1.8,
 							ImpactScore:         4.0,
 						},
-						PublishedDateTime: pieDay.Format(types.TimeFormat),
+						PublishedDateTime: pieDay.Format(types.NVDTimeLayout),
 					},
 					FixedBy: "1.0.1",
 				},
@@ -167,7 +167,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 							ExploitabilityScore: 3.1,
 							ImpactScore:         4.0,
 						},
-						PublishedDateTime: taxDay.Format(types.TimeFormat),
+						PublishedDateTime: taxDay.Format(types.NVDTimeLayout),
 					},
 					FixedBy: "1.1.1",
 				},
@@ -182,7 +182,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 							ExploitabilityScore: 3.1,
 							ImpactScore:         4.0,
 						},
-						PublishedDateTime: pieDay.Format(types.TimeFormat),
+						PublishedDateTime: pieDay.Format(types.NVDTimeLayout),
 					},
 				},
 				{
@@ -196,7 +196,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 							ExploitabilityScore: 3.1,
 							ImpactScore:         4.0,
 						},
-						PublishedDateTime: newYearsDay.Format(types.TimeFormat),
+						PublishedDateTime: newYearsDay.Format(types.NVDTimeLayout),
 					},
 					FixedBy: "1.1.3",
 				},
@@ -249,7 +249,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 							ExploitabilityScore: 1.8,
 							ImpactScore:         4.0,
 						},
-						PublishedDateTime: newYearsDay.Format(types.TimeFormat),
+						PublishedDateTime: newYearsDay.Format(types.NVDTimeLayout),
 					},
 					FixedBy: "v1.12.1+d4cacc0",
 				},

--- a/api/v1/convert/k8s_convert_test.go
+++ b/api/v1/convert/k8s_convert_test.go
@@ -2,13 +2,23 @@ package convert
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stackrox/k8s-cves/pkg/validation"
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
+	"github.com/stackrox/scanner/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConvertK8sVulnerabilities(t *testing.T) {
+	pieDay, err := time.Parse(validation.TimeFormat, "2020-03-14")
+	require.NoError(t, err)
+	taxDay, err := time.Parse(validation.TimeFormat, "2015-04-15")
+	require.NoError(t, err)
+	newYearsDay, err := time.Parse(validation.TimeFormat, "2022-01-01")
+	require.NoError(t, err)
+
 	testCases := []struct {
 		version  string
 		cves     []*validation.CVESchema
@@ -21,6 +31,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 					CVE:         "CVE-2020-1234",
 					Description: "test1",
 					IssueURL:    "issueUrl",
+					Published:   validation.Time{Time: pieDay},
 					CVSS: &validation.CVSSSchema{
 						NVD: &validation.NVDSchema{
 							ScoreV2:  3.5,
@@ -59,6 +70,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 							ExploitabilityScore: 1.8,
 							ImpactScore:         4.0,
 						},
+						PublishedDateTime: pieDay.Format(types.TimeFormat),
 					},
 					FixedBy: "1.0.1",
 				},
@@ -72,6 +84,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 					Description: "test2",
 					IssueURL:    "issueUrl",
 					URL:         "url",
+					Published:   validation.Time{Time: taxDay},
 					CVSS: &validation.CVSSSchema{
 						NVD: &validation.NVDSchema{
 							ScoreV3:  7.7,
@@ -97,6 +110,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 					CVE:         "CVE-2020-1235",
 					Description: "test2",
 					URL:         "url",
+					Published:   validation.Time{Time: pieDay},
 					CVSS: &validation.CVSSSchema{
 						NVD: &validation.NVDSchema{
 							ScoreV3:  7.7,
@@ -114,6 +128,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 					CVE:         "CVE-2020-1236",
 					Description: "test3",
 					URL:         "url",
+					Published:   validation.Time{Time: newYearsDay},
 					CVSS: &validation.CVSSSchema{
 						NVD: &validation.NVDSchema{
 							ScoreV3:  7.7,
@@ -152,6 +167,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 							ExploitabilityScore: 3.1,
 							ImpactScore:         4.0,
 						},
+						PublishedDateTime: taxDay.Format(types.TimeFormat),
 					},
 					FixedBy: "1.1.1",
 				},
@@ -166,6 +182,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 							ExploitabilityScore: 3.1,
 							ImpactScore:         4.0,
 						},
+						PublishedDateTime: pieDay.Format(types.TimeFormat),
 					},
 				},
 				{
@@ -179,6 +196,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 							ExploitabilityScore: 3.1,
 							ImpactScore:         4.0,
 						},
+						PublishedDateTime: newYearsDay.Format(types.TimeFormat),
 					},
 					FixedBy: "1.1.3",
 				},
@@ -192,6 +210,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 					CVE:         "CVE-2020-1234",
 					Description: "test1",
 					IssueURL:    "issueUrl",
+					Published:   validation.Time{Time: newYearsDay},
 					CVSS: &validation.CVSSSchema{
 						NVD: &validation.NVDSchema{
 							ScoreV2:  3.5,
@@ -230,6 +249,7 @@ func TestConvertK8sVulnerabilities(t *testing.T) {
 							ExploitabilityScore: 1.8,
 							ImpactScore:         4.0,
 						},
+						PublishedDateTime: newYearsDay.Format(types.TimeFormat),
 					},
 					FixedBy: "v1.12.1+d4cacc0",
 				},

--- a/e2etests/node_scan_test.go
+++ b/e2etests/node_scan_test.go
@@ -79,6 +79,7 @@ func TestGRPCGetNodeVulnerabilities(t *testing.T) {
 								ExploitabilityScore: 1.4,
 								ImpactScore:         3.4,
 							},
+							PublishedDateTime: "2019-05-24T00:00Z",
 						},
 						FixedBy: "1.14.3",
 					},

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd
-	github.com/stackrox/k8s-cves v0.0.0-20220817213406-b74247cbb247
+	github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d
 	github.com/stackrox/rox v0.0.0-20210914215712-9ac265932e28
 	github.com/stretchr/testify v1.8.0
 	go.etcd.io/bbolt v1.3.6

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containers/image/v5 v5.20.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.1+incompatible
-	github.com/facebookincubator/nvdtools v0.1.4
+	github.com/facebookincubator/nvdtools v0.1.5
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
@@ -41,7 +41,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd
-	github.com/stackrox/k8s-cves v0.0.0-20201110001126-cc333981eaab
+	github.com/stackrox/k8s-cves v0.0.0-20220817213406-b74247cbb247
 	github.com/stackrox/rox v0.0.0-20210914215712-9ac265932e28
 	github.com/stretchr/testify v1.8.0
 	go.etcd.io/bbolt v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -2443,8 +2443,9 @@ github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd/go.mod h1:
 github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7/go.mod h1:faUw9vx/mA7ql41Ftlst5MYar2DT3nnS6oK94lbaW0g=
 github.com/stackrox/helm-operator v0.0.8-0.20220506091602-3764c49abfb3/go.mod h1:w+aTtmogp/HRpQcRouVHeNGHn80IrDMiWkWzmIOdcGE=
 github.com/stackrox/helmtest v0.0.0-20220118100812-1ad97c4de347/go.mod h1:vWZFszN4CfxMWzzMI/XfrcG4kkoDIPdwfDry76nYIbo=
-github.com/stackrox/k8s-cves v0.0.0-20201110001126-cc333981eaab h1:77xJmm1YkqbgrQzHI3C4MyPckWL+PYRLWakQRC6Mzj8=
 github.com/stackrox/k8s-cves v0.0.0-20201110001126-cc333981eaab/go.mod h1:EBskgGC5Gzt/r8ToNsuD6tYMcf+AWY0ubaFSRy5/3QM=
+github.com/stackrox/k8s-cves v0.0.0-20220817213406-b74247cbb247 h1:EHiV8BDZZAamxRLf7YiPdhDLMgxaJEEmg8kuWAIhXfg=
+github.com/stackrox/k8s-cves v0.0.0-20220817213406-b74247cbb247/go.mod h1:GJwFpFwCxiYhgpJWrAkM+v9Z9gpgtyWxkRdK4JjsOIg=
 github.com/stackrox/k8s-istio-cve-pusher v0.0.0-20210422200002-d89f671ac4f5/go.mod h1:GEtZ9DYAzmOtyqQPCJCEIzXJ7NcrHbMy6ZPJbcyfmLM=
 github.com/stackrox/nvdtools v0.0.0-20220608171543-e758756071a0 h1:hLexaI/zJBDP4OlxN1za3IJM7cfH+Kie7F/wdWn3xGA=
 github.com/stackrox/nvdtools v0.0.0-20220608171543-e758756071a0/go.mod h1:AIeN7k60Q/kcW9aeiMpA0PY8CU3zsrLV0UhIksolMn4=

--- a/go.sum
+++ b/go.sum
@@ -2444,8 +2444,8 @@ github.com/stackrox/external-network-pusher v0.0.0-20210419192707-074af92bbfa7/g
 github.com/stackrox/helm-operator v0.0.8-0.20220506091602-3764c49abfb3/go.mod h1:w+aTtmogp/HRpQcRouVHeNGHn80IrDMiWkWzmIOdcGE=
 github.com/stackrox/helmtest v0.0.0-20220118100812-1ad97c4de347/go.mod h1:vWZFszN4CfxMWzzMI/XfrcG4kkoDIPdwfDry76nYIbo=
 github.com/stackrox/k8s-cves v0.0.0-20201110001126-cc333981eaab/go.mod h1:EBskgGC5Gzt/r8ToNsuD6tYMcf+AWY0ubaFSRy5/3QM=
-github.com/stackrox/k8s-cves v0.0.0-20220817213406-b74247cbb247 h1:EHiV8BDZZAamxRLf7YiPdhDLMgxaJEEmg8kuWAIhXfg=
-github.com/stackrox/k8s-cves v0.0.0-20220817213406-b74247cbb247/go.mod h1:GJwFpFwCxiYhgpJWrAkM+v9Z9gpgtyWxkRdK4JjsOIg=
+github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d h1:88Iui7fSMKgXvpyfBlbP3qosrqyv3qMgOJ6JJ4V4tFQ=
+github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d/go.mod h1:GJwFpFwCxiYhgpJWrAkM+v9Z9gpgtyWxkRdK4JjsOIg=
 github.com/stackrox/k8s-istio-cve-pusher v0.0.0-20210422200002-d89f671ac4f5/go.mod h1:GEtZ9DYAzmOtyqQPCJCEIzXJ7NcrHbMy6ZPJbcyfmLM=
 github.com/stackrox/nvdtools v0.0.0-20220608171543-e758756071a0 h1:hLexaI/zJBDP4OlxN1za3IJM7cfH+Kie7F/wdWn3xGA=
 github.com/stackrox/nvdtools v0.0.0-20220608171543-e758756071a0/go.mod h1:AIeN7k60Q/kcW9aeiMpA0PY8CU3zsrLV0UhIksolMn4=

--- a/pkg/component/type.go
+++ b/pkg/component/type.go
@@ -1,6 +1,7 @@
 package component
 
 // SourceType represents the specific type of a language-level component.
+//
 //go:generate stringer -type=SourceType
 type SourceType int
 

--- a/pkg/component/type.go
+++ b/pkg/component/type.go
@@ -1,7 +1,6 @@
 package component
 
 // SourceType represents the specific type of a language-level component.
-//
 //go:generate stringer -type=SourceType
 type SourceType int
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,9 +12,8 @@ import (
 	"github.com/stackrox/scanner/database"
 )
 
-// TimeFormat is the format used for vulnerability published and/or modified time.
-// This format is expected in StackRox Central.
-const TimeFormat = "2006-01-02T15:04Z"
+// NVDTimeLayout is the time layout used by NVD.
+const NVDTimeLayout = schema.TimeLayout
 
 // Metadata is the vulnerability metadata.
 type Metadata struct {
@@ -158,7 +157,7 @@ func ConvertMetadataFromK8s(cve *validation.CVESchema) (*Metadata, error) {
 		}
 	}
 
-	m.PublishedDateTime = cve.Published.Format(TimeFormat)
+	m.PublishedDateTime = cve.Published.Format(NVDTimeLayout)
 
 	return &m, nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -13,6 +13,7 @@ import (
 )
 
 // TimeFormat is the format used for vulnerability published and/or modified time.
+// This format is expected in StackRox Central.
 const TimeFormat = "2006-01-02T15:04Z"
 
 // Metadata is the vulnerability metadata.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stackrox/scanner/database"
 )
 
+// TimeFormat is the format used for vulnerability published and/or modified time.
+const TimeFormat = "2006-01-02T15:04Z"
+
 // Metadata is the vulnerability metadata.
 type Metadata struct {
 	PublishedDateTime    string
@@ -153,6 +156,8 @@ func ConvertMetadataFromK8s(cve *validation.CVESchema) (*Metadata, error) {
 			m.CVSSv3 = *cvssv3
 		}
 	}
+
+	m.PublishedDateTime = cve.Published.Format(TimeFormat)
 
 	return &m, nil
 }


### PR DESCRIPTION
The https://github.com/stackrox/k8s-cves repo now adds the vulnerability's published time, so this PR is meant to ingest this data.

Tested with a local instance of StackRox using the Scanner version built from this PR and found the following:

<img width="1440" alt="Screen Shot 2022-08-19 at 10 20 00 AM" src="https://user-images.githubusercontent.com/7704495/185673817-3c06b06e-ca7c-49eb-b093-b58892d75858.png">