### PR TITLE
Make gRPC service structs forward-compatible by embedding Unimplemented.. types

### DIFF
--- a/api/v1/imagescan/service.go
+++ b/api/v1/imagescan/service.go
@@ -38,6 +38,8 @@ func NewService(db database.Datastore, nvdCache nvdtoolscache.Cache) Service {
 }
 
 type serviceImpl struct {
+	v1.UnimplementedImageScanServiceServer
+
 	version  string
 	db       database.Datastore
 	nvdCache nvdtoolscache.Cache

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -42,6 +42,8 @@ func NewService(db database.Datastore, nvdCache nvdtoolscache.Cache, k8sCache k8
 }
 
 type serviceImpl struct {
+	v1.UnimplementedNodeScanServiceServer
+
 	version  string
 	db       database.Datastore
 	nvdCache nvdtoolscache.Cache

--- a/api/v1/orchestratorscan/service.go
+++ b/api/v1/orchestratorscan/service.go
@@ -36,6 +36,8 @@ func NewService(db database.Datastore, k8sCache k8scache.Cache) Service {
 }
 
 type serviceImpl struct {
+	v1.UnimplementedOrchestratorScanServiceServer
+
 	version  string
 	db       database.Datastore
 	k8sCache k8scache.Cache

--- a/api/v1/ping/service.go
+++ b/api/v1/ping/service.go
@@ -25,6 +25,8 @@ func NewService() Service {
 }
 
 type serviceImpl struct {
+	v1.UnimplementedPingServiceServer
+
 	version string
 }
 

--- a/api/v1/vulndefs/service.go
+++ b/api/v1/vulndefs/service.go
@@ -29,6 +29,8 @@ func NewService(db database.Datastore) Service {
 }
 
 type serviceImpl struct {
+	v1.UnimplementedVulnDefsServiceServer
+
 	db database.Datastore
 }
 


### PR DESCRIPTION
gRPC code generation generates `Unimplemented...` structs that return an unimplemented status code for all methods. This struct should be embedded in all gRPC service implementations. While this is not currently enforced, future gRPC code generator versions will make this mandatory (this behavior can be disabled, but it is not recommended; see [here](https://github.com/grpc/grpc-go/issues/3669) for a lengthy discussion on this matter with the clear verdict that gRPC authors see embedding of `Unimplemented..` as something that should always have been required).

Alas, this makes service type assertions ineffective, but that seems to be the pill to swallow.

(description copied from https://github.com/stackrox/stackrox/pull/3538)