### PR TITLE
ROX-12238: Add node analysis package

### DIFF
--- a/cmd/clair/config.go
+++ b/cmd/clair/config.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/scanner/api"
 	"github.com/stackrox/scanner/database"
-	"github.com/stackrox/scanner/pkg/tarutil"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/updater"
 	"gopkg.in/yaml.v2"
 )
@@ -64,9 +64,9 @@ func DefaultConfig() Config {
 			GRPCPort:  8443,
 		},
 		LogLevel:                       "info",
-		MaxExtractableFileSizeMB:       tarutil.DefaultMaxExtractableFileSizeMB,
-		MaxELFExecutableFileSizeMB:     tarutil.DefaultMaxELFExecutableFileSizeMB,
-		MaxImageFileReaderBufferSizeMB: tarutil.DefaultMaxLazyReaderBufferSizeMB,
+		MaxExtractableFileSizeMB:       analyzer.DefaultMaxExtractableFileSizeMB,
+		MaxELFExecutableFileSizeMB:     analyzer.DefaultMaxELFExecutableFileSizeMB,
+		MaxImageFileReaderBufferSizeMB: analyzer.DefaultMaxLazyReaderBufferSizeMB,
 		CentralEndpoint:                "https://central.stackrox.svc",
 		SensorEndpoint:                 "https://sensor.stackrox.svc",
 	}

--- a/cmd/clair/config_test.go
+++ b/cmd/clair/config_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/stackrox/scanner/api"
-	"github.com/stackrox/scanner/pkg/tarutil"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +23,7 @@ func TestLoadConfig(t *testing.T) {
 	}, cfg.API)
 
 	assert.Equal(t, 5*time.Minute, cfg.Updater.Interval)
-	assert.Equal(t, int64(tarutil.DefaultMaxExtractableFileSizeMB), cfg.MaxExtractableFileSizeMB)
+	assert.Equal(t, int64(analyzer.DefaultMaxExtractableFileSizeMB), cfg.MaxExtractableFileSizeMB)
 	assert.Equal(t, int64(400), cfg.MaxELFExecutableFileSizeMB)
 	assert.Equal(t, int64(150), cfg.MaxImageFileReaderBufferSizeMB)
 	assert.Equal(t, "https://central.stackrox.svc", cfg.CentralEndpoint)

