### PR TITLE
fix E2E test panic and test duplication

### DIFF
--- a/e2etests/grpc_test.go
+++ b/e2etests/grpc_test.go
@@ -20,10 +20,6 @@ func TestGRPCGetImageComponents(t *testing.T) {
 	client := v1.NewImageScanServiceClient(conn)
 
 	for _, testCase := range getEnabledTestCases() {
-		// Only run test cases for selected features if they are enabled.
-		if !testCase.requiredFeatureFlag.Enabled() {
-			continue
-		}
 		t.Run(testCase.image, func(t *testing.T) {
 			imgComponentsResp, err := client.GetImageComponents(context.Background(), &v1.GetImageComponentsRequest{
 				Image: testCase.image,

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3464,7 +3464,7 @@ For more details about the security issue(s), including the impact, a CVSS score
 // getEnabledTestCases returns the enabled test cases from the list of defined test cases.
 func getEnabledTestCases() []testCase {
 	once.Do(func() {
-		cases := testCases
+		cases := testCases[:0]
 		for _, tc := range testCases {
 			// We filter out test cases that depend on feature flags that are disabled.
 			if tc.requiredFeatureFlag != nil && !tc.requiredFeatureFlag.Enabled() {


### PR DESCRIPTION
E2E tests were panicking due to https://github.com/stackrox/scanner/blob/29bd3638e197a6bae24974b19b7d8f22111e3bb8/e2etests/grpc_test.go#L24, so removing that line, as it is not necessary.

Also, fixing the potential for running duplicate tests upon multiple calls to `getEnabledTestCases()`