### PR TITLE
Add go1.17 directives to db integration test files

### DIFF
--- a/database/pgsql/complex_test.go
+++ b/database/pgsql/complex_test.go
@@ -1,3 +1,4 @@
+//go:build db_integration
 // +build db_integration
 
 // Copyright 2017 clair authors

--- a/database/pgsql/feature_test.go
+++ b/database/pgsql/feature_test.go
@@ -1,3 +1,4 @@
+//go:build db_integration || slim_db_integration
 // +build db_integration slim_db_integration
 
 // Copyright 2016 clair authors

--- a/database/pgsql/keyvalue_test.go
+++ b/database/pgsql/keyvalue_test.go
@@ -1,3 +1,4 @@
+//go:build db_integration || slim_db_integration
 // +build db_integration slim_db_integration
 
 // Copyright 2016 clair authors

--- a/database/pgsql/language_vulnerability_test.go
+++ b/database/pgsql/language_vulnerability_test.go
@@ -1,3 +1,4 @@
+//go:build db_integration
 // +build db_integration
 
 package pgsql

--- a/database/pgsql/layer_test.go
+++ b/database/pgsql/layer_test.go
@@ -1,3 +1,4 @@
+//go:build db_integration
 // +build db_integration
 
 // Copyright 2017 clair authors

--- a/database/pgsql/namespace_test.go
+++ b/database/pgsql/namespace_test.go
@@ -1,3 +1,4 @@
+//go:build db_integration || slim_db_integration
 // +build db_integration slim_db_integration
 
 // Copyright 2016 clair authors

--- a/database/pgsql/pgsql_test.go
+++ b/database/pgsql/pgsql_test.go
@@ -1,3 +1,4 @@
+//go:build db_integration || slim_db_integration
 // +build db_integration slim_db_integration
 
 // Copyright 2016 clair authors

--- a/database/pgsql/rhelv2_layer_test.go
+++ b/database/pgsql/rhelv2_layer_test.go
@@ -1,3 +1,4 @@
+//go:build db_integration || slim_db_integration
 // +build db_integration slim_db_integration
 
 package pgsql

--- a/database/pgsql/rhelv2_vulnerability_test.go
+++ b/database/pgsql/rhelv2_vulnerability_test.go
@@ -1,3 +1,4 @@
+//go:build db_integration
 // +build db_integration
 
 package pgsql
@@ -5,8 +6,8 @@ package pgsql
 import (
 	"testing"
 
-	"github.com/stackrox/scanner/pkg/archop"
 	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/pkg/archop"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/database/pgsql/rhelv2_vulnerability_test.go
+++ b/database/pgsql/rhelv2_vulnerability_test.go
@@ -6,8 +6,8 @@ package pgsql
 import (
 	"testing"
 
-	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/pkg/archop"
+	"github.com/stackrox/scanner/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/database/pgsql/vulnerability_test.go
+++ b/database/pgsql/vulnerability_test.go
@@ -1,3 +1,4 @@
+//go:build db_integration
 // +build db_integration
 
 // Copyright 2017 clair authors


### PR DESCRIPTION
Add the go1.17 directives to all remaining files which were missing it. The older format is deprecated and will be removed in go1.18