### PR TITLE
ROX-12238: Isolate O.S. matchers to re-use by node scanning

### DIFF
--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -77,22 +77,22 @@ func (m *allowlistMatcher) GetCommonPrefixDirs() []string {
 // referenced. It does it by doing creating a trie-like structure with the
 // directory tree filtering paths with only single-children nodes.
 func findCommonDirPrefixes(prefixes []string) []string {
-	pre := make(map[string]set.StringSet)
+	prefixToSubdirs := make(map[string]set.StringSet)
 	for _, d := range prefixes {
 		for d != "" {
 			p, _ := path.Split(strings.TrimSuffix(d, "/"))
-			s := pre[p]
+			s := prefixToSubdirs[p]
 			s.Add(d)
-			pre[p] = s
+			prefixToSubdirs[p] = s
 			d = p
 		}
 	}
 	// Work on one step below root.
-	firstLevelDirs := pre[""].AsSlice()
+	firstLevelDirs := prefixToSubdirs[""].AsSlice()
 	ret := firstLevelDirs[:0]
 	for _, d := range firstLevelDirs {
-		for len(pre[d]) == 1 {
-			d = pre[d].GetArbitraryElem()
+		for len(prefixToSubdirs[d]) == 1 {
+			d = prefixToSubdirs[d].GetArbitraryElem()
 		}
 		d, _ := path.Split(d)
 		ret = append(ret, d)

--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -4,10 +4,12 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
 
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/scanner/pkg/whiteout"
 )
 
@@ -20,23 +22,82 @@ type Matcher interface {
 	Match(fullPath string, fileInfo os.FileInfo, contents io.ReaderAt) (matches bool, extract bool)
 }
 
+// PrefixMatcher is a matcher that uses file prefixes.
+type PrefixMatcher interface {
+	Matcher
+
+	// GetCommonPrefixDirs list all directories from all the prefixes used in this
+	// matcher, and returns a list of common directories in all of them, up to one
+	// level below the root dir, e.g. prefixes are {"a/b/f", "a/c/f", "b/c/"} the
+	// common prefix list is {"a/", "b/c/"}. The returned directories will always be
+	// terminated with /. If a name is not terminated by a slash it is considered a
+	// file and ignored. Example:
+	//
+	// Prefixes:
+	//   - var/lib/rpm/
+	//   - var/lib/dpkg/
+	//   - root/buildinfo/
+	//   - usr/bin
+	//   - usr/bin/bash
+	//   - etc/apt.sources
+	//
+	// Output:
+	//   - var/lib/
+	//   - root/buildinfo/
+	//   - usr/
+	//   - etc/
+	GetCommonPrefixDirs() []string
+}
+
 type allowlistMatcher struct {
 	allowlist []string
 }
 
-// NewPrefixAllowlistMatcher returns a matcher that matches all filenames which have any
-// of the passed paths as a prefix.
-func NewPrefixAllowlistMatcher(allowlist ...string) Matcher {
+// NewPrefixAllowlistMatcher returns a prefix matcher that matches all filenames
+// which have any of the passed paths as a prefix.
+func NewPrefixAllowlistMatcher(allowlist ...string) PrefixMatcher {
 	return &allowlistMatcher{allowlist: allowlist}
 }
 
-func (w *allowlistMatcher) Match(fullPath string, _ os.FileInfo, _ io.ReaderAt) (matches bool, extract bool) {
-	for _, s := range w.allowlist {
+func (m *allowlistMatcher) Match(fullPath string, _ os.FileInfo, _ io.ReaderAt) (matches bool, extract bool) {
+	for _, s := range m.allowlist {
 		if strings.HasPrefix(fullPath, s) {
 			return true, true
 		}
 	}
 	return false, false
+}
+
+func (m *allowlistMatcher) GetCommonPrefixDirs() []string {
+	return findCommonDirPrefixes(m.allowlist)
+}
+
+// findCommonDirPrefixes goes over all prefixes, steps one level down from the
+// root directory, and returns exactly one common prefix per first level dir
+// referenced. It does it by doing creating a trie-like structure with the
+// directory tree filtering paths with only single-children nodes.
+func findCommonDirPrefixes(prefixes []string) []string {
+	pre := make(map[string]set.StringSet)
+	for _, d := range prefixes {
+		for d != "" {
+			p, _ := path.Split(strings.TrimSuffix(d, "/"))
+			s := pre[p]
+			s.Add(d)
+			pre[p] = s
+			d = p
+		}
+	}
+	// Work on one step below root.
+	firstLevelDirs := pre[""].AsSlice()
+	ret := firstLevelDirs[:0]
+	for _, d := range firstLevelDirs {
+		for len(pre[d]) == 1 {
+			d = pre[d].GetArbitraryElem()
+		}
+		d, _ := path.Split(d)
+		ret = append(ret, d)
+	}
+	return ret
 }
 
 type whiteoutMatcher struct{}

--- a/pkg/matcher/matcher_test.go
+++ b/pkg/matcher/matcher_test.go
@@ -199,3 +199,82 @@ func TestAndMatcher(t *testing.T) {
 	assert.False(t, match)
 	assert.False(t, extract)
 }
+
+func Test_findCommonDirPrefixes(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefixes []string
+		want     []string
+	}{
+		{
+			name: "happy case",
+			prefixes: []string{
+				"bin/[",
+				"bin/busybox",
+				"etc/alpine-release",
+				"etc/apt/sources.list",
+				"etc/centos-release",
+				"etc/lsb-release",
+				"etc/oracle-release",
+				"etc/os-release",
+				"etc/os-release",
+				"etc/redhat-release",
+				"etc/system-release",
+				"lib/apk/db/installed",
+				"root/buildinfo/content_manifests",
+				"usr/lib/os-release",
+				"var/lib/dpkg/status",
+				"var/lib/rpm/Packages",
+				"var/lib/rpm/Packages",
+			},
+			want: []string{
+				"bin/",
+				"etc/",
+				"lib/apk/db/",
+				"root/buildinfo/",
+				"usr/lib/",
+				"var/lib/",
+			},
+		},
+		{
+			name: "prefixes with directories",
+			prefixes: []string{
+				"foo/bar/",
+				"foo/bar/ok/",
+				"foo/bar/nook/",
+				"foo/bar/nook/",
+			},
+			want: []string{"foo/bar/"},
+		},
+		{
+			name: "non-slash are considered files",
+			prefixes: []string{
+				"usr/bin",
+				"usr/bin/",
+			},
+			want: []string{"usr/"},
+		},
+		{
+			name: "example from doc comment",
+			prefixes: []string{
+				"var/lib/rpm/",
+				"var/lib/dpkg/",
+				"root/buildinfo/",
+				"usr/bin",
+				"usr/bin/bash",
+				"etc/apt.sources",
+			},
+			want: []string{
+				"var/lib/",
+				"root/buildinfo/",
+				"usr/",
+				"etc/",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want, findCommonDirPrefixes(tt.prefixes))
+		})
+	}
+}


### PR DESCRIPTION
Create singletons for two different types of "matcher" (O.S. features and active vulnerability), and add a new matcher interface called `PrefixMatcher` that offers a method to retrieve the list of directories to look for files.

Node scanning will exclusively use the O.S. matcher. And the list of directories will be used by the node scanner to determine which directories to walk and extract files from. This allows node scanning to be specific on the directories to walk and ignore the other files that are irrelevant during the extraction. Notice that, some analyzers (also known as detectors) do not have a deterministic set of files to scan, they look at prefixes, we still need to walk in directories. 

## Tests

UT and CI
