### PR TITLE
Replace uses of *zip.ReadCloser with *zip.Reader when Close is not used

### DIFF
--- a/cmd/updater/common/dump_utils.go
+++ b/cmd/updater/common/dump_utils.go
@@ -19,7 +19,7 @@ func OpenGenesisDumpAndExtractManifest(zipPath string) (*zip.ReadCloser, *vulndu
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "opening zip")
 	}
-	manifest, err := vulndump.LoadManifestFromDump(zipR)
+	manifest, err := vulndump.LoadManifestFromDump(&zipR.Reader)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/updater/diffdumps/rhelv2_diff.go
+++ b/cmd/updater/diffdumps/rhelv2_diff.go
@@ -153,7 +153,7 @@ func generateRHELv2Diff(cfg config, outputDir string, baseLastModifiedTime time.
 	return nil
 }
 
-func generateRHELv2VulnsDiff(cfg config, outputDir string, baseLastModifiedTime time.Time, baseZipR, headZipR *zip.ReadCloser) error {
+func generateRHELv2VulnsDiff(cfg config, outputDir string, baseLastModifiedTime time.Time, baseZipR, headZipR *zip.Reader) error {
 	rhelv2VulnsSubDir := filepath.Join(outputDir, vulndump.RHELv2DirName, vulndump.RHELv2VulnsSubDirName)
 	if err := os.MkdirAll(rhelv2VulnsSubDir, 0755); err != nil {
 		return errors.Wrap(err, "creating subdir for RHELv2")

--- a/cmd/updater/printstats/cmd.go
+++ b/cmd/updater/printstats/cmd.go
@@ -23,7 +23,7 @@ func Command() *cobra.Command {
 				return errors.Wrap(err, "loading dump")
 			}
 			defer utils.IgnoreError(zipR.Close)
-			vulns, err := vulndump.LoadOSVulnsFromDump(zipR)
+			vulns, err := vulndump.LoadOSVulnsFromDump(&zipR.Reader)
 			if err != nil {
 				return errors.Wrap(err, "loading os vulns from dump")
 			}

--- a/cpe/nvdtoolscache/db.go
+++ b/cpe/nvdtoolscache/db.go
@@ -56,6 +56,8 @@ func New() (Cache, error) {
 	return newWithDB(db), nil
 }
 
+var _ Cache = (*cacheImpl)(nil)
+
 type cacheImpl struct {
 	*bbolt.DB
 

--- a/cpe/nvdtoolscache/load.go
+++ b/cpe/nvdtoolscache/load.go
@@ -40,7 +40,7 @@ func (c *cacheImpl) LoadFromDirectory(definitionsDir string) error {
 	return nil
 }
 
-func (c *cacheImpl) LoadFromZip(zipR *zip.ReadCloser, definitionsDir string) error {
+func (c *cacheImpl) LoadFromZip(zipR *zip.Reader, definitionsDir string) error {
 	log.WithField("dir", definitionsDir).Info("Loading definitions directory")
 
 	readers, err := ziputil.OpenFilesInDir(zipR, definitionsDir, ".json")

--- a/k8s/cache/db.go
+++ b/k8s/cache/db.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stackrox/scanner/pkg/vulndump"
 )
 
+var _ Cache = (*cacheImpl)(nil)
+
 type cacheImpl struct {
 	cacheRWLock sync.RWMutex
 	// The expectation is that the number of Kubernetes vulns is rather low (100 or fewer).

--- a/k8s/cache/load.go
+++ b/k8s/cache/load.go
@@ -54,7 +54,7 @@ func (c *cacheImpl) LoadFromDirectory(definitionsDir string) error {
 	return nil
 }
 
-func (c *cacheImpl) LoadFromZip(zipR *zip.ReadCloser, definitionsDir string) error {
+func (c *cacheImpl) LoadFromZip(zipR *zip.Reader, definitionsDir string) error {
 	log.WithField("dir", definitionsDir).Info("Loading definitions directory")
 
 	rs, err := ziputil.OpenFilesInDir(zipR, definitionsDir, ".yaml")

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -9,7 +9,7 @@ import (
 type Cache interface {
 	Dir() string
 	LoadFromDirectory(definitionsDir string) error
-	LoadFromZip(zipR *zip.ReadCloser, definitionsDir string) error
+	LoadFromZip(zipR *zip.Reader, definitionsDir string) error
 	GetLastUpdate() time.Time
 	SetLastUpdate(t time.Time)
 }

--- a/pkg/repo2cpe/mapping.go
+++ b/pkg/repo2cpe/mapping.go
@@ -71,7 +71,7 @@ func (m *Mapping) LoadFile(path string) error {
 }
 
 // LoadFromZip reads the repo-to-cpe file in the given directory from the given zip reader.
-func (m *Mapping) LoadFromZip(zipR *zip.ReadCloser, dir string) error {
+func (m *Mapping) LoadFromZip(zipR *zip.Reader, dir string) error {
 	path := filepath.Join(dir, RHELv2CPERepoName)
 	r, err := ziputil.OpenFile(zipR, path)
 	if err != nil {

--- a/pkg/ziputil/open.go
+++ b/pkg/ziputil/open.go
@@ -18,7 +18,7 @@ type ReadCloser struct {
 // OpenFile opens the given file in the zip, and returns the ReadCloser.
 // It returns an error if the file was not found, or if there was an error opening
 // the file.
-func OpenFile(zipR *zip.ReadCloser, name string) (*ReadCloser, error) {
+func OpenFile(zipR *zip.Reader, name string) (*ReadCloser, error) {
 	for _, file := range zipR.File {
 		if file.Name == name {
 			f, err := file.Open()
@@ -37,7 +37,7 @@ func OpenFile(zipR *zip.ReadCloser, name string) (*ReadCloser, error) {
 
 // OpenFilesInDir opens the files with the given suffix which are in the given dir.
 // It returns an error if any of the files cannot be opened.
-func OpenFilesInDir(zipR *zip.ReadCloser, dir string, suffix string) ([]*ReadCloser, error) {
+func OpenFilesInDir(zipR *zip.Reader, dir string, suffix string) ([]*ReadCloser, error) {
 	var rs []*ReadCloser
 	for _, file := range zipR.File {
 		if within(dir, file.Name) && strings.HasSuffix(file.Name, suffix) {

--- a/pkg/ziputil/open_test.go
+++ b/pkg/ziputil/open_test.go
@@ -25,7 +25,7 @@ func TestOpenFile(t *testing.T) {
 	defer utils.IgnoreError(zipR.Close)
 
 	m := repo2cpe.NewMapping()
-	assert.NoError(t, m.LoadFromZip(zipR, "rhelv2"))
+	assert.NoError(t, m.LoadFromZip(&zipR.Reader, "rhelv2"))
 }
 
 func TestOpenFilesInDir(t *testing.T) {
@@ -36,7 +36,7 @@ func TestOpenFilesInDir(t *testing.T) {
 	require.NoError(t, err)
 	defer utils.IgnoreError(zipR.Close)
 
-	rcs, err := ziputil.OpenFilesInDir(zipR, "rhelv2/vulns", ".json")
+	rcs, err := ziputil.OpenFilesInDir(&zipR.Reader, "rhelv2/vulns", ".json")
 	assert.NoError(t, err)
 	assert.Len(t, rcs, 1)
 


### PR DESCRIPTION
Clears up any potential confusion about when Close is used/needed