### PR TITLE
ROX-12387: Prevent malformed k8s vuln update from hindering other k8s updates

### DIFF
--- a/k8s/cache/load.go
+++ b/k8s/cache/load.go
@@ -41,7 +41,8 @@ func (c *cacheImpl) LoadFromDirectory(definitionsDir string) error {
 		}
 		updated, err := c.handleYAMLFile(filepath.Join(definitionsDir, f.Name()))
 		if err != nil {
-			return errors.Wrapf(err, "handling file %s", f.Name())
+			log.Errorf("Skipping vuln update for %s due to error: %v", f.Name(), err)
+			continue
 		}
 		if updated {
 			totalVulns++

--- a/pkg/vulnloader/k8sloader/yaml.go
+++ b/pkg/vulnloader/k8sloader/yaml.go
@@ -21,17 +21,3 @@ func LoadYAMLFileFromReader(r io.Reader) (*validation.CVESchema, error) {
 	}
 	return &schema, nil
 }
-
-// WriteYAMLFileToWriter marshals the given Kubernetes CVE file as YAML and writes it to the given io.Writer.
-// The writer is NOT closed; that is the caller's responsibility.
-func WriteYAMLFileToWriter(contents *validation.CVESchema, w io.Writer) error {
-	contentBytes, err := yaml.Marshal(contents)
-	if err != nil {
-		return errors.Wrap(err, "marshaling YAML into bytes")
-	}
-	_, err = w.Write(contentBytes)
-	if err != nil {
-		return errors.Wrap(err, "writing YAML into writer")
-	}
-	return nil
-}


### PR DESCRIPTION
A malformed k8s vuln file can cause Scanner to halt all k8s vuln updates. This PR prevents this by simply logging the error and continuing.

Meanwhile, there is currently an issue with current live Scanner due to malformed k8s vuln files. This is because of how the published time is marshaled to JSON. To fix this, instead of requiring the JSON to be marshaled, we just copy the file contents directly over, as that is essentially what was already done anyway.

See https://go.dev/play/p/NCfVWO_AY5p?v=goprev to prove it is ok to unmarshal an empty file into a struct