### PR TITLE
ROX-12238: Create interface for images files from tarutil

### DIFF
--- a/ext/featurefmt/apk/apk.go
+++ b/ext/featurefmt/apk/apk.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stackrox/scanner/ext/featurefmt"
 	"github.com/stackrox/scanner/ext/versionfmt"
 	"github.com/stackrox/scanner/ext/versionfmt/apk"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/metrics"
-	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
 const (
@@ -40,7 +40,7 @@ func init() {
 
 type lister struct{}
 
-func (l lister) ListFeatures(files tarutil.LayerFiles) ([]database.FeatureVersion, error) {
+func (l lister) ListFeatures(files analyzer.Files) ([]database.FeatureVersion, error) {
 	file, exists := files.Get(dbPath)
 	if !exists {
 		return []database.FeatureVersion{}, nil

--- a/ext/featurefmt/apk/apk_test.go
+++ b/ext/featurefmt/apk/apk_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurefmt"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/elf"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
@@ -87,7 +88,7 @@ func TestAPKFeatureDetection(t *testing.T) {
 					Version: "0.7-r0",
 				},
 			},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"lib/apk/db/installed":      {Contents: featurefmt.LoadFileForTest("apk/testdata/installed")},
 				"lib/libc.musl-x86_64.so.1": {Executable: true, ELFMetadata: &elf.Metadata{Sonames: []string{"c.so.1"}, ImportedLibraries: []string{"ld.so.1"}}},
 				"lib/ld-musl-x86_64.so.1":   {Executable: true, ELFMetadata: &elf.Metadata{Sonames: []string{"ld.so.1"}}},

--- a/ext/featurefmt/dpkg/dpkg_test.go
+++ b/ext/featurefmt/dpkg/dpkg_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurefmt"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/elf"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
@@ -60,7 +61,7 @@ func TestDpkgFeatureDetection(t *testing.T) {
 				},
 			},
 			Files: tarutil.CreateNewLayerFiles(
-				map[string]tarutil.FileData{
+				map[string]analyzer.FileData{
 					"var/lib/dpkg/status":                       {Contents: featurefmt.LoadFileForTest("dpkg/testdata/status")},
 					"var/lib/dpkg/status.d":                     {},
 					"var/lib/dpkg/status.d/base":                {Contents: featurefmt.LoadFileForTest("dpkg/testdata/statusd-base")},

--- a/ext/featurefmt/driver.go
+++ b/ext/featurefmt/driver.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	rhelv2 "github.com/stackrox/scanner/pkg/rhelv2/rpm"
 	"github.com/stackrox/scanner/pkg/tarutil"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,7 @@ type PackageKey struct {
 // Lister represents an ability to list the features present in an image layer.
 type Lister interface {
 	// ListFeatures produces a list of FeatureVersions present in an image layer.
-	ListFeatures(tarutil.LayerFiles) ([]database.FeatureVersion, error)
+	ListFeatures(analyzer.Files) ([]database.FeatureVersion, error)
 
 	// RequiredFilenames returns the list of files required to be in the LayerFiles
 	// provided to the ListFeatures method.
@@ -77,7 +78,7 @@ func RegisterLister(name string, l Lister) {
 
 // ListFeatures produces the list of FeatureVersions in an image layer using
 // every registered Lister.
-func ListFeatures(files tarutil.LayerFiles) ([]database.FeatureVersion, error) {
+func ListFeatures(files analyzer.Files) ([]database.FeatureVersion, error) {
 	listersM.RLock()
 	defer listersM.RUnlock()
 
@@ -136,7 +137,7 @@ func TestLister(t *testing.T, l Lister, testData []TestData) {
 }
 
 // AddToDependencyMap checks and adds files to executable and library dependency
-func AddToDependencyMap(filename string, fileData tarutil.FileData, execToDeps, libToDeps database.StringToStringsMap) {
+func AddToDependencyMap(filename string, fileData analyzer.FileData, execToDeps, libToDeps database.StringToStringsMap) {
 	if fileData.Executable {
 		deps := set.NewStringSet()
 		if elfMeta := fileData.ELFMetadata; elfMeta != nil {

--- a/ext/featurefmt/rpm/rpm.go
+++ b/ext/featurefmt/rpm/rpm.go
@@ -29,10 +29,10 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurefmt"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/commonerr"
 	"github.com/stackrox/scanner/pkg/metrics"
 	"github.com/stackrox/scanner/pkg/rhelv2/rpm"
-	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
 const (
@@ -50,7 +50,7 @@ func init() {
 	featurefmt.RegisterLister("rpm", &lister{})
 }
 
-func (l lister) ListFeatures(files tarutil.LayerFiles) ([]database.FeatureVersion, error) {
+func (l lister) ListFeatures(files analyzer.Files) ([]database.FeatureVersion, error) {
 	f, hasFile := files.Get(dbPath)
 	if !hasFile {
 		return []database.FeatureVersion{}, nil
@@ -106,7 +106,7 @@ func (l lister) ListFeatures(files tarutil.LayerFiles) ([]database.FeatureVersio
 	return featureVersions, nil
 }
 
-func parseFeatures(r io.Reader, files tarutil.LayerFiles) ([]database.FeatureVersion, error) {
+func parseFeatures(r io.Reader, files analyzer.Files) ([]database.FeatureVersion, error) {
 	var featureVersions []database.FeatureVersion
 
 	var fv database.FeatureVersion

--- a/ext/featurefmt/rpm/rpm_test.go
+++ b/ext/featurefmt/rpm/rpm_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurefmt"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/elf"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
@@ -57,7 +58,7 @@ func TestRpmFeatureDetection(t *testing.T) {
 					},
 				},
 			},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"var/lib/rpm/Packages":   {Contents: featurefmt.LoadFileForTest("rpm/testdata/Packages")},
 				"etc/centos-release":     {Executable: true},
 				"usr/games":              {Executable: true, ELFMetadata: &elf.Metadata{ImportedLibraries: []string{"base.so.1", "mock.so.1.0"}}},

--- a/ext/featurens/alpinerelease/alpinerelease.go
+++ b/ext/featurens/alpinerelease/alpinerelease.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/apk"
-	"github.com/stackrox/scanner/pkg/tarutil"
+	"github.com/stackrox/scanner/pkg/analyzer"
 )
 
 const (
@@ -43,7 +43,7 @@ func init() {
 
 type detector struct{}
 
-func (d detector) Detect(files tarutil.LayerFiles, _ *featurens.DetectorOptions) *database.Namespace {
+func (d detector) Detect(files analyzer.Files, _ *featurens.DetectorOptions) *database.Namespace {
 	file, exists := files.Get(alpineReleasePath)
 	if !exists {
 		return nil

--- a/ext/featurens/alpinerelease/alpinerelease_test.go
+++ b/ext/featurens/alpinerelease/alpinerelease_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/apk"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
@@ -27,25 +28,25 @@ func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
 			ExpectedNamespace: &database.Namespace{Name: "alpine:v3.3", VersionFormat: apk.ParserName},
-			Files:             tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{"etc/alpine-release": {Contents: []byte(`3.3.4`)}}),
+			Files:             tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{"etc/alpine-release": {Contents: []byte(`3.3.4`)}}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "alpine:v3.4", VersionFormat: apk.ParserName},
-			Files:             tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{"etc/alpine-release": {Contents: []byte(`3.4.0`)}}),
+			Files:             tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{"etc/alpine-release": {Contents: []byte(`3.4.0`)}}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "alpine:v0.3", VersionFormat: apk.ParserName},
-			Files:             tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{"etc/alpine-release": {Contents: []byte(`0.3.4`)}}),
+			Files:             tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{"etc/alpine-release": {Contents: []byte(`0.3.4`)}}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "alpine:v0.3", VersionFormat: apk.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{"etc/alpine-release": {Contents: []byte(`
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{"etc/alpine-release": {Contents: []byte(`
 0.3.4
 `)}}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "alpine:edge", VersionFormat: apk.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/alpine-release": {Contents: []byte(`3.14.0_alpha20210212`)},
 				"etc/os-release": {Contents: []byte(
 					`NAME="Alpine Linux"

--- a/ext/featurens/aptsources/aptsources.go
+++ b/ext/featurens/aptsources/aptsources.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/dpkg"
-	"github.com/stackrox/scanner/pkg/tarutil"
+	"github.com/stackrox/scanner/pkg/analyzer"
 )
 
 type detector struct{}
@@ -35,7 +35,7 @@ func init() {
 	featurens.RegisterDetector("apt-sources", &detector{})
 }
 
-func (d detector) Detect(files tarutil.LayerFiles, _ *featurens.DetectorOptions) *database.Namespace {
+func (d detector) Detect(files analyzer.Files, _ *featurens.DetectorOptions) *database.Namespace {
 	f, hasFile := files.Get("etc/apt/sources.list")
 	if !hasFile {
 		return nil

--- a/ext/featurens/aptsources/aptsources_test.go
+++ b/ext/featurens/aptsources/aptsources_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/dpkg"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
@@ -27,7 +28,7 @@ func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
 			ExpectedNamespace: &database.Namespace{Name: "debian:unstable", VersionFormat: dpkg.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/os-release": {Contents: []byte(
 					`PRETTY_NAME="Debian GNU/Linux stretch/sid"
 NAME="Debian GNU/Linux"

--- a/ext/featurens/busybox/busybox.go
+++ b/ext/featurens/busybox/busybox.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/language"
-	"github.com/stackrox/scanner/pkg/tarutil"
+	"github.com/stackrox/scanner/pkg/analyzer"
 )
 
 type detector struct{}
@@ -54,7 +54,7 @@ func parseBusyBoxVersion(contents []byte) string {
 	return ""
 }
 
-func (detector) Detect(files tarutil.LayerFiles, options *featurens.DetectorOptions) *database.Namespace {
+func (detector) Detect(files analyzer.Files, options *featurens.DetectorOptions) *database.Namespace {
 	for _, filePath := range blockedFiles {
 		if _, hasFile := files.Get(filePath); hasFile {
 			return nil

--- a/ext/featurens/busybox/busybox_test.go
+++ b/ext/featurens/busybox/busybox_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/language"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
@@ -24,7 +25,7 @@ func Test_detector_Detect(t *testing.T) {
 				Name:          expectedName,
 				VersionFormat: language.ParserName,
 			},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"bin/busybox": {Contents: []byte(bbContent)},
 				"bin/[":       {Contents: []byte(bbContent)},
 			}),
@@ -32,21 +33,21 @@ func Test_detector_Detect(t *testing.T) {
 		// Invalid busybox version strings.
 		{
 			ExpectedNamespace: nil,
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"bin/busybox": {Contents: []byte(bbContentNoVersion)},
 				"bin/[":       {Contents: []byte(bbContentNoVersion)},
 			}),
 		},
 		{
 			ExpectedNamespace: nil,
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"bin/busybox": {Contents: []byte(bbContentBadVersion)},
 				"bin/[":       {Contents: []byte(bbContentBadVersion)},
 			}),
 		},
 		{
 			ExpectedNamespace: nil,
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"bin/busybox": {Contents: []byte(bbContentPartialVersion)},
 				"bin/[":       {Contents: []byte(bbContentPartialVersion)},
 			}),
@@ -54,34 +55,34 @@ func Test_detector_Detect(t *testing.T) {
 		// Unexpected coreutils or unnexpected files.
 		{
 			ExpectedNamespace: nil,
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"bin/busybox": {Contents: []byte("something else")},
 				"bin/[":       {Contents: []byte(bbContent)},
 			}),
 		},
 		{
 			ExpectedNamespace: nil,
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"bin/busybox": {Contents: []byte(bbContent)},
 				"bin/[":       {Contents: []byte("something else")},
 			}),
 		},
 		{
 			ExpectedNamespace: nil,
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"bin/busybox": {Contents: []byte(bbContent)},
 			}),
 		},
 		{
 			ExpectedNamespace: nil,
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"bin/[": {Contents: []byte(bbContent)},
 			}),
 		},
 		// Blocked files.
 		{
 			ExpectedNamespace: nil,
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/os-release": {},
 				"bin/busybox":    {Contents: []byte(bbContent)},
 				"bin/[":          {Contents: []byte(bbContent)},
@@ -89,7 +90,7 @@ func Test_detector_Detect(t *testing.T) {
 		},
 		{
 			ExpectedNamespace: nil,
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/lsb-release": {},
 				"bin/busybox":     {Contents: []byte(bbContent)},
 				"bin/[":           {Contents: []byte(bbContent)},

--- a/ext/featurens/driver.go
+++ b/ext/featurens/driver.go
@@ -22,6 +22,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/tarutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,7 +37,7 @@ var (
 type Detector interface {
 	// Detect attempts to determine a Namespace from a LayerFiles of an image
 	// layer.
-	Detect(tarutil.LayerFiles, *DetectorOptions) *database.Namespace
+	Detect(analyzer.Files, *DetectorOptions) *database.Namespace
 
 	// RequiredFilenames returns the list of files required to be in the LayerFiles
 	// provided to the Detect method.
@@ -69,7 +70,7 @@ func RegisterDetector(name string, d Detector) {
 
 // Detect iterators through all registered Detectors and returns the first
 // non-nil detected namespace.
-func Detect(files tarutil.LayerFiles, opts *DetectorOptions) *database.Namespace {
+func Detect(files analyzer.Files, opts *DetectorOptions) *database.Namespace {
 	detectorsM.RLock()
 	defer detectorsM.RUnlock()
 

--- a/ext/featurens/lsbrelease/lsbrelease.go
+++ b/ext/featurens/lsbrelease/lsbrelease.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stackrox/scanner/ext/featurens/util"
 	"github.com/stackrox/scanner/ext/versionfmt/dpkg"
 	"github.com/stackrox/scanner/ext/versionfmt/rpm"
-	"github.com/stackrox/scanner/pkg/tarutil"
+	"github.com/stackrox/scanner/pkg/analyzer"
 )
 
 var (
@@ -42,7 +42,7 @@ func init() {
 	featurens.RegisterDetector("lsb-release", &detector{})
 }
 
-func (d detector) Detect(files tarutil.LayerFiles, _ *featurens.DetectorOptions) *database.Namespace {
+func (d detector) Detect(files analyzer.Files, _ *featurens.DetectorOptions) *database.Namespace {
 	f, hasFile := files.Get("etc/lsb-release")
 	if !hasFile {
 		return nil

--- a/ext/featurens/lsbrelease/lsbrelease_test.go
+++ b/ext/featurens/lsbrelease/lsbrelease_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/dpkg"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
@@ -27,7 +28,7 @@ func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
 			ExpectedNamespace: &database.Namespace{Name: "ubuntu:12.04", VersionFormat: dpkg.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/lsb-release": {
 					Contents: []byte(
 						`DISTRIB_ID=Ubuntu
@@ -39,7 +40,7 @@ DISTRIB_DESCRIPTION="Ubuntu 12.04 LTS"`),
 		},
 		{ // We don't care about the minor version of Debian
 			ExpectedNamespace: &database.Namespace{Name: "debian:7", VersionFormat: dpkg.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/lsb-release": {
 					Contents: []byte(
 						`DISTRIB_ID=Debian

--- a/ext/featurens/osrelease/osrelease.go
+++ b/ext/featurens/osrelease/osrelease.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/dpkg"
 	"github.com/stackrox/scanner/ext/versionfmt/rpm"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/osrelease"
-	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
 var (
@@ -48,7 +48,7 @@ func init() {
 	featurens.RegisterDetector("os-release", &detector{})
 }
 
-func (d detector) Detect(files tarutil.LayerFiles, _ *featurens.DetectorOptions) *database.Namespace {
+func (d detector) Detect(files analyzer.Files, _ *featurens.DetectorOptions) *database.Namespace {
 	var OS, version string
 
 	for _, filePath := range blocklistFilenames {

--- a/ext/featurens/osrelease/osrelease_test.go
+++ b/ext/featurens/osrelease/osrelease_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/dpkg"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
@@ -27,7 +28,7 @@ func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
 			ExpectedNamespace: &database.Namespace{Name: "debian:8", VersionFormat: dpkg.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/os-release": {Contents: []byte(
 					`PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
 NAME="Debian GNU/Linux"
@@ -41,7 +42,7 @@ BUG_REPORT_URL="https://bugs.debian.org/"`)},
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "ubuntu:15.10", VersionFormat: dpkg.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/os-release": {Contents: []byte(
 					`NAME="Ubuntu"
 VERSION="15.10 (Wily Werewolf)"
@@ -56,7 +57,7 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`)},
 		},
 		{ // Doesn't have quotes around VERSION_ID
 			ExpectedNamespace: &database.Namespace{Name: "ubuntu:15.10", VersionFormat: dpkg.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/os-release": {Contents: []byte(
 					`NAME="Ubuntu"
 ID=ubuntu
@@ -70,7 +71,7 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`)},
 		},
 		{ // We do not support Fedora.
 			ExpectedNamespace: nil,
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/os-release": {Contents: []byte(
 					`NAME=Fedora
 VERSION="20 (Heisenbug)"

--- a/ext/featurens/redhatrelease/redhatrelease.go
+++ b/ext/featurens/redhatrelease/redhatrelease.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/rpm"
-	"github.com/stackrox/scanner/pkg/tarutil"
+	"github.com/stackrox/scanner/pkg/analyzer"
 )
 
 var (
@@ -45,7 +45,7 @@ func init() {
 	featurens.RegisterDetector("redhat-release", &detector{})
 }
 
-func (d detector) Detect(files tarutil.LayerFiles, opts *featurens.DetectorOptions) *database.Namespace {
+func (d detector) Detect(files analyzer.Files, opts *featurens.DetectorOptions) *database.Namespace {
 	for _, filePath := range d.RequiredFilenames() {
 		f, hasFile := files.Get(filePath)
 		if !hasFile {

--- a/ext/featurens/redhatrelease/redhatrelease_test.go
+++ b/ext/featurens/redhatrelease/redhatrelease_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/rpm"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
@@ -27,62 +28,62 @@ func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
 			ExpectedNamespace: &database.Namespace{Name: "amzn:2", VersionFormat: rpm.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/system-release": {Contents: []byte(`Amazon Linux release 2 (Karoo)`)},
 			}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "amzn:2018.03", VersionFormat: rpm.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/system-release": {Contents: []byte(`Amazon Linux AMI release 2018.03`)},
 			}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "oracle:6", VersionFormat: rpm.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/oracle-release": {Contents: []byte(`Oracle Linux Server release 6.8`)},
 			}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "oracle:7", VersionFormat: rpm.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/oracle-release": {Contents: []byte(`Oracle Linux Server release 7.2`)},
 			}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "centos:6", VersionFormat: rpm.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/centos-release": {Contents: []byte(`CentOS release 6.6 (Final)`)},
 			}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "rhel:7", VersionFormat: rpm.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/redhat-release": {Contents: []byte(`Red Hat Enterprise Linux Server release 7.2 (Maipo)`)},
 			}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "rhel:8", VersionFormat: rpm.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/redhat-release": {Contents: []byte(`Red Hat Enterprise Linux release 8.0 (Ootpa)`)},
 			}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "centos:8", VersionFormat: rpm.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/redhat-release": {Contents: []byte(`Red Hat Enterprise Linux release 8.0 (Ootpa)`)},
 			}),
 			Options: &featurens.DetectorOptions{UncertifiedRHEL: true},
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "centos:8", VersionFormat: rpm.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/redhat-release": {Contents: []byte(`CentOS Linux release 8.3.2011`)},
 			}),
 		},
 		{
 			ExpectedNamespace: &database.Namespace{Name: "centos:7", VersionFormat: rpm.ParserName},
-			Files: tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/system-release": {Contents: []byte(`CentOS Linux release 7.1.1503 (Core)`)},
 			}),
 		},

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -5,9 +5,35 @@ import (
 	"os"
 
 	"github.com/stackrox/scanner/pkg/component"
+	"github.com/stackrox/scanner/pkg/elf"
 )
 
 // Analyzer defines the functions for analyzing images and extracting the components present in them.
 type Analyzer interface {
 	ProcessFile(filePath string, fi os.FileInfo, contents io.ReaderAt) []*component.Component
+}
+
+// Files stores information on a sub-set of files being analyzed from an image.
+// It provides methods to retrieve information from individual files, or list
+// them based on some prefix.
+type Files interface {
+
+	// Get returns the data about a file if it exists, otherwise set exists to false.
+	Get(path string) (data FileData, exists bool)
+
+	// GetFilesPrefix returns a map of files matching the specified prefix, empty map
+	// if none found. The prefix itself is not matched.
+	GetFilesPrefix(prefix string) (filesMap map[string]FileData)
+}
+
+// FileData is the contents of a file and relevant metadata.
+type FileData struct {
+	// Contents is the contents of the file.
+	Contents []byte
+
+	// Executable indicates if the file is executable.
+	Executable bool
+
+	// ELFMetadata contains the dynamic library dependency metadata if the file is in ELF format.
+	ELFMetadata *elf.Metadata
 }

--- a/pkg/rhelv2/rpm/bench_test.go
+++ b/pkg/rhelv2/rpm/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/tarutil"
 	"github.com/stackrox/scanner/pkg/testutils"
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ func BenchmarkListFeatures(b *testing.B) {
 	envIsolator.Setenv("REPO_TO_CPE_DIR", cpesDir)
 	defer envIsolator.RestoreAll()
 
-	filemap := tarutil.CreateNewLayerFiles(map[string]tarutil.FileData{
+	filemap := tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 		"var/lib/rpm/Packages":                       {Contents: d},
 		"root/buildinfo/content_manifests/test.json": {Contents: manifest},
 		"usr/lib64/libz.so.1":                        {Executable: true},

--- a/pkg/rhelv2/rpm/rpm_language_analyzer.go
+++ b/pkg/rhelv2/rpm/rpm_language_analyzer.go
@@ -2,18 +2,18 @@ package rpm
 
 import (
 	"github.com/stackrox/rox/pkg/stringutils"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/component"
 	"github.com/stackrox/scanner/pkg/rpm"
-	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
 // AnnotateComponentsWithPackageManagerInfo checks for each component if it was installed by the package manager,
 // and sets the `FromPackageManager` attribute accordingly.
-func AnnotateComponentsWithPackageManagerInfo(files tarutil.LayerFiles, components []*component.Component) error {
+func AnnotateComponentsWithPackageManagerInfo(files analyzer.Files, components []*component.Component) error {
 	if len(components) == 0 {
 		return nil
 	}
-	rpmDB, err := rpm.CreateDatabaseFromLayer(files)
+	rpmDB, err := rpm.CreateDatabaseFromImage(files)
 	if err != nil {
 		return err
 	}

--- a/pkg/rhelv2/rpm/rpm_test.go
+++ b/pkg/rhelv2/rpm/rpm_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/features"
 	"github.com/stackrox/scanner/pkg/tarutil"
 	"github.com/stackrox/scanner/pkg/testutils"
@@ -37,7 +38,7 @@ func Test_listFeatures(t *testing.T) {
 		args args
 
 		// Add test layer files from a map of file data.
-		files map[string]tarutil.FileData
+		files map[string]analyzer.FileData
 		// Add test layer files from a map of files stored in the testdata/
 		// directory.
 		filesFromTestData map[string]string
@@ -94,7 +95,7 @@ func Test_listFeatures(t *testing.T) {
 		},
 		{
 			name: "TestRPMFeatureDetectionWithActiveVulnMgmt with BerkleyDB",
-			files: map[string]tarutil.FileData{
+			files: map[string]analyzer.FileData{
 				"usr/lib64/libz.so.1":          {Executable: true},
 				"usr/lib64/libz.so.1.2.11":     {Executable: true},
 				"usr/lib64/libform.so.6":       {Executable: true},
@@ -196,7 +197,7 @@ func Test_listFeatures(t *testing.T) {
 		},
 		{
 			name: "TestRPMFeatureDetectionWithActiveVulnMgmt with SQLite",
-			files: map[string]tarutil.FileData{
+			files: map[string]analyzer.FileData{
 				"usr/lib64/libz.so.1":          {Executable: true},
 				"usr/lib64/libz.so.1.2.11":     {Executable: true},
 				"usr/lib64/libform.so.6":       {Executable: true},
@@ -264,12 +265,12 @@ func Test_listFeatures(t *testing.T) {
 		// Initialize test arguments.
 		if tt.filesFromTestData != nil {
 			if tt.files == nil {
-				tt.files = make(map[string]tarutil.FileData)
+				tt.files = make(map[string]analyzer.FileData)
 			}
 			for n, f := range tt.filesFromTestData {
 				c, err := os.ReadFile(filepath.Join(testDirectory, "testdata", f))
 				require.NoError(t, err)
-				tt.files[n] = tarutil.FileData{Contents: c}
+				tt.files[n] = analyzer.FileData{Contents: c}
 			}
 		}
 		tt.args.layerFiles = tarutil.CreateNewLayerFiles(tt.files)

--- a/pkg/rpm/database.go
+++ b/pkg/rpm/database.go
@@ -15,9 +15,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/commonerr"
 	"github.com/stackrox/scanner/pkg/features"
-	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
 const (
@@ -104,16 +104,16 @@ func DatabaseFiles() []string {
 	return paths
 }
 
-// CreateDatabaseFromLayer creates an RPM database in a temporary directory
+// CreateDatabaseFromImage creates an RPM database in a temporary directory
 // from the RPM database found in the container image. All known RPM database
 // backend is supported (i.e. bdb, sqlite). If no database is found in the image,
 // returns nil.
-func CreateDatabaseFromLayer(imageFiles tarutil.LayerFiles) (*rpmDatabase, error) {
+func CreateDatabaseFromImage(imageFiles analyzer.Files) (*rpmDatabase, error) {
 	// Find all known RPM database models and their files. It is unlikely that the
 	// image will contain more than one model, but in that scenario we copy all files
 	// and rely on the fact that `rpm` will select the most up-to-date database
 	// model, instead of replicating that knowledge in the code.
-	dbFiles := make(map[string]tarutil.FileData)
+	dbFiles := make(map[string]analyzer.FileData)
 	for name := range databaseFiles {
 		if data, exists := imageFiles.Get(path.Join(databaseDir, name)); exists {
 			dbFiles[name] = data

--- a/pkg/tarutil/layer_files_test.go
+++ b/pkg/tarutil/layer_files_test.go
@@ -1,0 +1,76 @@
+package tarutil
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/scanner/pkg/analyzer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLayerFiles_GetFilesPrefix(t *testing.T) {
+	type fields struct {
+		data    map[string]analyzer.FileData
+		links   map[string]string
+		removed set.StringSet
+	}
+	type args struct {
+		prefix string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[string]analyzer.FileData
+	}{
+		{
+			name: "no match",
+			fields: fields{
+				data: map[string]analyzer.FileData{
+					"foo/fooz": {},
+					"bar/barz": {},
+				},
+			},
+			args: args{
+				prefix: "foobar",
+			},
+			want: map[string]analyzer.FileData{},
+		},
+		{
+			name: "match and ignore prefix",
+			fields: fields{
+				data: map[string]analyzer.FileData{
+					"var/lib/dpkg":          {},
+					"var/lib/dpkg/status.d": {},
+					"var/lib/dpkg/status.d/foo.json": {
+						Contents: []byte("foo.json"),
+					},
+					"var/lib/dpkg/status.d/subdir/bar.json": {
+						Contents: []byte("bar.json"),
+					},
+				},
+			},
+			args: args{
+				prefix: "var/lib/dpkg/status.d",
+			},
+			want: map[string]analyzer.FileData{
+				"var/lib/dpkg/status.d/foo.json": {
+					Contents: []byte("foo.json"),
+				},
+				"var/lib/dpkg/status.d/subdir/bar.json": {
+					Contents: []byte("bar.json"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := LayerFiles{
+				data:    tt.fields.data,
+				links:   tt.fields.links,
+				removed: tt.fields.removed,
+			}
+			assert.Equalf(t, tt.want, f.GetFilesPrefix(tt.args.prefix), "GetFilesPrefix(%v)", tt.args.prefix)
+		})
+	}
+}

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/elf"
 	"github.com/stackrox/scanner/pkg/ioutils"
 	"github.com/stackrox/scanner/pkg/matcher"
@@ -164,7 +165,7 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 		// Extract the element
 		switch hdr.Typeflag {
 		case tar.TypeReg, tar.TypeLink:
-			var fileData FileData
+			var fileData analyzer.FileData
 
 			executable, _ := executableMatcher.Match(filename, hdr.FileInfo(), contents)
 			if hdr.Size > maxELFExecutableFileSize {
@@ -223,7 +224,7 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 			// Do not bother saving the contents,
 			// and directories are NOT considered executable.
 			// However, add to the map, so the entry will exist.
-			files.data[filename] = FileData{}
+			files.data[filename] = analyzer.FileData{}
 		}
 	}
 	files.detectRemovedFiles()

--- a/pkg/tarutil/tarutil_test.go
+++ b/pkg/tarutil/tarutil_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/matcher"
 	"github.com/stretchr/testify/assert"
 )
@@ -111,7 +112,7 @@ func TestExtractWithSymlink(t *testing.T) {
 	}
 
 	files, err := ExtractFiles(f, matcher.NewPrefixAllowlistMatcher(""))
-	base := LayerFiles{data: make(map[string]FileData), links: map[string]string{"lib64": "l1"}}
+	base := LayerFiles{data: make(map[string]analyzer.FileData), links: map[string]string{"lib64": "l1"}}
 	files.MergeBaseAndResolveSymlinks(&base)
 	assert.NoError(t, err)
 	assert.Len(t, files.data, 9)


### PR DESCRIPTION
This PR slightly modifies the interface used to explore the image filesystem during analysis.  It replaces the `tarutil.LayerFiles` with an interface and introduces methods where its implementation detail leaks.  It also moves the interface and supporting type `tarutil.FileData` into the `analyzer` package. We are doing this to support node scanning.

In container image analysis, image content is retrieved as tarballs from registries, and streamed through the network.  Currently, `tarutil.LayerFiles` exists to encapsulate tarball manipulation and allow in-memory random access to intermediate image (layer) files[^1].  Random access to image content is necessary for O.S.-based package analysis because the details we want can only be identified by looking at multiple files in the intermediate images[^2].  For example, listing rpm packages require access to the rpm database, content manifests, and executable files.

This work paves the way for a different implementation of `analyzer.Files` based on an actual filesystem.  A hypothetical `nodescanning.FilesystemFiles`, or similar, will retrieve data from mounted volumes in the node scanning container rather than an image layer tar archive.

Now, the underlying file data source is already randomly accessible, so why do we need a `LayerFiles` in node scanning?  If we provide an `Layerfiles` we can reuse the same exact O.S. package detection and analysis code.  We don't necessarily need to store all contents in memory like intermediate images, but we need to find a way to handle errors gracefully since `FileData` hides them. A discussion to happen in a subsequent PR.

[^1]: This is not needed for language component analysis since each language component file is analyzed individually to identify components. But we still use the "image file map" to coordinate the information with O.S.-level components.

[^2]: With `LayerFiles`, the analyzer can randomly check for file existence or retrieve its content or metadata.  But not all the files added or removed from a layer are put into the `LayerFiles` map.  Instead, we filter them based on filename patterns and file attributes.  [A step delegated to "matchers"](https://github.com/stackrox/scanner/blob/15cccdf47932743b5aec81ef92e10510acd46d04/worker.go#L230).
