### PR TITLE
Use Stackrox builder to build Scanner for arm64 / apple silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BUILD_IMAGE := $(DEFAULT_IMAGE_REGISTRY)/apollo-ci:$(BUILD_IMAGE_VERSION)
 
 ifeq ($(shell uname -ms),Darwin arm64)
 	# TODO(ROX-12064) build these images in the CI pipeline
-	BUILD_IMAGE = quay.io/rhacs-eng/sandbox:apollo-ci-scanner-build-0.3.44-arm64
+	BUILD_IMAGE = quay.io/rhacs-eng/sandbox:apollo-ci-stackrox-build-0.3.49-arm64
 	ARCH := aarch64
 	GOARCH := arm64
 else


### PR DESCRIPTION
This is an alternative to fix Scanner builds (`make image`) errors on Apple silicon Macs (see also https://github.com/stackrox/scanner/pull/1038), that uses a native arm64 builder image.

The current builder image has Go v17 and cannot build the current source.

This PR changes the builder image to use the current Stackrox builder, which has Go 18.4. It should be acceptable to use this image (the main difference between the Scanner and the Stackrox builder images is that the Stackrox one also contains the RocksDB binaries and its dependencies).