### PR TITLE
CI: gate "upload-db-dump" for tag

### DIFF
--- a/scripts/ci/gate-jobs-config.json
+++ b/scripts/ci/gate-jobs-config.json
@@ -53,7 +53,7 @@
     "run_with_changed_path": "",
     "changed_path_to_ignore": "",
     "run_on_master": "true",
-    "run_on_tags": "true"
+    "run_on_tags": "false"
   },
   "upload-dumps-for-downstream": {
     "run_with_labels": [],


### PR DESCRIPTION
This step should not run upon tag creation.