### PR TITLE
ROX-12967: Introduce local-nodescanner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,11 @@ build-updater: deps
 	@echo "+ $@"
 	go build -trimpath -o ./bin/updater ./cmd/updater
 
+.PHONY: local-nodescanner-linux
+local-nodescanner-linux:
+	@echo "+ $@"
+	GOOS=linux GOARCH=amd64 go build -trimpath -o ./bin/local-nodescanner ./tools/local-nodescanner
+
 ###########
 ## Style ##
 ###########

--- a/api/v1/models.go
+++ b/api/v1/models.go
@@ -124,7 +124,7 @@ func LayerFromDatabaseModel(db database.Datastore, dbLayer database.Layer, linea
 
 	notes := getNotes(layer.NamespaceName, uncertifiedRHEL)
 
-	if (withFeatures || withVulnerabilities) && (dbLayer.Features != nil || namespaces.IsRHELNamespace(layer.NamespaceName)) {
+	if (withFeatures || withVulnerabilities) && (dbLayer.Features != nil || namespaces.IsRHELNamespace(layer.NamespaceName) || namespaces.IsRHCOSNamespace(layer.NamespaceName)) {
 		for _, dbFeatureVersion := range dbLayer.Features {
 			feature := featureFromDatabaseModel(dbFeatureVersion, opts.GetUncertifiedRHEL(), depMap)
 
@@ -135,7 +135,7 @@ func LayerFromDatabaseModel(db database.Datastore, dbLayer database.Layer, linea
 			updateFeatureWithVulns(feature, dbFeatureVersion.AffectedBy, dbFeatureVersion.Feature.Namespace.VersionFormat)
 			layer.Features = append(layer.Features, *feature)
 		}
-		if !uncertifiedRHEL && namespaces.IsRHELNamespace(layer.NamespaceName) {
+		if !uncertifiedRHEL && (namespaces.IsRHELNamespace(layer.NamespaceName) || namespaces.IsRHCOSNamespace(layer.NamespaceName)) {
 			certified, err := addRHELv2Vulns(db, &layer)
 			if err != nil {
 				return layer, notes, err
@@ -202,7 +202,7 @@ func ComponentsFromDatabaseModel(db database.Datastore, dbLayer *database.Layer,
 		}
 	}
 
-	if !uncertifiedRHEL && namespaces.IsRHELNamespace(namespaceName) {
+	if !uncertifiedRHEL && (namespaces.IsRHELNamespace(namespaceName) || namespaces.IsRHCOSNamespace(namespaceName)) {
 		var certified bool
 		var err error
 		rhelv2PkgEnvs, certified, err = getRHELv2PkgEnvs(db, dbLayer.Name)

--- a/ext/featurefmt/driver.go
+++ b/ext/featurefmt/driver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/pkg/analyzer"
+	"github.com/stackrox/scanner/pkg/rhcos"
 	rhelv2 "github.com/stackrox/scanner/pkg/rhelv2/rpm"
 	"github.com/stackrox/scanner/pkg/tarutil"
 	"github.com/stretchr/testify/assert"
@@ -105,6 +106,7 @@ func RequiredFilenames() (files []string) {
 	}
 
 	files = append(files, rhelv2.RequiredFilenames()...)
+	files = append(files, rhcos.RequiredFilenames()...)
 
 	return
 }

--- a/ext/featurens/redhatrelease/redhatrelease.go
+++ b/ext/featurens/redhatrelease/redhatrelease.go
@@ -32,7 +32,7 @@ import (
 var (
 	amazonReleaseRegexp = regexp.MustCompile(`(?P<os>Amazon) (Linux release|Linux AMI release) (?P<version>[\d]+\.[\d]+|[\d]+)`)
 	oracleReleaseRegexp = regexp.MustCompile(`(?P<os>Oracle) (Linux Server release) (?P<version>[\d]+)`)
-	centosReleaseRegexp = regexp.MustCompile(`(?P<os>[^\s]*) (Linux release|release) (?P<version>[\d]+)`)
+	centosReleaseRegexp = regexp.MustCompile(`(?P<os>CentOS) (Linux release|release) (?P<version>[\d]+)`)
 	redhatReleaseRegexp = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (Client release|Server release|Workstation release|release) (?P<version>[\d]+)`)
 	rockyReleaseRegexp  = regexp.MustCompile(`(?P<os>Rocky) (Linux release) (?P<version>[\d]+)`)
 

--- a/ext/featurens/redhatrelease/redhatrelease.go
+++ b/ext/featurens/redhatrelease/redhatrelease.go
@@ -34,6 +34,7 @@ var (
 	oracleReleaseRegexp = regexp.MustCompile(`(?P<os>Oracle) (Linux Server release) (?P<version>[\d]+)`)
 	centosReleaseRegexp = regexp.MustCompile(`(?P<os>CentOS) (Linux release|release) (?P<version>[\d]+)`)
 	redhatReleaseRegexp = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (Client release|Server release|Workstation release|release) (?P<version>[\d]+)`)
+	rhcosReleaseRegexp  = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (CoreOS release) (?P<version>[\d]+[\.]?[\d]*)`)
 	rockyReleaseRegexp  = regexp.MustCompile(`(?P<os>Rocky) (Linux release) (?P<version>[\d]+)`)
 
 	// RequiredFilenames defines the names of the files required to identify the RHEL-based release.
@@ -87,6 +88,15 @@ func (d detector) Detect(files analyzer.Files, opts *featurens.DetectorOptions) 
 				namespace.Name = "rhel:" + r[3]
 			}
 			return namespace
+		}
+
+		// Attempt to match CoreOS.
+		r = rhcosReleaseRegexp.FindStringSubmatch(string(f.Contents))
+		if len(r) == 4 {
+			return &database.Namespace{
+				Name:          "rhcos:" + r[3],
+				VersionFormat: rpm.ParserName,
+			}
 		}
 
 		// Attempt to match Rocky.

--- a/ext/featurens/redhatrelease/redhatrelease.go
+++ b/ext/featurens/redhatrelease/redhatrelease.go
@@ -32,7 +32,7 @@ import (
 var (
 	amazonReleaseRegexp = regexp.MustCompile(`(?P<os>Amazon) (Linux release|Linux AMI release) (?P<version>[\d]+\.[\d]+|[\d]+)`)
 	oracleReleaseRegexp = regexp.MustCompile(`(?P<os>Oracle) (Linux Server release) (?P<version>[\d]+)`)
-	centosReleaseRegexp = regexp.MustCompile(`(?P<os>CentOS) (Linux release|release) (?P<version>[\d]+)`)
+	centosReleaseRegexp = regexp.MustCompile(`(?P<os>[^\s]*) (Linux release|release) (?P<version>[\d]+)`)
 	redhatReleaseRegexp = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (Client release|Server release|Workstation release|release) (?P<version>[\d]+)`)
 	rhcosReleaseRegexp  = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (CoreOS release) (?P<version>[\d]+[\.]?[\d]*)`)
 	rockyReleaseRegexp  = regexp.MustCompile(`(?P<os>Rocky) (Linux release) (?P<version>[\d]+)`)
@@ -90,7 +90,7 @@ func (d detector) Detect(files analyzer.Files, opts *featurens.DetectorOptions) 
 			return namespace
 		}
 
-		// Attempt to match CoreOS.
+		// Attempt to match Red Hat CoreOS.
 		r = rhcosReleaseRegexp.FindStringSubmatch(string(f.Contents))
 		if len(r) == 4 {
 			return &database.Namespace{

--- a/ext/featurens/redhatrelease/redhatrelease_test.go
+++ b/ext/featurens/redhatrelease/redhatrelease_test.go
@@ -82,6 +82,12 @@ func TestDetector(t *testing.T) {
 			}),
 		},
 		{
+			ExpectedNamespace: &database.Namespace{Name: "rhcos:4.11", VersionFormat: rpm.ParserName},
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
+				"etc/redhat-release": {Contents: []byte(`Red Hat Enterprise Linux CoreOS release 4.11`)},
+			}),
+		},
+		{
 			ExpectedNamespace: &database.Namespace{Name: "centos:7", VersionFormat: rpm.ParserName},
 			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
 				"etc/system-release": {Contents: []byte(`CentOS Linux release 7.1.1503 (Core)`)},

--- a/pkg/analyzer/detection/detection.go
+++ b/pkg/analyzer/detection/detection.go
@@ -27,7 +27,7 @@ func DetectComponents(name string, files analyzer.Files, parent *database.Layer,
 	var featureVersions []database.FeatureVersion
 	var rhelfeatures *database.RHELv2Components
 
-	if namespace != nil && wellknownnamespaces.IsRHELNamespace(namespace.Name) {
+	if namespace != nil && (wellknownnamespaces.IsRHELNamespace(namespace.Name) || wellknownnamespaces.IsRHCOSNamespace(namespace.Name)) {
 		// This is a RHEL-based image that must be scanned in a certified manner.
 		// Use the RHELv2 scanner instead.
 		packages, cpes, err := rpm.ListFeatures(files)

--- a/pkg/analyzer/nodes/node.go
+++ b/pkg/analyzer/nodes/node.go
@@ -1,6 +1,7 @@
 package nodes
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -89,11 +90,12 @@ func extractFilesFromDirectory(root string, matcher matcher.PrefixMatcher) (*fil
 		files: make(map[string]*fileMetadata),
 	}
 	m := metrics.FileExtractionMetrics{}
-	for _, dir := range matcher.GetCommonPrefixDirs() {
+	for _, dir := range []string{"etc/", "usr/share/rpm", "var/lib/rpm"} { //TODO(ROX-13771): Use range matcher.GetCommonPrefixDirs() again after fixing
 		if err := n.addFiles(filepath.FromSlash(dir), matcher, &m); err != nil {
 			return nil, errors.Wrapf(err, "failed to match filesMap at %q (at %q)", dir, n.root)
 		}
 	}
+	fmt.Printf("added following files to filesMap: %v\n", n.files)
 	m.Emit()
 	return n, nil
 }
@@ -188,6 +190,7 @@ func (n *filesMap) Get(path string) (analyzer.FileData, bool) {
 		}
 		// Prepend the root to make this an absolute file path.
 		absPath := filepath.Join(n.root, filepath.FromSlash(path))
+		fmt.Printf("filesMap.Get full absPath: %v\n", absPath)
 		if f.isSymlink {
 			// Resolve the symlink to the correct destination.
 			var linkDest string

--- a/pkg/rhcos/rpm.go
+++ b/pkg/rhcos/rpm.go
@@ -1,0 +1,9 @@
+package rhcos
+
+const (
+	cpeManifests = `usr/share/buildinfo`
+)
+
+func RequiredFilenames() []string {
+	return append([]string{cpeManifests}) // FIXME: Nothing is aware of CPE manifests yet, e.g. SingletonOSMatcher
+}

--- a/pkg/wellknownnamespaces/util.go
+++ b/pkg/wellknownnamespaces/util.go
@@ -20,7 +20,7 @@ func IsCentOSNamespace(namespace string) bool {
 // The namespace is expected to be of form `namespacename:version` but only `namespacename` is required.
 // For example: rhel:7, rhel:8, centos:8, ubuntu:14.04.
 func IsRHELNamespace(namespace string) bool {
-	return strings.HasPrefix(namespace, "rhel")
+	return (strings.HasPrefix(namespace, "rhel") || strings.HasPrefix(namespace, "rhcos"))
 }
 
 // IsUbuntuNamespace returns true if the given argument identifies an Ubuntu namespace.

--- a/pkg/wellknownnamespaces/util.go
+++ b/pkg/wellknownnamespaces/util.go
@@ -20,7 +20,14 @@ func IsCentOSNamespace(namespace string) bool {
 // The namespace is expected to be of form `namespacename:version` but only `namespacename` is required.
 // For example: rhel:7, rhel:8, centos:8, ubuntu:14.04.
 func IsRHELNamespace(namespace string) bool {
-	return (strings.HasPrefix(namespace, "rhel") || strings.HasPrefix(namespace, "rhcos"))
+	return strings.HasPrefix(namespace, "rhel")
+}
+
+// IsRHCOSNamespace returns true if the given argument identifies an RHCOS namespace.
+// The namespace is expected to be of form `namespacename:version` but only `namespacename` is required.
+// For example: rhel:7, rhel:8, centos:8, ubuntu:14.04.
+func IsRHCOSNamespace(namespace string) bool {
+	return strings.HasPrefix(namespace, "rhcos")
 }
 
 // IsUbuntuNamespace returns true if the given argument identifies an Ubuntu namespace.

--- a/tools/local-nodescanner/main.go
+++ b/tools/local-nodescanner/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stackrox/scanner/pkg/analyzer/nodes"
+)
+
+// local-nodescanner is an application that allows you to run the node scan / inventory code locally on you machine.
+
+// Required:
+// Extracted filesystem from an RHCOS live .ISO (https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/)
+// installed RPM v 4.13.3 (precisely: have rpmdb in path) - newer versions, e.g. 4.17, WILL NOT WORK and produce empty components.
+//        alternatively:
+//        run this binary with mounted unpacked filesystem folder in an UBI8 image (e.g. registry.access.redhat.com/ubi8/ubi:8.7)
+
+// How To:
+// Download the ISO, extract with 7z x <iso-name>, then extract images/pxeboot/root.squashfs with 7z as well
+// The root fs will be in ostree/deploy/rhcos/deploy/
+// Caveat: The image doesn't contain a populated rpm Package DB. You still need to get that from a running system, e.g. a node.
+
+// There is also a make target available to build a linux binary: make local-nodescanner-linux
+
+func main() {
+	var uncertifiedRHEL bool
+	var path string
+
+	flag.StringVar(&path, "path", "", "Path to an extracted RHCOS rootFS folder")
+	flag.BoolVar(&uncertifiedRHEL, "uncertifiedRHEL", false, "Whether to treat this run as uncertified RHEL FS")
+	flag.Parse()
+
+	logrus.Infof("%v", path)
+	if path == "" {
+		logrus.Fatal("A valid path is required")
+	}
+
+	components, err := nodes.Analyze("localnode", path, uncertifiedRHEL)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	logrus.Infof("Nodescan finished. Returned components: %v", components)
+}


### PR DESCRIPTION
This PR introduces `local-nodescanner` in the `tools` directory.
Its goal is to run the code used for RHCOS node scanning, usually run by `Compliance` on a Node, locally.
As the local version expects a path to a filesystem as argument, it can either run in a live environment or on an unpacked filesystem on disk.

Testing:
- Tested on live UBI8 image by executing with `path=/`
- Tested on extracted RHCOS FS by executing with `path=/path/to/extracted/dir`

In case of the RHCOS FS, I copied a populated `/var/lib/rpm/Packages` file from an OpenShift Node running RHCOS 4.11 and manually added it to the right folder in the unpacked FS dump.
Results of both runs can be found in the comments below.