### PR TITLE
Use http consts for HTTP methods

### DIFF
--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -119,7 +119,7 @@ var (
 )
 
 func httpGet(url string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clairify/clair/clair.go
+++ b/pkg/clairify/clair/clair.go
@@ -67,7 +67,7 @@ func (c *Client) analyzeLayer(path, layerName, parentLayerName string, h map[str
 	}
 	fullURL := fmt.Sprintf("%v/v1/layers", c.endpoint)
 	logrus.Debugf("Pushing layer %v to Clair", path)
-	request, err := http.NewRequest("POST", fullURL, bytes.NewBuffer(jsonPayload))
+	request, err := http.NewRequest(http.MethodPost, fullURL, bytes.NewBuffer(jsonPayload))
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (c *Client) sendRequest(req *http.Request) ([]byte, int, error) {
 // RetrieveLayerData fetches the layer information for the passed layer.
 func (c *Client) RetrieveLayerData(layer string, values url.Values) (*v1.LayerEnvelope, bool, error) {
 	url := fmt.Sprintf("%v/v1/layers/%v", c.endpoint, layer)
-	request, err := http.NewRequest("GET", url, nil)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/clairify/client/client.go
+++ b/pkg/clairify/client/client.go
@@ -111,7 +111,7 @@ func encodeValues(opts *types.GetImageDataOpts) url.Values {
 
 // Ping verifies that Clairify is accessible.
 func (c *Clairify) Ping() error {
-	request, err := http.NewRequest("GET", c.endpoint+"/scanner/ping", nil)
+	request, err := http.NewRequest(http.MethodGet, c.endpoint+"/scanner/ping", nil)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (c *Clairify) AddImage(username, password string, req *types.ImageRequest) 
 	if err != nil {
 		return nil, err
 	}
-	request, err := http.NewRequest("POST", c.endpoint+"/scanner/image", bytes.NewBuffer(data))
+	request, err := http.NewRequest(http.MethodPost, c.endpoint+"/scanner/image", bytes.NewBuffer(data))
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (c *Clairify) AddImage(username, password string, req *types.ImageRequest) 
 // RetrieveImageDataBySHA contacts Clairify to fetch vulnerability data by the image SHA.
 func (c *Clairify) RetrieveImageDataBySHA(sha string, opts *types.GetImageDataOpts) (*v1.LayerEnvelope, error) {
 	values := encodeValues(opts)
-	request, err := http.NewRequest("GET", c.endpoint+"/scanner/sha/"+sha, nil)
+	request, err := http.NewRequest(http.MethodGet, c.endpoint+"/scanner/sha/"+sha, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func (c *Clairify) RetrieveImageDataBySHA(sha string, opts *types.GetImageDataOp
 func (c *Clairify) RetrieveImageDataByName(image *types.Image, opts *types.GetImageDataOpts) (*v1.LayerEnvelope, error) {
 	values := encodeValues(opts)
 	url := fmt.Sprintf("%s/scanner/image/%s/%s/%s", c.endpoint, image.Registry, image.Remote, image.Tag)
-	request, err := http.NewRequest("GET", url, nil)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (c *Clairify) RetrieveImageDataByName(image *types.Image, opts *types.GetIm
 // GetVulnDefsMetadata contacts Clairify to fetch vulnerability definitions metadata.
 func (c *Clairify) GetVulnDefsMetadata() (*protoV1.VulnDefsMetadata, error) {
 	url := fmt.Sprintf("%s/scanner/vulndefs/metadata", c.endpoint)
-	request, err := http.NewRequest("GET", url, nil)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -36,7 +36,7 @@ func GetWithUserAgent(url string) (*http.Response, error) {
 		Transport: proxy.RoundTripper(),
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Prefer consts within the `http` package (i.e. `http.MethodGet`) instead of specifying the string literal "GET".
