### PR TITLE
Add init-db resource specs for E2E tests

### DIFF
--- a/chart/templates/db-deployment.yaml
+++ b/chart/templates/db-deployment.yaml
@@ -23,6 +23,13 @@ spec:
         env:
         - name: POSTGRES_PASSWORD_FILE
           value: "/run/secrets/stackrox.io/secrets/password"
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 200m
+            memory: 200Mi
         volumeMounts:
         - name: scanner-db-data
           mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
Using the same resource specs as the `db` image. This is related to https://github.com/stackrox/stackrox/pull/2976