### PR TITLE
Improve e2e testcase for RHCOS

### DIFF
--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -113,7 +113,6 @@ func TestGRPCGetRHCOSNodeVulnerabilities(t *testing.T) {
 	cases := map[string]struct {
 		request          *v1.GetNodeVulnerabilitiesRequest
 		expectedResponse *v1.GetNodeVulnerabilitiesResponse
-		assertVulnsLen   func(t *testing.T, expected, got int, msgAndArgs ...interface{}) bool
 	}{
 		"Selected vulnerabilities should be returned by the certified scan": {
 			request: buildRequest([]v1.Note{}),

--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -93,10 +93,10 @@ func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
 				},
 				{
 					Id:        int64(3),
-					Name:      "grep",
+					Name:      "tzdata",
 					Namespace: "rhel:8",
-					Version:   "3.1-6.el8",
-					Arch:      "x86_64",
+					Version:   "2022g.el8",
+					Arch:      "noarch",
 					Module:    "",
 					Cpes:      cpes,
 					AddedBy:   "",
@@ -134,9 +134,9 @@ func TestGRPCGetRHCOSNodeVulnerabilities(t *testing.T) {
 						Vulnerabilities: []*v1.Vulnerability{vulnTar},
 					},
 					{
-						Name:    "grep",
-						Version: "3.1-6.el8.x86_64",
-						// Warning: if this test fails, it may mean that new vulnerabilities have been found for grep:3.1-6
+						Name:    "tzdata",
+						Version: "2022g.el8.noarch",
+						// Warning: if this test fails, then probably vulnerabilities have been found for tzdata:2022g
 						// To fix that, one would need to find another package/version that has 0 vulnerabilities
 						// or mock the scanning behavior of scanner to always return 0 vulnerabilities for the pkg used in this case.
 						Vulnerabilities: []*v1.Vulnerability{},


### PR DESCRIPTION
This is a follow-up to #1004.
In the test case, we need a package that has high probability of being free from vulnerabilities because we assert on it to be recognized by scanner and have exactly 0 vulnerabilities.

In this PR, I replace the previously used `grep` by `tzdata` guesstimating that the chance of finding a vulnerability in the latter is lower than in the former.

## Tested

On CI and locally with:
- `make image deploy-local`
- Opening a port-forward to scanner:8443
- Running `go test -tags e2e -timeout=10s -count=1 -v -run ^TestGRPCGetRHCOSNodeVulnerabilities$  github.com/stackrox/scanner/e2etests`