### PR TITLE
Remove TODO in ubuntu:22.04 E2E test

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3775,7 +3775,9 @@ Applications using RegexRequestMatcher with '.' in the regular expression are po
 					},
 				},
 				FixedBy: "3.0.2-0ubuntu1.7",
-				// TODO: Why is it this layer?
+				// This image installs the openssl pacakge in the second layer;
+				// however, the first layer already installed libssl3 whose source package is openssl.
+				// Therefore, we claim openssl was installed in the first layer.
 				AddedBy: "sha256:301a8b74f71f85f3a31e9c7e7fedd5b001ead5bcf895bc2911c1d260e06bd987",
 			},
 		},


### PR DESCRIPTION
I just accepted this to ensure the vulnerability was added to our data feed ASAP. I finally was able to do some analysis and we can remove this TODO.