### PR TITLE
Added fix for ROX-12979- Vulnerability scan doesn't include dependency libs

### DIFF
--- a/e2etests/grpc_full_test.go
+++ b/e2etests/grpc_full_test.go
@@ -59,6 +59,13 @@ func verifyImage(t *testing.T, imgScan *v1.Image, test testCase) {
 							exec.RequiredFeatures[i].GetName() == exec.RequiredFeatures[j].GetName() && exec.RequiredFeatures[i].GetVersion() < exec.RequiredFeatures[j].GetVersion()
 					})
 				}
+
+				for _, exec := range feature.ProvidedExecutables {
+					sort.Slice(exec.RequiredFeatures, func(i, j int) bool {
+						return exec.RequiredFeatures[i].GetName() < exec.RequiredFeatures[j].GetName() ||
+							exec.RequiredFeatures[i].GetName() == exec.RequiredFeatures[j].GetName() && exec.RequiredFeatures[i].GetVersion() < exec.RequiredFeatures[j].GetVersion()
+					})
+				}
 				assert.ElementsMatch(t, feature.ProvidedExecutables, matching.ProvidedExecutables)
 			}
 			feature.ProvidedExecutables = nil

--- a/e2etests/grpc_test.go
+++ b/e2etests/grpc_test.go
@@ -89,6 +89,14 @@ func verifyComponents(t *testing.T, components *v1.Components, test testCase) {
 						exec.RequiredFeatures[i].GetName() == exec.RequiredFeatures[j].GetName() && exec.RequiredFeatures[i].GetVersion() < exec.RequiredFeatures[j].GetVersion()
 				})
 			}
+
+			for _, exec := range expectedFeature.Executables {
+				sort.Slice(exec.RequiredFeatures, func(i, j int) bool {
+					return exec.RequiredFeatures[i].GetName() < exec.RequiredFeatures[j].GetName() ||
+						exec.RequiredFeatures[i].GetName() == exec.RequiredFeatures[j].GetName() && exec.RequiredFeatures[i].GetVersion() < exec.RequiredFeatures[j].GetVersion()
+				})
+			}
+
 			assert.ElementsMatch(t, expectedFeature.Executables, f.Executables)
 		}
 		expectedFeature.Executables = nil

