### PR TITLE
ROX-11315: Disable RHEL9 scanning

### DIFF
--- a/e2etests/grpc_full_test.go
+++ b/e2etests/grpc_full_test.go
@@ -148,7 +148,7 @@ func TestGRPCGetImageVulnerabilities(t *testing.T) {
 	conn := connectToScanner(t)
 	client := v1.NewImageScanServiceClient(conn)
 
-	for _, testCase := range testCases {
+	for _, testCase := range getEnabledTestCases() {
 		imgComponentsResp, err := client.GetImageComponents(context.Background(), &v1.GetImageComponentsRequest{
 			Image: testCase.image,
 			Registry: &v1.RegistryData{

--- a/e2etests/grpc_test.go
+++ b/e2etests/grpc_test.go
@@ -19,7 +19,11 @@ func TestGRPCGetImageComponents(t *testing.T) {
 	conn := connectToScanner(t)
 	client := v1.NewImageScanServiceClient(conn)
 
-	for _, testCase := range testCases {
+	for _, testCase := range getEnabledTestCases() {
+		// Only run test cases for selected features if they are enabled.
+		if !testCase.requiredFeatureFlag.Enabled() {
+			continue
+		}
 		t.Run(testCase.image, func(t *testing.T) {
 			imgComponentsResp, err := client.GetImageComponents(context.Background(), &v1.GetImageComponentsRequest{
 				Image: testCase.image,

--- a/e2etests/sanity_test.go
+++ b/e2etests/sanity_test.go
@@ -127,7 +127,7 @@ func verifyImageHasExpectedFeatures(t *testing.T, client *client.Clairify, test 
 func TestImageSanity(t *testing.T) {
 	cli := client.New(getScannerHTTPEndpoint(), true)
 
-	for _, testCase := range testCases {
+	for _, testCase := range getEnabledTestCases() {
 		t.Run(testCase.image, func(t *testing.T) {
 			verifyImageHasExpectedFeatures(t, cli, testCase, &types.ImageRequest{Image: testCase.image, Registry: testCase.registry, UncertifiedRHELScan: testCase.uncertifiedRHEL})
 		})

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -9,6 +9,7 @@ import (
 	apiV1 "github.com/stackrox/scanner/api/v1"
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
 	"github.com/stackrox/scanner/pkg/component"
+	"github.com/stackrox/scanner/pkg/features"
 )
 
 type testCase struct {
@@ -23,6 +24,8 @@ type testCase struct {
 	onlyCheckSpecifiedVulns  bool
 	uncertifiedRHEL          bool
 	checkProvidedExecutables bool
+	// If assigned a features.FeatureFlag, only enable the test if it is enabled.
+	requiredFeatureFlag features.FeatureFlag
 }
 
 var testCases = []testCase{
@@ -3383,6 +3386,7 @@ var testCases = []testCase{
 		},
 	},
 	{
+		requiredFeatureFlag:     features.RHEL9Scanning,
 		image:                   "ubi9/ubi:9.0.0-1576@sha256:f22a438f4967419bd477c648d25ed0627f54b81931d0143dc45801c8356bd379",
 		namespace:               "rhel:9",
 		onlyCheckSpecifiedVulns: true,
@@ -3449,4 +3453,17 @@ For more details about the security issue(s), including the impact, a CVSS score
 			},
 		},
 	},
+}
+
+// getEnabledTestCases returns the enabled test cases from the list of defined test cases.
+func getEnabledTestCases() []testCase {
+	cases := testCases[:0]
+	for _, tc := range testCases {
+		// We filter out test cases that depend on feature flags that are disabled.
+		if tc.requiredFeatureFlag != nil && !tc.requiredFeatureFlag.Enabled() {
+			continue
+		}
+		cases = append(cases, tc)
+	}
+	return cases
 }

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -4,5 +4,5 @@ var (
 	// ContinueUnknownOS defines if scanning should continue upon detecting unknown OS.
 	ContinueUnknownOS = registerFeature("Enable continuation upon detecting unknown OS", "ROX_CONTINUE_UNKNOWN_OS", true)
 	// RHEL9Scanning enables support for scanning RHEL9-based images.
-	RHEL9Scanning = registerFeature("Enable support for scanning RHEL9 images", "ROX_RHEL9_SCANNING", true)
+	RHEL9Scanning = registerFeature("Enable support for scanning RHEL9 images", "ROX_RHEL9_SCANNING", false)
 )


### PR DESCRIPTION
Disable RHEL9 scanning support. Leave E2E tests behind the feature flag.

Unfortunately, Red Hat ACS builds are tied to Stackrox, and currently, there are difficulties running the RHEL9 scanning code downstream. To not block downstream releases while we address the difficulties we are reverting back RHEL9 support to disabled.
 