### PR TITLE
Skip data dump GCS upload for tagged builds

### DIFF
--- a/scripts/ci/jobs/upload-db-dump.sh
+++ b/scripts/ci/jobs/upload-db-dump.sh
@@ -10,6 +10,9 @@ upload_db_dump() {
     if is_in_PR_context; then
         info "Skipping upload, as this is a PR"
     fi
+    if is_tagged; then
+        info "SKipping upload, as this is a tag"
+    fi
 
     info "Starting DB dump upload"
 

--- a/scripts/ci/jobs/upload-db-dump.sh
+++ b/scripts/ci/jobs/upload-db-dump.sh
@@ -11,7 +11,7 @@ upload_db_dump() {
         info "Skipping upload, as this is a PR"
     fi
     if is_tagged; then
-        info "SKipping upload, as this is a tag"
+        info "Skipping upload, as this is a tag"
     fi
 
     info "Starting DB dump upload"

--- a/scripts/ci/jobs/upload-dumps-for-embedding.sh
+++ b/scripts/ci/jobs/upload-dumps-for-embedding.sh
@@ -11,6 +11,10 @@ upload_dumps_for_embedding() {
         info "In PR context. Skipping..."
         return 0
     fi
+    if is_tagged; then
+        info "In tag context. Skipping..."
+        return 0
+    fi
 
     info "Starting dumps upload"
 


### PR DESCRIPTION
Let's say, after releasing some Scanner version X, we add a column to a database, or change the links for all Alpine vulnerabilities, or something related to that.

Any PRs and data relied upon while developing X + 1 will assume the data is consistent with the latest format.

If, after this time, we patch X and make a new tag, then, currently, we overwrite the GCS data used in PRs with the data following the old format, which causes PRs to fail until that data is overwritten again.

Let's just stop uploading this data upon new creating a new tag. There is no need for it, and it just causes unnecessary errors.