### PR TITLE
CI: Fix missing CLUSTER_NAME

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -240,16 +240,6 @@ refresh_gke_token() {
 teardown_gke_cluster() {
     info "Tearing down the GKE cluster: ${CLUSTER_NAME:-}"
 
-    if [[ -z "${CLUSTER_NAME:-}" ]]; then
-        # CLUSTER_NAME is not propagating as it _should_ via ci_export / BASH_ENV
-        echo "DEBUG missing CLUSTER_NAME"
-        echo "BASH_ENV: ${BASH_ENV:-}"
-        if [[ -n "${BASH_ENV:-}" ]]; then
-            ls -l "${BASH_ENV:-}" || true
-            cat "${BASH_ENV:-}" || true
-        fi
-    fi
-
     require_environment "CLUSTER_NAME"
     require_executable "gcloud"
 

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -240,6 +240,16 @@ refresh_gke_token() {
 teardown_gke_cluster() {
     info "Tearing down the GKE cluster: ${CLUSTER_NAME:-}"
 
+    if [[ -z "${CLUSTER_NAME:-}" ]]; then
+        # CLUSTER_NAME is not propagating as it _should_ via ci_export / BASH_ENV
+        echo "DEBUG missing CLUSTER_NAME"
+        echo "BASH_ENV: ${BASH_ENV:-}"
+        if [[ -n "${BASH_ENV:-}" ]]; then
+            ls -l "${BASH_ENV:-}" || true
+            cat "${BASH_ENV:-}" || true
+        fi
+    fi
+
     require_environment "CLUSTER_NAME"
     require_executable "gcloud"
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -14,7 +14,8 @@ ensure_CI() {
     fi
 }
 
-# ci_export is a wrapper around export. This is here for legacy purposes.
+# ci_export is a wrapper around cci-export which persists exported variables
+# between bash processes.
 ci_export() {
     if [[ "$#" -ne 2 ]]; then
         die "missing args. usage: ci_export <env-name> <env-value>"
@@ -23,7 +24,11 @@ ci_export() {
     local env_name="$1"
     local env_value="$2"
 
-    export "$env_name"="$env_value"
+    if command -v cci-export >/dev/null; then
+        cci-export "$env_name" "$env_value"
+    else
+        export "$env_name"="$env_value"
+    fi
 }
 
 ci_exit_trap() {
@@ -485,6 +490,7 @@ openshift_ci_mods() {
     # For ci_export(), override BASH_ENV from stackrox-test with something that is writable.
     BASH_ENV=$(mktemp)
     export BASH_ENV
+    info "BASH_ENV is now ${BASH_ENV}"
 
     # These are not set in the binary_build_commands or image build envs.
     export CI=true


### PR DESCRIPTION
#954 changed `ci_export()` to not use `cci-export()` which is required to persist state for CLUSTER_NAME and ZONE for e2e tests. The e2e tests failed on the original PR.

This PR reverts the change to `ci_export()`.