--- a/e2etests/sanity_test.go
+++ b/e2etests/sanity_test.go
@@ -46,6 +46,7 @@ func verifyImageHasExpectedFeatures(t *testing.T, client *client.Clairify, test 
 	env, err := client.RetrieveImageDataBySHA(img.SHA, &types.GetImageDataOpts{
 		UncertifiedRHELResults: imageRequest.UncertifiedRHELScan,
 	})
+
 	require.NoError(t, err)
 	require.Nil(t, env.Error)
 	require.NotNil(t, env.Layer)
@@ -75,6 +76,13 @@ func verifyImageHasExpectedFeatures(t *testing.T, client *client.Clairify, test 
 
 			if test.checkProvidedExecutables {
 				for _, exec := range matching.Executables {
+					sort.Slice(exec.RequiredFeatures, func(i, j int) bool {
+						return exec.RequiredFeatures[i].GetName() < exec.RequiredFeatures[j].GetName() ||
+							exec.RequiredFeatures[i].GetName() == exec.RequiredFeatures[j].GetName() && exec.RequiredFeatures[i].GetVersion() < exec.RequiredFeatures[j].GetVersion()
+					})
+				}
+
+				for _, exec := range feature.Executables {
 					sort.Slice(exec.RequiredFeatures, func(i, j int) bool {
 						return exec.RequiredFeatures[i].GetName() < exec.RequiredFeatures[j].GetName() ||
 							exec.RequiredFeatures[i].GetName() == exec.RequiredFeatures[j].GetName() && exec.RequiredFeatures[i].GetVersion() < exec.RequiredFeatures[j].GetVersion()

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -20,7 +20,7 @@ type testCase struct {
 	namespace          string
 	expectedFeatures   []apiV1.Feature
 	unexpectedFeatures []apiV1.Feature
-	// This specifies that the features only need to contain at least the vulnerabilities specified
+	// This specifies that the features only need to contain at least the vulnerabilities specified.
 	onlyCheckSpecifiedVulns  bool
 	uncertifiedRHEL          bool
 	checkProvidedExecutables bool
@@ -2570,9 +2570,8 @@ var testCases = []testCase{
 						Path: "/lib/libapk.so.3.12.0",
 						RequiredFeatures: []*v1.FeatureNameVersion{
 							{Name: "apk-tools", Version: "2.12.0-r4"},
-							{Name: "libcrypto1.1", Version: "1.1.1i-r0"},
-							{Name: "libssl1.1", Version: "1.1.1i-r0"},
 							{Name: "musl", Version: "1.2.2_pre7-r0"},
+							{Name: "openssl", Version: "1.1.1i-r0"},
 							{Name: "zlib", Version: "1.2.11-r3"},
 						},
 					},
@@ -2580,8 +2579,7 @@ var testCases = []testCase{
 						Path: "/sbin/apk",
 						RequiredFeatures: []*v1.FeatureNameVersion{
 							{Name: "apk-tools", Version: "2.12.0-r4"},
-							{Name: "libcrypto1.1", Version: "1.1.1i-r0"},
-							{Name: "libssl1.1", Version: "1.1.1i-r0"},
+							{Name: "openssl", Version: "1.1.1i-r0"},
 							{Name: "musl", Version: "1.2.2_pre7-r0"},
 							{Name: "zlib", Version: "1.2.11-r3"},
 						},
@@ -2622,6 +2620,15 @@ var testCases = []testCase{
 				AddedBy: "sha256:596ba82af5aaa3e2fd9d6f955b8b94f0744a2b60710e3c243ba3e4a467f051d1",
 				FixedBy: "1.32.1-r9",
 				Executables: []*v1.Executable{
+					{
+						Path: "/usr/bin/ssl_client",
+						RequiredFeatures: []*v1.FeatureNameVersion{
+							{Name: "busybox", Version: "1.32.1-r0"},
+							{Name: "libtls-standalone", Version: "2.9.1-r1"},
+							{Name: "musl", Version: "1.2.2_pre7-r0"},
+							{Name: "openssl", Version: "1.1.1i-r0"},
+						},
+					},
 					{
 						Path: "/etc/network/if-up.d/dad",
 						RequiredFeatures: []*v1.FeatureNameVersion{
@@ -2767,6 +2774,40 @@ var testCases = []testCase{
 				},
 				AddedBy: "sha256:2408cc74d12b6cd092bb8b516ba7d5e290f485d3eb9672efc00f0583730179e8",
 				FixedBy: "1.35.0-r15",
+			},
+			{
+				Name:          "openssl",
+				NamespaceName: "alpine:v3.16",
+				VersionFormat: "apk",
+				Version:       "1.1.1o-r0",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:          "CVE-2022-2097",
+						NamespaceName: "alpine:v3.16",
+						Description:   "AES OCB mode for 32-bit x86 platforms using the AES-NI assembly optimised implementation will not encrypt the entirety of the data under some circumstances. This could reveal sixteen bytes of data that was preexisting in the memory that wasn't written. In the special case of \"in place\" encryption, sixteen bytes of the plaintext would be revealed. Since OpenSSL does not support OCB based cipher suites for TLS and DTLS, they are both unaffected. Fixed in OpenSSL 3.0.5 (Affected 3.0.0-3.0.4). Fixed in OpenSSL 1.1.1q (Affected 1.1.1-1.1.1p).",
+						Link:          "https://www.cve.org/CVERecord?id=CVE-2022-2097",
+						Severity:      "Moderate",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 3.9,
+									"ImpactScore":         1.4,
+									"Score":               5.3,
+									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+								},
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 10.0,
+									"ImpactScore":         2.9,
+									"Score":               5.0,
+									"Vectors":             "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+								},
+							},
+						},
+						FixedBy: "1.1.1q-r0",
+					},
+				},
+				AddedBy: "sha256:2408cc74d12b6cd092bb8b516ba7d5e290f485d3eb9672efc00f0583730179e8",
+				FixedBy: "1.1.1q-r0",
 			},
 		},
 	},

--- a/e2etests/utils_test.go
+++ b/e2etests/utils_test.go
@@ -21,6 +21,6 @@ func getMatchingFeature(t *testing.T, featureList []v1.Feature, featureToFind v1
 	if allowNotFound && candidateIdx == -1 {
 		return nil
 	}
-	require.NotEqual(t, -1, candidateIdx, "Feature %+v not in list: %v", featureToFind, featureList)
+	require.NotEqual(t, -1, candidateIdx, "Feature %+v not in list: %+v", featureToFind, featureList)
 	return &featureList[candidateIdx]
 }

--- a/ext/featurefmt/apk/apk_test.go
+++ b/ext/featurefmt/apk/apk_test.go
@@ -64,11 +64,7 @@ func TestAPKFeatureDetection(t *testing.T) {
 					Version: "1.2.8-r2",
 				},
 				{
-					Feature: database.Feature{Name: "libcrypto1.0"},
-					Version: "1.0.2h-r1",
-				},
-				{
-					Feature: database.Feature{Name: "libssl1.0"},
+					Feature: database.Feature{Name: "openssl"},
 					Version: "1.0.2h-r1",
 				},
 				{
@@ -76,15 +72,11 @@ func TestAPKFeatureDetection(t *testing.T) {
 					Version: "2.6.7-r0",
 				},
 				{
-					Feature: database.Feature{Name: "scanelf"},
+					Feature: database.Feature{Name: "pax-utils"},
 					Version: "1.1.6-r0",
 				},
 				{
-					Feature: database.Feature{Name: "musl-utils"},
-					Version: "1.1.14-r10",
-				},
-				{
-					Feature: database.Feature{Name: "libc-utils"},
+					Feature: database.Feature{Name: "libc-dev"},
 					Version: "0.7-r0",
 				},
 			},


### PR DESCRIPTION
This change will enable scanner to show vulnerabilities for source package for alpine linux.
Added a new e2e openssl vuln test for this scenario.