### PR TITLE
ROX-14035: only read file if within given root

### DIFF
--- a/pkg/analyzer/nodes/node.go
+++ b/pkg/analyzer/nodes/node.go
@@ -1,6 +1,7 @@
 package nodes
 
 import (
+	"github.com/stackrox/scanner/pkg/fsutil"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -181,35 +182,42 @@ func extractFile(path string, entry fs.DirEntry, pathMatcher matcher.Matcher, m 
 func (n *filesMap) Get(path string) (analyzer.FileData, bool) {
 	// When a previous read error has happened, we act as if all the files map is
 	// empty. Analyzer are expected to handle it gracefully.
-	if f, ok := n.files[path]; n.readError == nil && ok {
-		fileData := analyzer.FileData{Executable: f.isExecutable}
-		if !f.isExtractable {
-			return fileData, true
+	f, ok := n.files[path]
+	if n.readError != nil || !ok {
+		return analyzer.FileData{}, false
+	}
+
+	fileData := analyzer.FileData{Executable: f.isExecutable}
+	if !f.isExtractable {
+		return fileData, true
+	}
+	// Prepend the root to make this an absolute file path.
+	absPath := filepath.Join(n.root, filepath.FromSlash(path))
+	if f.isSymlink {
+		// Resolve the symlink to the correct destination.
+		var linkDest string
+		linkDest, n.readError = os.Readlink(absPath)
+		if n.readError != nil {
+			return analyzer.FileData{}, false
 		}
-		// Prepend the root to make this an absolute file path.
-		absPath := filepath.Join(n.root, filepath.FromSlash(path))
-		if f.isSymlink {
-			// Resolve the symlink to the correct destination.
-			var linkDest string
-			linkDest, n.readError = os.Readlink(absPath)
-			if n.readError != nil {
-				return analyzer.FileData{}, false
-			}
-			// If the symlink is an absolute path,
-			// prepend n.root to the link's destination
-			// and read that file, instead.
-			// Note: this only matters for symlinks to absolute paths.
-			// Symlinks to relative paths are followed correctly.
-			if filepath.IsAbs(linkDest) {
-				absPath = filepath.Join(n.root, filepath.FromSlash(linkDest))
-			}
-		}
-		fileData.Contents, n.readError = os.ReadFile(absPath)
-		if n.readError == nil {
-			return fileData, true
+		// If the symlink is an absolute path,
+		// prepend n.root to the link's destination
+		// and read that file, instead.
+		// Note: this only matters for symlinks to absolute paths.
+		// Symlinks to relative paths are followed correctly.
+		if filepath.IsAbs(linkDest) {
+			absPath = filepath.Join(n.root, filepath.FromSlash(linkDest))
 		}
 	}
-	return analyzer.FileData{}, false
+
+	if !fsutil.Within(n.root, absPath) {
+
+	}
+
+	fileData.Contents, n.readError = os.ReadFile(absPath)
+	if n.readError == nil {
+		return fileData, true
+	}
 }
 
 // GetFilesPrefix implements analyzer.Files

--- a/pkg/analyzer/nodes/node.go
+++ b/pkg/analyzer/nodes/node.go
@@ -210,14 +210,17 @@ func (n *filesMap) Get(path string) (analyzer.FileData, bool) {
 		}
 	}
 
+	// Protect against potentially reading from a path outside root.
 	if !fsutil.Within(n.root, absPath) {
-
+		return analyzer.FileData{}, false
 	}
 
 	fileData.Contents, n.readError = os.ReadFile(absPath)
-	if n.readError == nil {
-		return fileData, true
+	if n.readError != nil {
+		return analyzer.FileData{}, false
 	}
+
+	return fileData, true
 }
 
 // GetFilesPrefix implements analyzer.Files

--- a/pkg/analyzer/nodes/node.go
+++ b/pkg/analyzer/nodes/node.go
@@ -1,7 +1,6 @@
 package nodes
 
 import (
-	"github.com/stackrox/scanner/pkg/fsutil"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/analyzer/detection"
 	"github.com/stackrox/scanner/pkg/component"
+	"github.com/stackrox/scanner/pkg/fsutil"
 	"github.com/stackrox/scanner/pkg/fsutil/fileinfo"
 	"github.com/stackrox/scanner/pkg/matcher"
 	"github.com/stackrox/scanner/pkg/metrics"

--- a/pkg/analyzer/nodes/node.go
+++ b/pkg/analyzer/nodes/node.go
@@ -211,6 +211,7 @@ func (n *filesMap) Get(path string) (analyzer.FileData, bool) {
 	}
 
 	// Protect against potentially reading from a path outside root.
+	// This is possible when reading a symlinked file.
 	if !fsutil.Within(n.root, absPath) {
 		return analyzer.FileData{}, false
 	}

--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -17,6 +17,7 @@ package fsutil
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -63,4 +64,14 @@ func Readdir(path string, filter dirFilter) ([]string, error) {
 	}
 
 	return files, nil
+}
+
+// Within returns true if sub is within parent.
+// This function is inspired by https://github.com/mholt/archiver/blob/v3.5.0/archiver.go#L360
+func Within(parent, sub string) bool {
+	rel, err := filepath.Rel(parent, sub)
+	if err != nil {
+		return false
+	}
+	return !strings.Contains(rel, "..")
 }

--- a/pkg/fsutil/fsutil_test.go
+++ b/pkg/fsutil/fsutil_test.go
@@ -2,54 +2,55 @@ package fsutil
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWithin(t *testing.T) {
-	testcases := []struct{
+	testcases := []struct {
 		parent string
 		child  string
 		within bool
 	}{
 		{
 			parent: "/a/b",
-			child: "/a/b/c",
+			child:  "/a/b/c",
 			within: true,
 		},
 		{
 			parent: "/a/b/c",
-			child: "/a/b",
+			child:  "/a/b",
 			within: false,
 		},
 		{
 			parent: "/a/b",
-			child: "/a/b",
+			child:  "/a/b",
 			within: true,
 		},
 		{
 			parent: "a/b",
-			child: "a/b",
+			child:  "a/b",
 			within: true,
 		},
 		{
 			parent: "a/b",
-			child: "/a/b",
+			child:  "/a/b",
 			within: false,
 		},
 		{
 			parent: "/a/b",
-			child: "a/b",
+			child:  "a/b",
 			within: false,
 		},
 		{
 			parent: "/a",
-			child: "/a/b/../c/..",
+			child:  "/a/b/../c/..",
 			within: true,
 		},
 		{
 			parent: "/a",
-			child: "/a/b/../..",
+			child:  "/a/b/../..",
 			within: false,
 		},
 	}

--- a/pkg/fsutil/fsutil_test.go
+++ b/pkg/fsutil/fsutil_test.go
@@ -32,9 +32,29 @@ func TestWithin(t *testing.T) {
 			child: "a/b",
 			within: true,
 		},
+		{
+			parent: "a/b",
+			child: "/a/b",
+			within: false,
+		},
+		{
+			parent: "/a/b",
+			child: "a/b",
+			within: false,
+		},
+		{
+			parent: "/a",
+			child: "/a/b/../c/..",
+			within: true,
+		},
+		{
+			parent: "/a",
+			child: "/a/b/../..",
+			within: false,
+		},
 	}
 	for _, testcase := range testcases {
-		t.Run(fmt.Sprintf("%s-%s", testcase.parent, testcase.child), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s %s", testcase.parent, testcase.child), func(t *testing.T) {
 			assert.Equal(t, testcase.within, Within(testcase.parent, testcase.child))
 		})
 	}

--- a/pkg/fsutil/fsutil_test.go
+++ b/pkg/fsutil/fsutil_test.go
@@ -1,0 +1,41 @@
+package fsutil
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWithin(t *testing.T) {
+	testcases := []struct{
+		parent string
+		child  string
+		within bool
+	}{
+		{
+			parent: "/a/b",
+			child: "/a/b/c",
+			within: true,
+		},
+		{
+			parent: "/a/b/c",
+			child: "/a/b",
+			within: false,
+		},
+		{
+			parent: "/a/b",
+			child: "/a/b",
+			within: true,
+		},
+		{
+			parent: "a/b",
+			child: "a/b",
+			within: true,
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(fmt.Sprintf("%s-%s", testcase.parent, testcase.child), func(t *testing.T) {
+			assert.Equal(t, testcase.within, Within(testcase.parent, testcase.child))
+		})
+	}
+}

--- a/pkg/ziputil/open.go
+++ b/pkg/ziputil/open.go
@@ -2,8 +2,8 @@ package ziputil
 
 import (
 	"archive/zip"
+	"github.com/stackrox/scanner/pkg/fsutil"
 	"io"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -40,7 +40,7 @@ func OpenFile(zipR *zip.Reader, name string) (*ReadCloser, error) {
 func OpenFilesInDir(zipR *zip.Reader, dir string, suffix string) ([]*ReadCloser, error) {
 	var rs []*ReadCloser
 	for _, file := range zipR.File {
-		if within(dir, file.Name) && strings.HasSuffix(file.Name, suffix) {
+		if fsutil.Within(dir, file.Name) && strings.HasSuffix(file.Name, suffix) {
 			f, err := file.Open()
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to open file %s in directory %s", file.Name, dir)
@@ -53,14 +53,4 @@ func OpenFilesInDir(zipR *zip.Reader, dir string, suffix string) ([]*ReadCloser,
 	}
 
 	return rs, nil
-}
-
-// within returns true if sub is within the parent.
-// This function is inspired by https://github.com/mholt/archiver/blob/v3.5.0/archiver.go#L360
-func within(parent, sub string) bool {
-	rel, err := filepath.Rel(parent, sub)
-	if err != nil {
-		return false
-	}
-	return !strings.Contains(rel, "..")
 }

--- a/pkg/ziputil/open.go
+++ b/pkg/ziputil/open.go
@@ -2,11 +2,11 @@ package ziputil
 
 import (
 	"archive/zip"
-	"github.com/stackrox/scanner/pkg/fsutil"
 	"io"
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/scanner/pkg/fsutil"
 )
 
 // ReadCloser is a wrapper around io.ReadCloser for reading files in a ZIP.


### PR DESCRIPTION
It is possible a symlink in a node references a file outside of the "root". It's possible the symlink is a path which attempts to link to a file outside the bounds of its own "root".

It should be noted that we should, perhaps, drop symlink support in favor of determining and reading the expected paths, directly. This fix is added in case this does not happen or it happens after a release in which this function may be used.