### PR TITLE
ROX-13435: fix RHELv2 updates

### DIFF
--- a/cmd/updater/diffdumps/cmd.go
+++ b/cmd/updater/diffdumps/cmd.go
@@ -395,6 +395,7 @@ type config struct {
 	KeepUnusedRHELv2CPEs        bool `json:"keepUnusedRHELv2CPEs"`
 	UseLegacyUbuntuCVEURLPrefix bool `json:"useLegacyUbuntuCVEURLPrefix"`
 	UseLegacyAlpineCVEURLPrefix bool `json:"useLegacyAlpineCVEURLPrefix"`
+	UseLegacyRHELv2PackageInfos bool `json:"useLegacyRHELv2PackageInfos"`
 }
 
 // Command defines the diff-dumps command.

--- a/image/scanner/dump/genesis_manifests.json
+++ b/image/scanner/dump/genesis_manifests.json
@@ -19,7 +19,8 @@
         "useDPKGParserForAlpine": true,
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
-        "useLegacyAlpineCVEURLPrefix": true
+        "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true
       }
     },
     {
@@ -36,7 +37,8 @@
         "useDPKGParserForAlpine": true,
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
-        "useLegacyAlpineCVEURLPrefix": true
+        "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true
       }
     },
     {
@@ -52,7 +54,8 @@
         "useDPKGParserForAlpine": true,
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
-        "useLegacyAlpineCVEURLPrefix": true
+        "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true
       }
     },
     {
@@ -68,7 +71,8 @@
         "useDPKGParserForAlpine": true,
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
-        "useLegacyAlpineCVEURLPrefix": true
+        "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true
       }
     },
     {
@@ -84,7 +88,8 @@
         "useDPKGParserForAlpine": true,
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
-        "useLegacyAlpineCVEURLPrefix": true
+        "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true
       }
     },
     {
@@ -100,7 +105,8 @@
         "useDPKGParserForAlpine": true,
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
-        "useLegacyAlpineCVEURLPrefix": true
+        "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true
       }
     },
     {
@@ -116,7 +122,8 @@
         "useDPKGParserForAlpine": true,
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
-        "useLegacyAlpineCVEURLPrefix": true
+        "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true
       }
     },
     {
@@ -132,7 +139,8 @@
         "useDPKGParserForAlpine": true,
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
-        "useLegacyAlpineCVEURLPrefix": true
+        "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true
       }
     },
     {
@@ -148,7 +156,8 @@
         "useDPKGParserForAlpine": true,
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
-        "useLegacyAlpineCVEURLPrefix": true
+        "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true
       }
     },
     {
@@ -164,7 +173,8 @@
         "useDPKGParserForAlpine": true,
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
-        "useLegacyAlpineCVEURLPrefix": true
+        "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true
       }
     },
     {
@@ -179,6 +189,7 @@
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -193,6 +204,7 @@
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -207,6 +219,7 @@
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -221,6 +234,7 @@
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -235,6 +249,7 @@
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -248,6 +263,7 @@
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -259,6 +275,7 @@
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -270,6 +287,7 @@
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -281,6 +299,7 @@
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -292,6 +311,7 @@
         "keepUnusedRHELv2CPEs": true,
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -302,6 +322,7 @@
       "config": {
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -312,6 +333,7 @@
       "config": {
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -322,6 +344,7 @@
       "config": {
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -332,6 +355,7 @@
       "config": {
         "useLegacyUbuntuCVEURLPrefix": true,
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -341,6 +365,7 @@
       "uuid": "76920bf9-d0d2-47cd-9d53-ae4943edc02a",
       "config": {
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -350,6 +375,7 @@
       "uuid": "4d2f8c67-af86-443e-9c21-58261672f262",
       "config": {
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -359,6 +385,7 @@
       "uuid": "90ed7d2d-7839-4f65-93fb-e56f37a62224",
       "config": {
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -368,6 +395,7 @@
       "uuid": "56f8939b-653c-468c-8114-ff8a009d67cd",
       "config": {
         "useLegacyAlpineCVEURLPrefix": true,
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -376,6 +404,7 @@
       "timestamp": "2022-07-07T00:19:50.023423474Z",
       "uuid": "b36af074-8f40-4221-a4f6-b96d05d177dd",
       "config": {
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     },
@@ -384,6 +413,7 @@
       "timestamp": "2022-09-08T18:34:29.343211144Z",
       "uuid": "f81dbc6b-5899-433b-bc86-9127219a9d89",
       "config": {
+        "useLegacyRHELv2PackageInfos": true,
         "ignoreIstioVulns": true
       }
     }


### PR DESCRIPTION
The changes relating to the diff step in https://github.com/stackrox/scanner/pull/928 caused RHELv2 updates to not work properly with older Scanner versions.

Older Scanner versions rely on `PackageInfos` to be populated. Genesis dumps no longer populate this field, and the diff converted each base dump's `PackageInfos` to `Packages`. Instead, we should have converted the new `Packages` to the old `PackageInfos` so older scanners would understand them properly.

Local Testing Steps:

1. Run `make build-updater`
2. Run `./bin/updater generate-dump --out-file test.zip`. This will generate the latest genesis dump with the latest vulnerabilities
3. Run `./test.sh` where `test.sh` is defined below
4. Confirm `PackageInfos` are populated the correct data. For example, you can unzip `/tmp/diff-dumps/dump0/diff.zip` and look at `rhelv2/vulns/RHEL9-rhel-9-including-unpatched.json` and verify "RHSA-2022:7288" has all the fields populated as expected

test.sh:

```
mkdir -p /tmp/diff-dumps
idx=-1
while IFS=$'\t' read -r dumploc timestamp config; do
    idx=$((idx+1))
    dump_file_name="${dumploc##*/}"
    echo "Pulling genesis dump from ${dumploc}"
    gsutil cp "${dumploc}" .
    timestamp_in_zip="$(unzip -p "${dump_file_name}" manifest.json | jq -r '.until')"
    echo "Got timestamps -- from zip: ${timestamp_in_zip}; from manifest: ${timestamp}"
    [[ "${timestamp_in_zip}" == "${timestamp}" ]] # Assertion on the manifest contents
    # $ROOT/bin/updater is from the generate-genesis image in OpenShift CI.
    ./bin/updater diff-dumps --base-dump "${dump_file_name}" --head-dump test.zip --config "${config}" --out-file "/tmp/diff-dumps/dump${idx}/diff.zip"
done < <(jq -r '.knownGenesisDumps | .[]| [.dumpLocationInGS, .timestamp, (.config // empty | tostring)] | @tsv' < test.json)
du -d 2 -kh "/tmp/diff-dumps"
```

test.json:

```
{
  "knownGenesisDumps": [
    {
      "dumpLocationInGS": "gs://stackrox-scanner-ci-vuln-dump/genesis-20220908183429.zip",
      "timestamp": "2022-09-08T18:34:29.343211144Z",
      "uuid": "f81dbc6b-5899-433b-bc86-9127219a9d89",
      "config": {
        "useLegacyRHELv2PackageInfos": true,
        "ignoreIstioVulns": true
      }
    }
  ]
}
```