--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -40,13 +40,13 @@ import (
 	"github.com/stackrox/scanner/cpe/nvdtoolscache"
 	"github.com/stackrox/scanner/database"
 	k8scache "github.com/stackrox/scanner/k8s/cache"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/clairify/metrics"
 	"github.com/stackrox/scanner/pkg/clairify/server"
 	"github.com/stackrox/scanner/pkg/env"
 	"github.com/stackrox/scanner/pkg/formatter"
 	"github.com/stackrox/scanner/pkg/ioutils"
 	"github.com/stackrox/scanner/pkg/repo2cpe"
-	"github.com/stackrox/scanner/pkg/tarutil"
 	"github.com/stackrox/scanner/pkg/updater"
 	"github.com/stackrox/scanner/pkg/version"
 	"golang.org/x/sys/unix"
@@ -227,19 +227,19 @@ func main() {
 
 	// Set the max extractable file size from the config.
 	if config.MaxExtractableFileSizeMB > 0 {
-		tarutil.SetMaxExtractableFileSize(config.MaxExtractableFileSizeMB * 1024 * 1024)
+		analyzer.SetMaxExtractableFileSize(config.MaxExtractableFileSizeMB * 1024 * 1024)
 		log.Infof("Max extractable file size set to %d MB", config.MaxExtractableFileSizeMB)
 	}
 
 	// Set the max ELF executable file size from the config.
 	if config.MaxELFExecutableFileSizeMB > 0 {
-		tarutil.SetMaxELFExecutableFileSize(config.MaxELFExecutableFileSizeMB * 1024 * 1024)
+		analyzer.SetMaxELFExecutableFileSize(config.MaxELFExecutableFileSizeMB * 1024 * 1024)
 		log.Infof("Max ELF executable file size set to %d MB", config.MaxELFExecutableFileSizeMB)
 	}
 
 	// Set the max lazy reader buffer size from the config.
 	if config.MaxImageFileReaderBufferSizeMB > 0 {
-		tarutil.SetMaxLazyReaderBufferSize(config.MaxImageFileReaderBufferSizeMB * 1024 * 1024)
+		analyzer.SetMaxLazyReaderBufferSize(config.MaxImageFileReaderBufferSizeMB * 1024 * 1024)
 		log.Infof("Max image file reader buffer size set to %d MB", config.MaxImageFileReaderBufferSizeMB)
 	}
 

--- a/localdev/main.go
+++ b/localdev/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/scanner/cpe/nvdtoolscache"
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/imagefmt"
+	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/component"
 	"github.com/stackrox/scanner/pkg/tarutil"
 	"github.com/stackrox/scanner/singletons/requiredfilenames"
@@ -78,8 +79,8 @@ func analyzeLocalImage(path string) {
 
 	// Extract
 	var matcher manifestMatcher
-	tarutil.SetMaxExtractableFileSize(1024 * 1024 * 1024)
-	tarutil.SetMaxELFExecutableFileSize(1024 * 1024 * 1024)
+	analyzer.SetMaxExtractableFileSize(1024 * 1024 * 1024)
+	analyzer.SetMaxELFExecutableFileSize(1024 * 1024 * 1024)
 	filemap, err := tarutil.ExtractFiles(f, &matcher)
 	if err != nil {
 		panic(err)

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -8,16 +8,79 @@ import (
 	"github.com/stackrox/scanner/pkg/elf"
 )
 
+const (
+	// DefaultMaxELFExecutableFileSizeMB is the default value for the max ELF executable file we analyze.
+	DefaultMaxELFExecutableFileSizeMB = 800
+
+	// DefaultMaxLazyReaderBufferSizeMB is the default maximum lazy reader buffer size. Any file data beyond this
+	// limit is backed by temporary files on disk.
+	DefaultMaxLazyReaderBufferSizeMB = 100
+
+	// DefaultMaxExtractableFileSizeMB is the default value for the max extractable file size.
+	DefaultMaxExtractableFileSizeMB = 200
+
+	// ElfHeaderSize is the size of an ELF header based on https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html.
+	ElfHeaderSize = 16
+)
+
+var (
+	maxExtractableFileSize   int64 = DefaultMaxExtractableFileSizeMB * 1024 * 1024
+	maxELFExecutableFileSize int64 = DefaultMaxELFExecutableFileSizeMB * 1024 * 1024
+	maxLazyReaderBufferSize  int64 = DefaultMaxLazyReaderBufferSizeMB * 1024 * 1024
+)
+
+// SetMaxExtractableFileSize sets the max extractable file size. It is NOT
+// thread-safe, and callers must ensure that it is called only when no scans are
+// in progress (ex: during initialization). See comments on the
+// maxExtractableFileSize variable for more details on its purpose.
+func SetMaxExtractableFileSize(val int64) {
+	maxExtractableFileSize = val
+}
+
+// GetMaxExtractableFileSize returns the maximum size of a single file within a
+// tarball that will be extracted. This protects against malicious files that may
+// be used in an attempt to perform a Denial of Service attack.
+func GetMaxExtractableFileSize() int64 {
+	return maxExtractableFileSize
+}
+
+// GetMaxLazyReaderBufferSize returns the maximum lazy reader buffer size. Any
+// file data beyond this limit is backed by temporary files on disk.
+func GetMaxLazyReaderBufferSize() int64 {
+	return maxLazyReaderBufferSize
+}
+
+// SetMaxLazyReaderBufferSize sets the max lazy reader buffer size. It is NOT
+// thread-safe, and callers must ensure that it is called only when no scans are
+// in progress (ex: during initialization). See comments on the
+// maxLazyReaderBufferSize variable for more details on its purpose.
+func SetMaxLazyReaderBufferSize(val int64) {
+	maxLazyReaderBufferSize = val
+}
+
+// GetMaxELFExecutableFileSize returns the maximum size of an ELF executable file
+// tarball that will be analyzed.
+func GetMaxELFExecutableFileSize() int64 {
+	return maxELFExecutableFileSize
+}
+
+// SetMaxELFExecutableFileSize sets the max ELF executable file size. It is NOT
+// thread-safe, and callers must ensure that it is called only when no scans are
+// in progress (ex: during initialization). See comments on the
+// maxELFExecutableFileSize variable for more details on its purpose.
+func SetMaxELFExecutableFileSize(val int64) {
+	maxELFExecutableFileSize = val
+}
+
 // Analyzer defines the functions for analyzing images and extracting the components present in them.
 type Analyzer interface {
 	ProcessFile(filePath string, fi os.FileInfo, contents io.ReaderAt) []*component.Component
 }
 
-// Files stores information on a sub-set of files being analyzed from an image.
+// Files stores information on a sub-set of files being analyzed.
 // It provides methods to retrieve information from individual files, or list
 // them based on some prefix.
 type Files interface {
-
 	// Get returns the data about a file if it exists, otherwise set exists to false.
 	Get(path string) (data FileData, exists bool)
 

--- a/pkg/analyzer/analyzertest/fake_file.go
+++ b/pkg/analyzer/analyzertest/fake_file.go
@@ -16,16 +16,18 @@ type FakeFile interface {
 }
 
 // NewFakeFile creates a new fake file from the given path and contents.
-func NewFakeFile(fullPath string, contents []byte) FakeFile {
+func NewFakeFile(fullPath string, contents []byte, mode os.FileMode) FakeFile {
 	return fakeFile{
 		fullPath: fullPath,
 		contents: contents,
+		mode:     mode,
 	}
 }
 
 type fakeFile struct {
 	fullPath string
 	contents []byte
+	mode     os.FileMode
 }
 
 func (f fakeFile) FullPath() string {
@@ -45,7 +47,7 @@ func (f fakeFile) Name() string {
 }
 
 func (f fakeFile) Mode() os.FileMode {
-	return 0644
+	return f.mode
 }
 
 func (f fakeFile) IsDir() bool {

--- a/pkg/analyzer/gem/analyzer_test.go
+++ b/pkg/analyzer/gem/analyzer_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMatching(t *testing.T) {
 	a := Analyzer()
-	f := analyzertest.NewFakeFile("usr/local/bundle/specifications/rails-4.2.5.1.gemspec", []byte(validRailsSpec))
+	f := analyzertest.NewFakeFile("usr/local/bundle/specifications/rails-4.2.5.1.gemspec", []byte(validRailsSpec), 0644)
 	cs := a.ProcessFile(f.FullPath(), f.FileInfo(), f.Contents())
 	assert.Len(t, cs, 1)
 }

--- a/pkg/analyzer/nodes/node.go
+++ b/pkg/analyzer/nodes/node.go
@@ -1,0 +1,211 @@
+package nodes
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	clair "github.com/stackrox/scanner"
+	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/pkg/analyzer"
+	"github.com/stackrox/scanner/pkg/component"
+	"github.com/stackrox/scanner/pkg/matcher"
+	"github.com/stackrox/scanner/pkg/metrics"
+	"github.com/stackrox/scanner/singletons/requiredfilenames"
+)
+
+// Information about extracted files.
+type fileData struct {
+	// If true, the file has executable permissions.
+	isExecutable bool
+	// If true, contents should be extracted from the filesystem.
+	isExtractable bool
+}
+
+// filesMap is an analyzer.Files implementation mapping files extracted from
+// filesystem directories. In this implementation the file content is read lazily
+// when calls to Get() are made. If an error occurs during content read the map
+// will stop returning entries and the error will be available at readErr().
+// Analyzer are expected to handle missing files gracefully during analysis and
+// check readErr() to confirm all potential data was read.
+type filesMap struct {
+	// Root directory where all the files, and their relative paths, reside.
+	root string
+	// Map of extracted file information keyed by their relative file paths.
+	files map[string]*fileData
+	// Last error found when reading files contents.
+	readError error
+}
+
+// Components contains the result of a node analyzis, listing the O.S. namespace,
+// components and language components.
+type Components struct {
+	OSNamespace             *database.Namespace
+	OSComponents            []database.FeatureVersion
+	CertifiedRHELComponents *database.RHELv2Components
+	LanguageComponents      []*component.Component
+}
+
+// Analyze performs analysis of node's hosts filesystem and return the detected components.
+func Analyze(nodeName, rootFSdir string, uncertifiedRHEL bool) (Components, error) {
+	// Currently, the node analyzer can only identify operating system components
+	// without active vulnerability, so we use the OS matcher.
+	matcher := requiredfilenames.SingletonOSMatcher()
+	files, err := extractFilesFromDirectory(rootFSdir, matcher)
+	if err != nil {
+		return Components{}, err
+	}
+	c := Components{}
+	c.OSNamespace, c.OSComponents, c.CertifiedRHELComponents, _, err =
+		clair.DetectFromFiles(files, nodeName, nil, nil, uncertifiedRHEL)
+	if err != nil {
+		return Components{}, nil
+	}
+	// File reading errors during analysis failed are not exposed to DetectFiles,
+	// hence we check it and if there were any we fail the analysis.
+	if err := files.readErr(); err != nil {
+		return Components{}, errors.Wrapf(err, "analysis of node %q failed", nodeName)
+	}
+	return c, nil
+}
+
+// extractFilesFromDirectory extracts files from the specified root directory
+// using a file matcher.
+func extractFilesFromDirectory(root string, matcher matcher.PrefixMatcher) (*filesMap, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid root path %q", root)
+	}
+	n := &filesMap{
+		root:  absRoot,
+		files: make(map[string]*fileData),
+	}
+	m := metrics.FileExtractionMetrics{}
+	for _, dir := range matcher.GetCommonPrefixDirs() {
+		if err := n.addFiles(filepath.FromSlash(dir), matcher, &m); err != nil {
+			return nil, errors.Wrapf(err, "failed to match filesMap at %q (at %q)", dir, n.root)
+		}
+	}
+	m.Emit()
+	return n, nil
+}
+
+// addFiles searches the directory for files using the matcher and adds them to the file map.
+func (n *filesMap) addFiles(dir string, matcher matcher.Matcher, m *metrics.FileExtractionMetrics) error {
+	logrus.WithFields(logrus.Fields{
+		"root":      n.root,
+		"directory": dir,
+	}).Info("add files from directory")
+	return filepath.WalkDir(filepath.Join(n.root, dir), func(fullPath string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			if filesIsNotAccessible(err) {
+				m.ErrorCount()
+				return nil
+			}
+			return errors.Wrapf(err, "failed to read %q", fullPath)
+		}
+		relPath, err := filepath.Rel(n.root, fullPath)
+		if err != nil {
+			return errors.Wrapf(err, "walking %q", dir)
+		}
+		path := filepath.ToSlash(relPath)
+		f, err := extractFile(path, entry, matcher, m)
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"root":          n.root,
+				"directory":     dir,
+				"relative_path": relPath,
+			}).Error("extract file")
+			return err
+		}
+		if f != nil {
+			n.files[path] = f
+		}
+		return nil
+	})
+}
+
+// filesIsNotAccessible returns true if the error means the file cannot be read.
+func filesIsNotAccessible(err error) bool {
+	return errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrPermission)
+}
+
+// extractFile extracts data from the given directory entry, if granted by the
+// path matcher, and if it passes safety checks. Otherwise, returns nil.
+func extractFile(path string, entry fs.DirEntry, pathMatcher matcher.Matcher, m *metrics.FileExtractionMetrics) (*fileData, error) {
+	// Ignore all directories.
+	if entry.IsDir() {
+		return nil, nil
+	}
+	fileInfo, err := entry.Info()
+	if err != nil {
+		if filesIsNotAccessible(err) {
+			m.ErrorCount()
+			return nil, nil
+		}
+		// We assume that other errors reflect underlying problems with the filesystem
+		// worth failing the whole extraction.
+		return nil, err
+	}
+	m.FileCount()
+	// FIXME No matcher actually uses the file contents, except the matcher for
+	//       language components, which is not currently used by directory scans, hence we
+	//       offer nil.  This will break if a language component matcher (analyzer) is used.
+	matches, isExtractable := pathMatcher.Match(path, fileInfo, nil)
+	if !matches {
+		return nil, nil
+	}
+	m.MatchCount()
+	// File size limit check.
+	if isExtractable && fileInfo.Size() > analyzer.GetMaxExtractableFileSize() {
+		logrus.Errorf("skipping file %q (%d bytes): size is greater than maxExtractableFileSize of %d MiB",
+			path, fileInfo.Size(), analyzer.GetMaxExtractableFileSize()/1024/1024)
+		return nil, nil
+	}
+	return &fileData{
+		isExecutable:  matcher.IsFileExecutable(fileInfo),
+		isExtractable: isExtractable,
+	}, nil
+}
+
+// Get implements analyzer.Files
+func (n *filesMap) Get(path string) (analyzer.FileData, bool) {
+	// When a previous read error has happened, we act as if all the files map is
+	// empty. Analyzer are expected to handle it gracefully.
+	if f, ok := n.files[path]; n.readError == nil && ok {
+		fileData := analyzer.FileData{Executable: f.isExecutable}
+		if !f.isExtractable {
+			return fileData, true
+		}
+		fileData.Contents, n.readError = os.ReadFile(filepath.Join(n.root, filepath.FromSlash(path)))
+		if n.readError == nil {
+			return fileData, true
+		}
+	}
+	return analyzer.FileData{}, false
+}
+
+// GetFilesPrefix implements analyzer.Files
+func (n *filesMap) GetFilesPrefix(prefix string) (filesMap map[string]analyzer.FileData) {
+	filesMap = make(map[string]analyzer.FileData)
+	for name := range n.files {
+		if strings.HasPrefix(name, prefix) && name != prefix {
+			data, exists := n.Get(name)
+			if exists {
+				filesMap[name] = data
+			}
+		}
+	}
+	return
+}
+
+// readErr returns the first error encountered when reading file content, and
+// resets the error, enabling re-scans using the same map.
+func (n *filesMap) readErr() error {
+	err := n.readError
+	n.readError = nil
+	return err
+}

--- a/pkg/analyzer/nodes/node_test.go
+++ b/pkg/analyzer/nodes/node_test.go
@@ -59,7 +59,7 @@ func Test_filesMap_extractFile(t *testing.T) {
 	type test struct {
 		name         string
 		args         args
-		wantFileData *fileData
+		wantFileData *fileMetadata
 		maxFileSize  int64
 		wantErr      assert.ErrorAssertionFunc
 	}
@@ -158,7 +158,7 @@ func Test_filesMap_extractFile(t *testing.T) {
 					return ff.FileInfo(), nil
 				}},
 			},
