### PR TITLE
Pass correct arguments to tar when creating db bundle

### DIFF
--- a/image/db/rhel/create-bundle.sh
+++ b/image/db/rhel/create-bundle.sh
@@ -44,7 +44,7 @@ else
 fi
 
 # Create output bundle of all files in $bundle_root
-tar cz --file "$OUTPUT_BUNDLE" --directory "${bundle_root}" .
+tar cz "${tar_chown_args[@]}" --file "$OUTPUT_BUNDLE" --directory "${bundle_root}" .
 
 # Create checksum
 sha512sum "${OUTPUT_BUNDLE}" > "${OUTPUT_BUNDLE}.sha512"


### PR DESCRIPTION
This line was changed by mistake in https://github.com/stackrox/scanner/pull/874/
This PR is only reverting that change.