### PR TITLE
update binaries used in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,14 +116,14 @@ ifdef CI
 	@echo 'The environment indicates we are in CI; running linters in check mode.'
 	@echo 'If this fails, run `make style`.'
 	@echo "Running with no tags..."
-	golangci-lint run
+	$(GOLANGCILINT_BIN) run
 	@echo "Running with release tags..."
 	@# We use --tests=false because some unit tests don't compile with release tags,
 	@# since they use functions that we don't define in the release build. That's okay.
-	golangci-lint run --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false
+	$(GOLANGCILINT_BIN) run --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false
 else
-	golangci-lint run --fix
-	golangci-lint run --fix --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false
+	$(GOLANGCILINT_BIN) run --fix
+	$(GOLANGCILINT_BIN) run --fix --build-tags "$(subst $(comma),$(space),$(RELEASE_GOTAGS))" --tests=false
 endif
 
 .PHONY: blanks
@@ -261,8 +261,8 @@ deploy-local: clean-helm-rendered
 
 .PHONY: ossls-notice
 ossls-notice: deps $(OSSLS_BIN)
-	ossls version
-	ossls audit --export image/scanner/rhel/THIRD_PARTY_NOTICES
+	$(OSSLS_BIN) version
+	$(OSSLS_BIN) audit --export image/scanner/rhel/THIRD_PARTY_NOTICES
 
 ###########
 ## Tests ##
@@ -314,7 +314,7 @@ scale-tests: deps
 .PHONY: report
 report: $(GO_JUNIT_REPORT_BIN)
 	@echo "+ $@"
-	@cat test.log | go-junit-report > report.xml
+	@cat test.log | $(GO_JUNIT_REPORT_BIN) > report.xml
 	@mkdir -p $(JUNIT_OUT)
 	@cp test.log report.xml $(JUNIT_OUT)
 	@echo
@@ -353,8 +353,8 @@ proto-generated-srcs: $(PROTO_GENERATED_SRCS)
 .PHONY: go-easyjson-srcs
 go-easyjson-srcs: $(EASYJSON_BIN)
 	@echo "+ $@"
-	@easyjson -pkg pkg/vulnloader/nvdloader
-	@easyjson -pkg api/v1
+	$(SILENT)$(EASYJSON_BIN) -pkg pkg/vulnloader/nvdloader
+	$(SILENT)$(EASYJSON_BIN) -pkg api/v1
 
 clean-proto-generated-srcs:
 	@echo "+ $@"
@@ -364,7 +364,7 @@ clean-proto-generated-srcs:
 ## Clean ##
 ###########
 .PHONY: clean
-clean: clean-image clean-helm-rendered clean-proto-generated-srcs clean-pprof clean-test
+clean: clean-image clean-helm-rendered clean-proto-generated-srcs clean-pprof clean-test clean-gobin
 	@echo "+ $@"
 
 .PHONY: clean-image
@@ -380,7 +380,7 @@ clean-helm-rendered:
 .PHONY: clean-pprof
 clean-pprof:
 	@echo "+ $@"
-	rm /tmp/pprof.zip || true
+	rm -f /tmp/pprof.zip
 	rm -rf /tmp/pprof
 
 .PHONY: clean-test
@@ -388,6 +388,11 @@ clean-test:
 	@echo "+ $@"
 	rm -rf test-output/
 	rm -rf junit-reports/
+
+.PHONY: clean-gobin
+clean-gobin:
+	@echo "+ $@"
+	rm -rf .gobin
 
 ##################
 ## Genesis Dump ##

--- a/Makefile
+++ b/Makefile
@@ -380,7 +380,7 @@ clean-helm-rendered:
 .PHONY: clean-pprof
 clean-pprof:
 	@echo "+ $@"
-	rm -f /tmp/pprof.zip
+	rm -f /tmp/pprof-out/pprof.zip
 	rm -rf /tmp/pprof
 
 .PHONY: clean-test
@@ -392,7 +392,7 @@ clean-test:
 .PHONY: clean-gobin
 clean-gobin:
 	@echo "+ $@"
-	rm -rf .gobin
+	rm -rf $(GOBIN)
 
 ##################
 ## Genesis Dump ##

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -3,7 +3,7 @@ module github.com/stackrox/scanner/tools/linters
 go 1.18
 
 require (
-	// TODO: remove the github.com/sourcegraph/go-diff replacement once updated.
+	// ROX-14255: remove the github.com/sourcegraph/go-diff replacement once updated to > v1.50.1.
 	github.com/golangci/golangci-lint v1.47.3
 	honnef.co/go/tools v0.3.3
 )
@@ -171,7 +171,7 @@ require (
 	mvdan.cc/unparam v0.0.0-20220706161116-678bad134442 // indirect
 )
 
-// TODO: Remove once golangci is updated.
+// ROX-14255: Remove once golangci-lint is updated.
 // This is added because github.com/sourcegraph/go-diff v0.6.1 (shipped with github.com/golangci/golangci-lint v1.47.3)
 // does not support Apple's `diff` as shipped with macOS Ventura.
 // Adding this replacement so macOS Ventura users can run golangci.

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -3,6 +3,7 @@ module github.com/stackrox/scanner/tools/linters
 go 1.18
 
 require (
+	// TODO: remove the github.com/sourcegraph/go-diff replacement once updated.
 	github.com/golangci/golangci-lint v1.47.3
 	honnef.co/go/tools v0.3.3
 )
@@ -169,3 +170,10 @@ require (
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 	mvdan.cc/unparam v0.0.0-20220706161116-678bad134442 // indirect
 )
+
+// TODO: Remove once golangci is updated.
+// This is added because github.com/sourcegraph/go-diff v0.6.1 (shipped with github.com/golangci/golangci-lint v1.47.3)
+// does not support Apple's `diff` as shipped with macOS Ventura.
+// Adding this replacement so macOS Ventura users can run golangci.
+// See https://github.com/golangci/golangci-lint/issues/3087 and https://github.com/sourcegraph/go-diff/pull/65 for details.
+replace github.com/sourcegraph/go-diff => github.com/sourcegraph/go-diff v0.6.2-0.20221031073116-7ef5f68ebea1

--- a/tools/linters/go.sum
+++ b/tools/linters/go.sum
@@ -610,8 +610,8 @@ github.com/sivchari/tenv v1.7.0/go.mod h1:64yStXKSOxDfX47NlhVwND4dHwfZDdbp2Lyl01
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sonatard/noctx v0.0.1 h1:VC1Qhl6Oxx9vvWo3UDgrGXYCeKCe3Wbw7qAWL6FrmTY=
 github.com/sonatard/noctx v0.0.1/go.mod h1:9D2D/EoULe8Yy2joDHJj7bv3sZoq9AaSb8B4lqBjiZI=
-github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
-github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
+github.com/sourcegraph/go-diff v0.6.2-0.20221031073116-7ef5f68ebea1 h1:FEIBISvqa2IsyC4KQQBQ1Ef2QvweGUgEIjCdE3gz+zs=
+github.com/sourcegraph/go-diff v0.6.2-0.20221031073116-7ef5f68ebea1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=


### PR DESCRIPTION
In the Makefile, we define a few binaries which we download. However, when using them, we may not have necessarily used the correct binary versions (they may have been pulled from the system instead). This PR ensures we use the freshly downloaded versions of the binaries. See https://github.com/stackrox/stackrox/blob/master/Makefile to see that the stackrox repo does it this way.

This PR also updates the version of `github.com/sourcegraph/go-diff` used by `golangci-lint`. See https://github.com/stackrox/stackrox/pull/4320 for more information.