-			wantFileData: &fileData{
+			wantFileData: &fileMetadata{
 				isExecutable:  true,
 				isExtractable: true,
 			},
@@ -188,7 +188,7 @@ func Test_filesMap_Get(t *testing.T) {
 	testdata := filepath.Join(wd, "testdata")
 	type fields struct {
 		root      string
-		fileMap   map[string]*fileData
+		fileMap   map[string]*fileMetadata
 		readError error
 	}
 	tests := []struct {
@@ -207,7 +207,7 @@ func Test_filesMap_Get(t *testing.T) {
 			name: "when file is not extractable then returns without content",
 			fields: fields{
 				root: "",
-				fileMap: map[string]*fileData{
+				fileMap: map[string]*fileMetadata{
 					"foo/bar.txt": {
 						isExecutable:  true,
 						isExtractable: false,
@@ -225,7 +225,7 @@ func Test_filesMap_Get(t *testing.T) {
 			name: "when file is in map and is extractable, should return with contents",
 			fields: fields{
 				root: filepath.Join(testdata, "rootfs-foo"),
-				fileMap: map[string]*fileData{
+				fileMap: map[string]*fileMetadata{
 					"etc/redhat-release": {
 						isExecutable:  false,
 						isExtractable: true,
@@ -243,7 +243,7 @@ func Test_filesMap_Get(t *testing.T) {
 			name: "when file is in map and is extractable but does not exist, then keep error",
 			fields: fields{
 				root: filepath.Join(testdata, "rootfs-foo"),
-				fileMap: map[string]*fileData{
+				fileMap: map[string]*fileMetadata{
 					"foo/does/not/exist": {
 						isExecutable:  false,
 						isExtractable: true,

--- a/pkg/analyzer/nodes/node_test.go
+++ b/pkg/analyzer/nodes/node_test.go
@@ -1,0 +1,310 @@
+package nodes
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/scanner/pkg/analyzer"
+	"github.com/stackrox/scanner/pkg/analyzer/analyzertest"
+	"github.com/stretchr/testify/assert"
+)
+
+type matcherMock struct {
+	matchFunc func(fullPath string, fileInfo os.FileInfo, contents io.ReaderAt) (matches bool, extract bool)
+}
+
+func (f matcherMock) Match(fullPath string, fileInfo os.FileInfo, contents io.ReaderAt) (bool, bool) {
+	if f.matchFunc == nil {
+		return false, false
+	}
+	return f.matchFunc(fullPath, fileInfo, contents)
+}
+
+type dirEntryMock struct {
+	name     string
+	isDir    bool
+	fileMode fs.FileMode
+	infoFunc func() (fs.FileInfo, error)
+}
+
+func (d dirEntryMock) Name() string {
+	return d.name
+}
+
+func (d dirEntryMock) IsDir() bool {
+	return d.isDir
+}
+
+func (d dirEntryMock) Type() fs.FileMode {
+	return d.fileMode
+}
+
+func (d dirEntryMock) Info() (fs.FileInfo, error) {
+	if d.infoFunc != nil {
+		return d.infoFunc()
+	}
+	return nil, nil
+}
+
+func Test_filesMap_extractFile(t *testing.T) {
+	type args struct {
+		fileMatcherMock matcherMock
+		path            string
+		entryMock       dirEntryMock
+	}
+	type test struct {
+		name         string
+		args         args
+		wantFileData *fileData
+		maxFileSize  int64
+		wantErr      assert.ErrorAssertionFunc
+	}
+	tests := []test{
+		{
+			name: "when path is dir then do nothing",
+			args: args{
+				fileMatcherMock: matcherMock{},
+				entryMock: dirEntryMock{
+					isDir: true,
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "when path does not exist then do nothing",
+			args: args{
+				fileMatcherMock: matcherMock{},
+				entryMock: dirEntryMock{
+					isDir: false,
+					infoFunc: func() (fs.FileInfo, error) {
+						return nil, fs.ErrNotExist
+					},
+				},
+			},
+			wantFileData: nil,
+			wantErr:      assert.NoError,
+		},
+		{
+			name: "when no permission to read file info then ignore error",
+			args: args{
+				fileMatcherMock: matcherMock{},
+				entryMock: dirEntryMock{
+					isDir: false,
+					infoFunc: func() (fs.FileInfo, error) {
+						return nil, fs.ErrPermission
+					},
+				},
+			},
+			wantFileData: nil,
+			wantErr:      assert.NoError,
+		},
+		{
+			name: "when failed to get file info then return error",
+			args: args{
+				fileMatcherMock: matcherMock{},
+				entryMock: dirEntryMock{
+					isDir: false,
+					infoFunc: func() (fs.FileInfo, error) {
+						return nil, fs.ErrInvalid // randomly picked
+					},
+				},
+			},
+			wantFileData: nil,
+			wantErr:      assert.Error,
+		},
+		{
+			name: "when file does not match then return nothing",
+			args: args{
+				fileMatcherMock: matcherMock{
+					matchFunc: func(_ string, _ os.FileInfo, _ io.ReaderAt) (bool, bool) {
+						return false, false
+					},
+				},
+			},
+			wantFileData: nil,
+			wantErr:      assert.NoError,
+		},
+		{
+			name:        "when file is extractable and size is bigger then the limit then return nothing",
+			maxFileSize: 1, // minimal size set to fail
+			args: args{
+				fileMatcherMock: matcherMock{
+					matchFunc: func(_ string, _ os.FileInfo, _ io.ReaderAt) (bool, bool) {
+						return true, true
+					},
+				},
+				entryMock: dirEntryMock{infoFunc: func() (fs.FileInfo, error) {
+					ff := analyzertest.NewFakeFile("foobar", []byte("foobar is too big"), 0644)
+					return ff.FileInfo(), nil
+				}},
+			},
+			wantFileData: nil,
+			wantErr:      assert.NoError,
+		},
+		{
+			name: "when file is extractable then return it",
+			args: args{
+				fileMatcherMock: matcherMock{
+					matchFunc: func(_ string, _ os.FileInfo, _ io.ReaderAt) (bool, bool) {
+						return true, true
+					},
+				},
+				entryMock: dirEntryMock{infoFunc: func() (fs.FileInfo, error) {
+					ff := analyzertest.NewFakeFile("foobar", []byte{}, 0755)
+					return ff.FileInfo(), nil
+				}},
+			},
+			wantFileData: &fileData{
+				isExecutable:  true,
+				isExtractable: true,
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.maxFileSize > 0 {
+				prevMaxFileSize := analyzer.GetMaxExtractableFileSize()
+				analyzer.SetMaxExtractableFileSize(tt.maxFileSize)
+				defer func() {
+					analyzer.SetMaxExtractableFileSize(prevMaxFileSize)
+				}()
+			}
+			got, err := extractFile(tt.args.path, tt.args.entryMock, tt.args.fileMatcherMock, nil)
+			if !tt.wantErr(t, err) {
+				return
+			}
+			assert.Equal(t, tt.wantFileData, got)
+		})
+	}
+}
+
+func Test_filesMap_Get(t *testing.T) {
+	wd, _ := os.Getwd()
+	testdata := filepath.Join(wd, "testdata")
+	type fields struct {
+		root      string
+		fileMap   map[string]*fileData
+		readError error
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		path         string
+		wantFileData analyzer.FileData
+		wantExists   bool
+		wantError    error
+	}{
+		{
+			name: "when path not in map then returns does not exist",
+			path: "whatever",
+		},
+		{
+			name: "when file is not extractable then returns without content",
+			fields: fields{
+				root: "",
+				fileMap: map[string]*fileData{
+					"foo/bar.txt": {
+						isExecutable:  true,
+						isExtractable: false,
+					},
+				},
+				readError: nil,
+			},
+			path: "foo/bar.txt",
+			wantFileData: analyzer.FileData{
+				Executable: true,
+			},
+			wantExists: true,
+		},
+		{
+			name: "when file is in map and is extractable, should return with contents",
+			fields: fields{
+				root: filepath.Join(testdata, "rootfs-foo"),
+				fileMap: map[string]*fileData{
+					"etc/redhat-release": {
+						isExecutable:  false,
+						isExtractable: true,
+					},
+				},
+				readError: nil,
+			},
+			path: "etc/redhat-release",
+			wantFileData: analyzer.FileData{
+				Contents: []byte("Some random red hat release that does not exist (X.Y) (foo bar)\n"),
+			},
+			wantExists: true,
+		},
+		{
+			name: "when file is in map and is extractable but does not exist, then keep error",
+			fields: fields{
+				root: filepath.Join(testdata, "rootfs-foo"),
+				fileMap: map[string]*fileData{
+					"foo/does/not/exist": {
+						isExecutable:  false,
+						isExtractable: true,
+					},
+				},
+				readError: nil,
+			},
+			path:         "foo/does/not/exist",
+			wantFileData: analyzer.FileData{},
+			wantExists:   false,
+			wantError:    os.ErrNotExist,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &filesMap{
+				root:      tt.fields.root,
+				files:     tt.fields.fileMap,
+				readError: tt.fields.readError,
+			}
+			gotFileData, gotExists := n.Get(tt.path)
+			assert.Equalf(t, tt.wantFileData, gotFileData, "Get(%v)", tt.path)
+			assert.Equalf(t, tt.wantExists, gotExists, "Get(%v)", tt.path)
+			if tt.wantError != nil {
+				assert.ErrorIs(t, n.readError, tt.wantError)
+			} else {
+				assert.NoError(t, n.readError)
+			}
+		})
+	}
+}
+
+func Test_filesMap_ReadErr(t *testing.T) {
+	type fields struct {
+		readError error
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "when error is set then return error and reset",
+			fields: fields{
+				readError: errors.New("foobar"),
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "when error is not set then return nil",
+			fields:  fields{},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &filesMap{
+				readError: tt.fields.readError,
+			}
+			tt.wantErr(t, n.readErr(), "readErr()")
+			assert.NoError(t, n.readError)
+		})
+	}
+}

--- a/pkg/analyzer/nodes/testdata/rootfs-foo/etc/redhat-release
+++ b/pkg/analyzer/nodes/testdata/rootfs-foo/etc/redhat-release
@@ -1,0 +1,1 @@
+Some random red hat release that does not exist (X.Y) (foo bar)

--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -59,8 +59,8 @@ func NewPrefixAllowlistMatcher(allowlist ...string) PrefixMatcher {
 	return &allowlistMatcher{allowlist: allowlist}
 }
 
-func (m *allowlistMatcher) Match(fullPath string, _ os.FileInfo, _ io.ReaderAt) (matches bool, extract bool) {
-	for _, s := range m.allowlist {
+func (w *allowlistMatcher) Match(fullPath string, _ os.FileInfo, _ io.ReaderAt) (matches bool, extract bool) {
+	for _, s := range w.allowlist {
 		if strings.HasPrefix(fullPath, s) {
 			return true, true
 		}
@@ -68,14 +68,10 @@ func (m *allowlistMatcher) Match(fullPath string, _ os.FileInfo, _ io.ReaderAt) 
 	return false, false
 }
 
-func (m *allowlistMatcher) GetCommonPrefixDirs() []string {
-	return findCommonDirPrefixes(m.allowlist)
+func (w *allowlistMatcher) GetCommonPrefixDirs() []string {
+	return findCommonDirPrefixes(w.allowlist)
 }
 
-// findCommonDirPrefixes goes over all prefixes, steps one level down from the
-// root directory, and returns exactly one common prefix per first level dir
-// referenced. It does it by doing creating a trie-like structure with the
-// directory tree filtering paths with only single-children nodes.
 func findCommonDirPrefixes(prefixes []string) []string {
 	prefixToSubdirs := make(map[string]set.StringSet)
 	for _, d := range prefixes {

--- a/pkg/metrics/extractfiles.go
+++ b/pkg/metrics/extractfiles.go
@@ -15,9 +15,9 @@ var (
 		Buckets: []float64{50, 100, 500, 1000},
 	})
 
-	fileExtractionErrorCountMetric = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "file_extraction_error_count",
-		Help:    "Number of files in an node filesystem scan that failed to read",
+	fileExtractionInaccessibleCountMetric = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "file_extraction_inaccessible_count",
+		Help:    "Number of matched files in an node filesystem scan that were not accessible for reading",
 		Buckets: []float64{50, 100, 500, 1000},
 	})
 )
@@ -26,13 +26,13 @@ func init() {
 	prometheus.MustRegister(
 		fileExtractionCountMetric,
 		fileExtractionMatchCountMetric,
-		fileExtractionErrorCountMetric,
+		fileExtractionInaccessibleCountMetric,
 	)
 }
 
 // FileExtractionMetrics tracks and emit node extraction metrics.
 type FileExtractionMetrics struct {
-	fileCount, matchCount, errorCount float64
+	fileCount, matchCount, inaccessibleCount float64
 }
 
 // FileCount increments the file count.
@@ -49,11 +49,11 @@ func (m *FileExtractionMetrics) MatchCount() {
 	}
 }
 
-// ErrorCount increments the file error count that were ignored and treated as
+// InaccessibleCount increments the file error count that were ignored and treated as
 // non-existent files.
-func (m *FileExtractionMetrics) ErrorCount() {
+func (m *FileExtractionMetrics) InaccessibleCount() {
 	if m != nil {
-		m.errorCount++
+		m.inaccessibleCount++
 	}
 }
 
@@ -62,7 +62,7 @@ func (m *FileExtractionMetrics) Emit() {
 	if m != nil {
 		fileExtractionCountMetric.Observe(m.matchCount)
 		fileExtractionMatchCountMetric.Observe(m.fileCount)
-		fileExtractionErrorCountMetric.Observe(m.errorCount)
+		fileExtractionInaccessibleCountMetric.Observe(m.inaccessibleCount)
 	}
 	*m = FileExtractionMetrics{}
 }

--- a/pkg/metrics/extractfiles.go
+++ b/pkg/metrics/extractfiles.go
@@ -1,0 +1,68 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	fileExtractionCountMetric = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "file_extraction_count",
+		Help:    "Number of files in a node filesystem scan",
+		Buckets: []float64{50, 100, 500, 1000},
+	})
+
+	fileExtractionMatchCountMetric = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "file_extraction_match_count",
+		Help:    "Number of matched files in an node filesystem scan",
+		Buckets: []float64{50, 100, 500, 1000},
+	})
+
+	fileExtractionErrorCountMetric = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "file_extraction_error_count",
+		Help:    "Number of files in an node filesystem scan that failed to read",
+		Buckets: []float64{50, 100, 500, 1000},
+	})
+)
+
+func init() {
+	prometheus.MustRegister(
+		fileExtractionCountMetric,
+		fileExtractionMatchCountMetric,
+		fileExtractionErrorCountMetric,
+	)
+}
+
+// FileExtractionMetrics tracks and emit node extraction metrics.
+type FileExtractionMetrics struct {
+	fileCount, matchCount, errorCount float64
+}
+
+// FileCount increments the file count.
+func (m *FileExtractionMetrics) FileCount() {
+	if m != nil {
+		m.fileCount++
+	}
+}
+
+// MatchCount increments the file match count.
+func (m *FileExtractionMetrics) MatchCount() {
+	if m != nil {
+		m.matchCount++
+	}
+}
+
+// ErrorCount increments the file error count that were ignored and treated as
+// non-existent files.
+func (m *FileExtractionMetrics) ErrorCount() {
+	if m != nil {
+		m.errorCount++
+	}
+}
+
+// Emit emits the metrics and reset counters
+func (m *FileExtractionMetrics) Emit() {
+	if m != nil {
+		fileExtractionCountMetric.Observe(m.matchCount)
+		fileExtractionMatchCountMetric.Observe(m.fileCount)
+		fileExtractionErrorCountMetric.Observe(m.errorCount)
+	}
+	*m = FileExtractionMetrics{}
+}

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -36,31 +36,7 @@ import (
 	"github.com/stackrox/scanner/pkg/metrics"
 )
 
-const (
-	// DefaultMaxExtractableFileSizeMB is the default value for the max extractable file size.
-	DefaultMaxExtractableFileSizeMB = 200
-	// DefaultMaxELFExecutableFileSizeMB is the default value for the max ELF executable file we analyze.
-	DefaultMaxELFExecutableFileSizeMB = 800
-	// DefaultMaxLazyReaderBufferSizeMB is the default maximum lazy reader buffer size. Any file data beyond this
-	// limit is backed by temporary files on disk.
-	DefaultMaxLazyReaderBufferSizeMB = 100
-
-	// elfHeaderSize is the size of an ELF header based on https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html.
-	elfHeaderSize = 16
-)
-
 var (
-	// maxExtractableFileSize enforces the maximum size of a single file within a
-	// tarball that will be extracted. This protects against malicious files that
-	// may used in an attempt to perform a Denial of Service attack.
-	maxExtractableFileSize int64 = DefaultMaxExtractableFileSizeMB * 1024 * 1024
-	// maxELFExecutableFileSize defines the maximum size of an ELF executable file
-	// tarball that will be analyzed.
-	maxELFExecutableFileSize int64 = DefaultMaxELFExecutableFileSizeMB * 1024 * 1024
-	// maxLazyReaderBufferSize is the maximum lazy reader buffer size. Any file data beyond this
-	// limit is backed by temporary files on disk.
-	maxLazyReaderBufferSize int64 = DefaultMaxLazyReaderBufferSizeMB * 1024 * 1024
-
 	readLen           = 6 // max bytes to sniff
 	gzipHeader        = []byte{0x1f, 0x8b}
 	bzip2Header       = []byte{0x42, 0x5a, 0x68}
@@ -69,41 +45,10 @@ var (
 	shebangHeaderSize = len(shebangHeader)
 )
 
-// SetMaxExtractableFileSize sets the max extractable file size.
-// It is NOT thread-safe, and callers must ensure that it is called
-// only when no scans are in progress (ex: during initialization).
-// See comments on the maxExtractableFileSize variable for
-// more details on its purpose.
-func SetMaxExtractableFileSize(val int64) {
-	maxExtractableFileSize = val
-}
-
-// SetMaxLazyReaderBufferSize sets the max lazy reader buffer size.
-// It is NOT thread-safe, and callers must ensure that it is called
-// only when no scans are in progress (ex: during initialization).
-// See comments on the maxLazyReaderBufferSize variable for
-// more details on its purpose.
-func SetMaxLazyReaderBufferSize(val int64) {
-	maxLazyReaderBufferSize = val
-}
-
-// SetMaxELFExecutableFileSize sets the max ELF executable file size.
-// It is NOT thread-safe, and callers must ensure that it is called
-// only when no scans are in progress (ex: during initialization).
-// See comments on the maxELFExecutableFileSize variable for
-// more details on its purpose.
-func SetMaxELFExecutableFileSize(val int64) {
-	maxELFExecutableFileSize = val
-}
-
 // ExtractFiles decompresses and extracts only the specified files from an
 // io.Reader representing an archive.
 func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, error) {
 	files := CreateNewLayerFiles(nil)
-
-	// executableMatcher indicates if the given file is executable
-	// for the FileData struct.
-	executableMatcher := matcher.NewExecutableMatcher()
 
 	// Decompress the archive.
 	tr, err := NewTarReadCloser(r)
@@ -144,7 +89,7 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 				buf = prevLazyReader.StealBuffer()
 				utils.IgnoreError(prevLazyReader.Close)
 			}
-			prevLazyReader = ioutils.NewLazyReaderAtWithDiskBackedBuffer(tr, hdr.Size, buf, maxLazyReaderBufferSize)
+			prevLazyReader = ioutils.NewLazyReaderAtWithDiskBackedBuffer(tr, hdr.Size, buf, analyzer.GetMaxLazyReaderBufferSize())
 			contents = prevLazyReader
 		} else {
 			contents = bytes.NewReader(nil)
@@ -157,8 +102,9 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 		numMatchedFiles++
 
 		// File size limit
-		if extractContents && hdr.Size > maxExtractableFileSize {
-			log.Errorf("Skipping file %q (%d bytes) because it was greater than the configured maxExtractableFileSizeMB of %d", filename, hdr.Size, maxExtractableFileSize/1024/1024)
+		if extractContents && hdr.Size > analyzer.GetMaxExtractableFileSize() {
+			log.Errorf("Skipping file %q (%d bytes) because it was greater than the configured maxExtractableFileSize of %d MiB",
+				filename, hdr.Size, analyzer.GetMaxExtractableFileSize()/1024/1024)
 			continue
 		}
 
@@ -167,11 +113,12 @@ func ExtractFiles(r io.Reader, filenameMatcher matcher.Matcher) (LayerFiles, err
 		case tar.TypeReg, tar.TypeLink:
 			var fileData analyzer.FileData
 
-			executable, _ := executableMatcher.Match(filename, hdr.FileInfo(), contents)
-			if hdr.Size > maxELFExecutableFileSize {
-				log.Warnf("Skipping ELF executable check for file %q (%d bytes) because it is larger than the configured maxELFExecutableFileSizeMB of %d", filename, hdr.Size, maxELFExecutableFileSize/1024/1024)
+			executable := matcher.IsFileExecutable(hdr.FileInfo())
+			if hdr.Size > analyzer.GetMaxELFExecutableFileSize() {
+				log.Warnf("Skipping ELF executable check for file %q (%d bytes) because it is larger than the configured maxELFExecutableFileSize of %d MiB",
+					filename, hdr.Size, analyzer.GetMaxELFExecutableFileSize()/1024/1024)
 			} else {
-				if hdr.Size >= elfHeaderSize { // Only bother attempting to get ELF metadata if the file is large enough for the ELF header.
+				if hdr.Size >= analyzer.ElfHeaderSize { // Only bother attempting to get ELF metadata if the file is large enough for the ELF header.
 					fileData.ELFMetadata, err = elf.GetExecutableMetadata(contents)
 					if err != nil {
 						log.Errorf("Failed to get dependencies for %s: %v", filename, err)

--- a/pkg/tarutil/tarutil_test.go
+++ b/pkg/tarutil/tarutil_test.go
@@ -80,7 +80,7 @@ func TestMaxExtractableFileSize(t *testing.T) {
 	// test_big.txt is of size 57 bytes.
 	assert.Contains(t, files.data, "test_big.txt")
 
-	SetMaxExtractableFileSize(50)
+	analyzer.SetMaxExtractableFileSize(50)
 	files, err = ExtractFiles(f, matcher.NewPrefixAllowlistMatcher("test_big.txt"))
 	assert.NoError(t, err)
 	assert.Empty(t, files.data)

--- a/singletons/requiredfilenames/matcher.go
+++ b/singletons/requiredfilenames/matcher.go
@@ -28,7 +28,7 @@ var (
 )
 
 // SingletonOSMatcher returns the singleton matcher instance for extracting files
-// for OS package analysis.
+// for O.S. package analysis.
 func SingletonOSMatcher() matcher.PrefixMatcher {
 	osMatcherOnce.Do(func() {
 		allFileNames := append(featurefmt.RequiredFilenames(), featurens.RequiredFilenames()...)
@@ -61,7 +61,7 @@ func SingletonActiveVulnMatcher() matcher.Matcher {
 }
 
 // SingletonMatcher returns the singleton matcher instance to use for extracting
-// files for analyzing image container. It includes matching for OS features
+// files for analyzing image container. It includes matching for O.S. features
 // and active vulnerability. Note: language-level analyzers implement a different
 // interface, and do not require extraction of files. Therefore, the respective
 // files do not need to be matched here.

--- a/singletons/requiredfilenames/matcher.go
+++ b/singletons/requiredfilenames/matcher.go
@@ -28,7 +28,7 @@ var (
 )
 
 // SingletonOSMatcher returns the singleton matcher instance for extracting files
-// for O.S. package analysis.
+// for OS package analysis.
 func SingletonOSMatcher() matcher.PrefixMatcher {
 	osMatcherOnce.Do(func() {
 		allFileNames := append(featurefmt.RequiredFilenames(), featurens.RequiredFilenames()...)
@@ -61,7 +61,7 @@ func SingletonActiveVulnMatcher() matcher.Matcher {
 }
 
 // SingletonMatcher returns the singleton matcher instance to use for extracting
-// files for analyzing image container. It includes matching for O.S. features
+// files for analyzing image container. It includes matching for OS features
 // and active vulnerability. Note: language-level analyzers implement a different
 // interface, and do not require extraction of files. Therefore, the respective
 // files do not need to be matched here.


### PR DESCRIPTION
This PR is built on top of https://github.com/stackrox/scanner/pull/904 (please filter commits in the diff for a narrowed view of the changes).

Add `Analyze()` to `pkg/analyzer/nodes`, including related changes to allow external packages (in particular, Compliance) to consume it. `node.Analyze` is built on the recently introduced interfaces added to `pkg/analyzer`, and re-uses `clair.DetectContentFromFile()`.

Other marginal changes:

- Move file size limits to the `analyzer` package.
- Add metrics for node scanning.

## Tests

UTs.

Local validation, here's the code (omitting imports):

```
func main() {
	components, err := nodes.Analyze("localhost", "/", true)
	if err != nil {
		panic(err)
	}

	s, err := json.MarshalIndent(components, "", "    ")
	if err != nil {
		panic(err)
	}
	fmt.Println(string(s))
}
```

Next steps: E2E.
