### PR TITLE
fix tag used for hourly CI runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ BASE_DIR=$(CURDIR)
 
 TAG := # make sure tag is never injectable as an env var
 
+ifdef CI
+ifneq ($(NIGHTLY_TAG),)
+TAG := $(NIGHTLY_TAG)
+endif
+endif
+
 ifeq ($(TAG),)
 TAG=$(shell git describe --tags --abbrev=10 --dirty --long)
 endif

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,6 @@ BASE_DIR=$(CURDIR)
 
 TAG := # make sure tag is never injectable as an env var
 
-ifdef CI
-ifneq ($(CIRCLE_TAG),)
-TAG := $(CIRCLE_TAG)
-endif
-endif
-
 ifeq ($(TAG),)
 TAG=$(shell git describe --tags --abbrev=10 --dirty --long)
 endif

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -14,6 +14,7 @@ ensure_CI() {
     fi
 }
 
+# ci_export is a wrapper around export. This is here for legacy purposes.
 ci_export() {
     if [[ "$#" -ne 2 ]]; then
         die "missing args. usage: ci_export <env-name> <env-value>"
@@ -22,11 +23,7 @@ ci_export() {
     local env_name="$1"
     local env_value="$2"
 
-    if command -v cci-export >/dev/null; then
-        cci-export "$env_name" "$env_value"
-    else
-        export "$env_name"="$env_value"
-    fi
+    export "$env_name"="$env_value"
 }
 
 ci_exit_trap() {
@@ -173,7 +170,7 @@ is_tagged() {
 }
 
 is_nightly_run() {
-    [[ "${CIRCLE_TAG:-}" =~ -nightly- ]]
+    [[ "${NIGHTLY_TAG:-}" =~ -nightly- ]]
 }
 
 is_in_PR_context() {
@@ -516,11 +513,6 @@ openshift_ci_mods() {
         fi
     fi
 
-    # Provide Circle CI vars that are commonly used
-    export CIRCLE_JOB="${JOB_NAME:-${OPENSHIFT_BUILD_NAME}}"
-    CIRCLE_TAG="$(make --quiet --no-print-directory tag)" || warn "Cannot get tag"
-    export CIRCLE_TAG
-
     handle_nightly_runs
 
     info "Status after mods:"
@@ -581,7 +573,7 @@ handle_nightly_runs() {
     local nightly_tag_prefix
     nightly_tag_prefix="$(git describe --tags --abbrev=0 --exclude '*-nightly-*')-nightly-"
     if ! is_in_PR_context && [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then
-        ci_export CIRCLE_TAG "${nightly_tag_prefix}$(date '+%Y%m%d')"
+        ci_export NIGHTLY_TAG "${nightly_tag_prefix}$(date '+%Y%m%d')"
     fi
 }
 

--- a/scripts/ci/logcheck/check-logs.sh
+++ b/scripts/ci/logcheck/check-logs.sh
@@ -40,7 +40,7 @@ check_for_stackrox_restarts() {
     if [[ -n "$previous_logs" ]]; then
         echo >&2 "Previous logs found"
         # shellcheck disable=SC2086
-        if ! "$SCRIPTS_ROOT/ci/logcheck/check-restart-logs.sh" "${CI_JOB_NAME:-${CIRCLE_JOB}}" $previous_logs; then
+        if ! "$SCRIPTS_ROOT/ci/logcheck/check-restart-logs.sh" "${CI_JOB_NAME}" $previous_logs; then
             exit 1
         fi
     fi


### PR DESCRIPTION
I noticed "hourly" CI runs are pushing images with the nightly tag. I think this is because we set `CIRCLE_TAG` to `git tag --sort=creatordate --contains | tail -1`. I think if there have not been any merges to the `master` branch since the nightly ran, then this will return a nightly tag. For example, running this on the `master` branch right now gave me `2.26-nightly-20220930`.

This PR removes `CIRCLE_JOB` and `CIRCLE_TAG` and replaces `CIRCLE_TAG` with `NIGHTLY_TAG`