### PR TITLE
fix release tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ TAG := # make sure tag is never injectable as an env var
 ifdef CI
 ifneq ($(NIGHTLY_TAG),)
 TAG := $(NIGHTLY_TAG)
+else ifneq ($(RELEASE_TAG),)
+TAG := $(RELEASE_TAG)
 endif
 endif
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -588,6 +588,8 @@ openshift_ci_mods() {
 
     handle_nightly_runs
 
+    handle_release_runs
+
     info "Status after mods:"
     "$ROOT/status.sh" || true
 
@@ -647,6 +649,18 @@ handle_nightly_runs() {
     nightly_tag_prefix="$(git describe --tags --abbrev=0 --exclude '*-nightly-*')-nightly-"
     if ! is_in_PR_context && [[ "${JOB_NAME_SAFE:-}" =~ ^nightly- ]]; then
         ci_export NIGHTLY_TAG "${nightly_tag_prefix}$(date '+%Y%m%d')"
+    fi
+}
+
+handle_release_runs() {
+    if ! is_OPENSHIFT_CI; then
+        die "Only for OpenShift CI"
+    fi
+
+    local base_ref
+    base_ref="$(get_base_ref)"
+    if is_tagged && [[ "$base_ref" =~ ^release- ]]; then
+        ci_export RELEASE_TAG "$(git tag --sort=creatordate --contains | tail -1)"
     fi
 }
 


### PR DESCRIPTION
https://github.com/stackrox/scanner/pull/954 ensured hourly CI runs are not tagged with "nightly"; however, that change caused releases to be tagged improperly (the tag is the "long" version).

This PR adds a `RELEASE_TAG` which does not use the "long" version is the CI build is discovered to be for a release tag.

These changes were already used to tag `2.27.2`. Please see the CI run for this commit: https://github.com/stackrox/scanner/commit/e365ba197d3e2a0e459cc40cf6d2a00e08226701