### PR TITLE
ROX-12226: Fetch RHELv2 unpatched CVE component resolution status and store in the scanner db

### DIFF
--- a/database/models.go
+++ b/database/models.go
@@ -177,7 +177,8 @@ type RHELv2Package struct {
 	// Executables lists the executables determined from ExecutableToDependencies and
 	// LibraryToDependencies. This is only populated when both ExecutableToDependencies and
 	// LibraryToDependencies are empty.
-	Executables []*v1.Executable `json:"executables,omitempty"`
+	Executables     []*v1.Executable `json:"executables,omitempty"`
+	ResolutionState string           `json:"resolution_state"`
 }
 
 func (p *RHELv2Package) String() string {

--- a/database/pgsql/migrations/00018_add_vuln_state_rhel.go
+++ b/database/pgsql/migrations/00018_add_vuln_state_rhel.go
@@ -1,0 +1,12 @@
+package migrations
+
+import "github.com/remind101/migrate"
+
+func init() {
+	RegisterMigration(migrate.Migration{
+		ID: 18,
+		Up: migrate.Queries([]string{
+			`ALTER TABLE vuln_package ADD COLUMN IF NOT EXISTS resolution_state VARCHAR(100)`,
+		}),
+	})
+}

--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -226,13 +226,13 @@ const (
 			name,
 			package_name, package_module, package_arch,
 			cpe,
-			fixed_in_version, arch_operation
+			fixed_in_version, arch_operation, resolution_state
 		) VALUES (
 			$1,
 			$2,
 			$3, $4, $5,
 			$6,
-			$7, $8
+			$7, $8, $9
 		)
 		ON CONFLICT (hash) DO NOTHING;`
 

--- a/database/pgsql/rhelv2_vulnerability.go
+++ b/database/pgsql/rhelv2_vulnerability.go
@@ -74,6 +74,7 @@ func (pgSQL *pgSQL) insertRHELv2Vulnerability(vulnStatement, vulnPackageStatemen
 					pkg.Name, pkg.Module, pkg.Arch,
 					cpe,
 					pkgInfo.FixedInVersion, pkgInfo.ArchOperation,
+					pkg.ResolutionState,
 				)
 				if err != nil {
 					return errors.Wrapf(err, "inserting RHELv2 vulnerability package %q with cpe %q for vuln %q into the DB", pkg.Name, cpe, vuln.Name)

--- a/pkg/rhelv2/ovalutil/rpm.go
+++ b/pkg/rhelv2/ovalutil/rpm.go
@@ -7,6 +7,7 @@ package ovalutil
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/quay/goval-parser/oval"
@@ -65,8 +66,12 @@ func RPMDefsToVulns(root *oval.Root, protoVuln ProtoVulnFunc) ([]*database.RHELv
 		if vuln == nil {
 			continue
 		}
-		// recursively collect criterions for this definition
 
+		//parse unpatched CVE component resolution for each def
+		componentResolutions, err := parseUnpatchedCVEComponents(def)
+		log.Infof(">>>> Unpatched CVE components size is: %d", len(componentResolutions))
+
+		// recursively collect criterions for this definition
 		cris := cris[:0]
 		walkCriterion("", &def.Criteria, &cris)
 		// unpack criterions into vulnerabilities
@@ -222,4 +227,42 @@ func GetDefinitionType(def oval.Definition) (string, error) {
 		return "", errors.New("cannot parse definition ID for its type")
 	}
 	return match[1], nil
+}
+
+func parseUnpatchedCVEComponents(def oval.Definition) (map[string]string, error) {
+	defType, err := GetDefinitionType(def)
+	if err != nil {
+		return nil, err
+	}
+
+	// Red Hat OVAL v2 data include information about vulnerabilities,
+	// that actually don't affect the package in any way. Storing them
+	// would increase number of records in DB without adding any value.
+	if defType == UnaffectedDefinition {
+		return nil, nil
+	}
+	resolutions := def.Advisory.Affected.Resolutions
+	if len(resolutions) < 1 {
+		return nil, nil
+	}
+	result := make(map[string]string)
+
+	for i := 0; i < len(resolutions); i++ {
+		state := resolutions[i].State
+		components := resolutions[i].Components
+
+		for j := 0; j < len(components); j++ {
+			component := components[j]
+			stringSlice := strings.Split(component, "/")
+			var componentName string
+			if len(stringSlice) > 1 {
+				componentName = stringSlice[len(stringSlice)-1]
+			} else {
+				componentName = stringSlice[0]
+			}
+			result[componentName] = state
+		}
+	}
+
+	return result, nil
 }

--- a/pkg/rhelv2/ovalutil/rpm.go
+++ b/pkg/rhelv2/ovalutil/rpm.go
@@ -68,7 +68,7 @@ func RPMDefsToVulns(root *oval.Root, protoVuln ProtoVulnFunc) ([]*database.RHELv
 		}
 
 		//parse unpatched CVE component resolution for each def
-		componentResolutions, err := parseUnpatchedCVEComponents(def)
+		componentResolutions := parseUnpatchedCVEComponents(def)
 		log.Infof(">>>> Unpatched CVE components size is: %d", len(componentResolutions))
 
 		// recursively collect criterions for this definition
@@ -229,21 +229,10 @@ func GetDefinitionType(def oval.Definition) (string, error) {
 	return match[1], nil
 }
 
-func parseUnpatchedCVEComponents(def oval.Definition) (map[string]string, error) {
-	defType, err := GetDefinitionType(def)
-	if err != nil {
-		return nil, err
-	}
-
-	// Red Hat OVAL v2 data include information about vulnerabilities,
-	// that actually don't affect the package in any way. Storing them
-	// would increase number of records in DB without adding any value.
-	if defType == UnaffectedDefinition {
-		return nil, nil
-	}
+func parseUnpatchedCVEComponents(def oval.Definition) map[string]string {
 	resolutions := def.Advisory.Affected.Resolutions
 	if len(resolutions) < 1 {
-		return nil, nil
+		return nil
 	}
 	result := make(map[string]string)
 
@@ -264,5 +253,5 @@ func parseUnpatchedCVEComponents(def oval.Definition) (map[string]string, error)
 		}
 	}
 
-	return result, nil
+	return result
 }

--- a/pkg/rhelv2/ovalutil/rpm.go
+++ b/pkg/rhelv2/ovalutil/rpm.go
@@ -133,6 +133,7 @@ func RPMDefsToVulns(root *oval.Root, protoVuln ProtoVulnFunc) ([]*database.RHELv
 				// If FixedInVersion is not defined, we keep the title empty to reduce the scale of the database.
 				vuln.Title = ""
 			}
+
 			pkg := &database.RHELv2Package{
 				// object.Name will never be empty.
 				Name:   object.Name,
@@ -141,7 +142,11 @@ func RPMDefsToVulns(root *oval.Root, protoVuln ProtoVulnFunc) ([]*database.RHELv
 			if state != nil && state.Arch != nil {
 				pkg.Arch = state.Arch.Body
 			}
-
+			if len(componentResolutions) > 0 {
+				if val, ok := componentResolutions[object.Name]; ok {
+					pkg.ResolutionState = val
+				}
+			}
 			pkgInfo.Packages = append(pkgInfo.Packages, pkg)
 
 			vuln.PackageInfos = append(vuln.PackageInfos, pkgInfo)


### PR DESCRIPTION
In this ticket, the scanner is enabled to fetch packages status affected in RHELv2 unpatched CVEs
Store those status in the scanner db
In the future we will work with UI team to display those components status so that the users will understand more about those CVEs and decide what they want to do with those.