### PR TITLE
Make bundle reproducible

### DIFF
--- a/.openshift-ci/build/build-bundle.sh
+++ b/.openshift-ci/build/build-bundle.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Execute the build steps required to create the scanner image's bundle.tar.gz.
+# Execute the build steps required to create the scanner image's bundle.tar.xz.
 #
 # Adapted from https://github.com/stackrox/stackrox/blob/master/.openshift-ci/build/build-main-and-bundle.sh
 

--- a/.openshift-ci/build/build-db-bundle.sh
+++ b/.openshift-ci/build/build-db-bundle.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Execute the build steps required to create the scanner-db image's bundle.tar.gz.
+# Execute the build steps required to create the scanner-db image's bundle.tar.xz.
 #
 # Adapted from https://github.com/stackrox/stackrox/blob/master/.openshift-ci/build/build-central-db-bundle.sh
 
@@ -28,7 +28,7 @@ get_db_dump() {
 build_db_bundle() {
     get_db_dump
 
-    info "Creating scanner-db bundle.tar.gz"
+    info "Creating scanner-db bundle.tar.xz"
     "$ROOT/image/db/rhel/create-bundle.sh" "$ROOT/image/db" "$ROOT/image/db/rhel"
 }
 

--- a/Makefile
+++ b/Makefile
@@ -207,32 +207,32 @@ endif
 scanner-build-nodeps:
 	$(BUILD_FLAGS) $(BUILD_CMD)
 
-.PHONY: $(CURDIR)/image/scanner/rhel/bundle.tar.gz
-$(CURDIR)/image/scanner/rhel/bundle.tar.gz:
+.PHONY: $(CURDIR)/image/scanner/rhel/bundle.tar.xz
+$(CURDIR)/image/scanner/rhel/bundle.tar.xz:
 	$(CURDIR)/image/scanner/rhel/create-bundle.sh $(CURDIR)/image/scanner $(CURDIR)/image/scanner/rhel
 
-.PHONY: $(CURDIR)/image/db/rhel/bundle.tar.gz
-$(CURDIR)/image/db/rhel/bundle.tar.gz:
+.PHONY: $(CURDIR)/image/db/rhel/bundle.tar.xz
+$(CURDIR)/image/db/rhel/bundle.tar.xz:
 	$(CURDIR)/image/db/rhel/create-bundle.sh $(CURDIR)/image/db $(CURDIR)/image/db/rhel
 
 .PHONY: scanner-image
-scanner-image: scanner-build-dockerized ossls-notice $(CURDIR)/image/scanner/rhel/bundle.tar.gz
+scanner-image: scanner-build-dockerized ossls-notice $(CURDIR)/image/scanner/rhel/bundle.tar.xz
 	@echo "+ $@"
 	@docker build -t scanner:$(TAG) -f image/scanner/rhel/Dockerfile image/scanner/rhel
 
 .PHONY: scanner-image-slim
-scanner-image-slim: scanner-build-dockerized ossls-notice $(CURDIR)/image/scanner/rhel/bundle.tar.gz
+scanner-image-slim: scanner-build-dockerized ossls-notice $(CURDIR)/image/scanner/rhel/bundle.tar.xz
 	@echo "+ $@"
 	@docker build -t scanner-slim:$(TAG) -f image/scanner/rhel/Dockerfile.slim image/scanner/rhel
 
 .PHONY: db-image
-db-image: $(CURDIR)/image/db/rhel/bundle.tar.gz
+db-image: $(CURDIR)/image/db/rhel/bundle.tar.xz
 	@echo "+ $@"
 	@test -f image/db/dump/definitions.sql.gz || { echo "FATAL: No definitions dump found in image/dump/definitions.sql.gz. Exiting..."; exit 1; }
 	@docker build -t scanner-db:$(TAG) --build-arg POSTGRESQL_ARCH=${ARCH} -f image/db/rhel/Dockerfile image/db/rhel
 
 .PHONY: db-image-slim
-db-image-slim: $(CURDIR)/image/db/rhel/bundle.tar.gz
+db-image-slim: $(CURDIR)/image/db/rhel/bundle.tar.xz
 	@echo "+ $@"
 	@test -f image/db/dump/definitions.sql.gz || { echo "FATAL: No definitions dump found in image/dump/definitions.sql.gz. Exiting..."; exit 1; }
 	@docker build -t scanner-db-slim:$(TAG) --build-arg POSTGRESQL_ARCH=${ARCH} -f image/db/rhel/Dockerfile.slim image/db/rhel

--- a/image/db/rhel/.gitignore
+++ b/image/db/rhel/.gitignore
@@ -1,4 +1,4 @@
-bundle.tar.gz
-bundle.tar.gz.sha512
+bundle.tar.xz
+bundle.tar.xz.sha512
 prebuild.sh
 

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -3,10 +3,10 @@ ARG BASE_IMAGE=ubi8-minimal
 ARG BASE_TAG=8.7
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
-COPY bundle.tar.gz /
+COPY bundle.tar.xz /
 
 WORKDIR /bundle
-RUN microdnf -y install tar gzip && tar -zxf /bundle.tar.gz
+RUN microdnf -y install tar xz && tar -xf /bundle.tar.xz
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS base
 

--- a/image/db/rhel/Dockerfile.slim
+++ b/image/db/rhel/Dockerfile.slim
@@ -3,10 +3,10 @@ ARG BASE_IMAGE=ubi8-minimal
 ARG BASE_TAG=8.7
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
-COPY bundle.tar.gz /
+COPY bundle.tar.xz /
 
 WORKDIR /bundle
-RUN microdnf -y install tar gzip && tar -zxf /bundle.tar.gz
+RUN microdnf -y install tar xz && tar -xf /bundle.tar.xz
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS base
 

--- a/image/scanner/dump/.gitignore
+++ b/image/scanner/dump/.gitignore
@@ -1,4 +1,2 @@
 *
 !.gitignore
-!genesis_manifests.json
-!README.md

--- a/image/scanner/rhel/.gitignore
+++ b/image/scanner/rhel/.gitignore
@@ -1,5 +1,5 @@
-bundle.tar.gz
-bundle.tar.gz.sha512
+bundle.tar.xz
+bundle.tar.xz.sha512
 prebuild.sh
 scripts
 /THIRD_PARTY_NOTICES/

--- a/image/scanner/rhel/Dockerfile
+++ b/image/scanner/rhel/Dockerfile
@@ -4,9 +4,9 @@ ARG BASE_TAG=8.7
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 
-COPY bundle.tar.gz /
+COPY bundle.tar.xz /
 WORKDIR /bundle
-RUN microdnf -y install tar gzip && tar -zxf /bundle.tar.gz
+RUN microdnf -y install tar xz && tar -xf /bundle.tar.xz
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS base
 

--- a/image/scanner/rhel/Dockerfile.slim
+++ b/image/scanner/rhel/Dockerfile.slim
@@ -4,9 +4,9 @@ ARG BASE_TAG=8.7
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 
-COPY bundle.tar.gz /
+COPY bundle.tar.xz /
 WORKDIR /bundle
-RUN microdnf -y install tar gzip && tar -zxf /bundle.tar.gz
+RUN microdnf -y install tar xz && tar -xf /bundle.tar.xz
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS base
 

--- a/image/scanner/rhel/create-bundle.sh
+++ b/image/scanner/rhel/create-bundle.sh
@@ -23,7 +23,7 @@ OUTPUT_DIR="$2"
 [[ -d "$OUTPUT_DIR" ]] \
     || die "Output directory doesn't exist or is not a directory."
 
-OUTPUT_BUNDLE="${OUTPUT_DIR}/bundle.tar.gz"
+OUTPUT_BUNDLE="${OUTPUT_DIR}/bundle.tar.xz"
 
 # Create tmp directory with stackrox directory structure
 bundle_root="$(mktemp -d)"
@@ -58,15 +58,14 @@ cp -pr "${INPUT_ROOT}/rhel/THIRD_PARTY_NOTICES"           "${bundle_root}/"
 
 # =============================================================================
 
-# Files should have owner/group equal to root:root
-if tar --version | grep -q "gnu" ; then
-  tar_chown_args=("--owner=root:0" "--group=root:0")
-else
-  tar_chown_args=("--uid=0" "--uname=root" "--gid=0" "--gname=root")
-fi
-
 # Create output bundle of all files in $bundle_root
-tar cz "${tar_chown_args[@]}" --file "$OUTPUT_BUNDLE" --directory "${bundle_root}" .
+COPYFILE_DISABLE=true tar -c \
+    --sort=name \
+    --mtime='UTC 1970-01-01' \
+    --owner=0 --group=0 --numeric-owner \
+    --file - \
+    --directory "${bundle_root}" . | \
+    xz --compress -1 --threads=8 - > "$OUTPUT_BUNDLE"
 
 # Create checksum
 sha512sum "${OUTPUT_BUNDLE}" > "${OUTPUT_BUNDLE}.sha512"


### PR DESCRIPTION
When running `make image` twice on the same codebase generated bundles are not identical. Although they have the same content they checksum differs due to metadata differences. This PR makes the bundles identical when generating multiple times for the same inputs allowing full docker cache usage.

See: https://reproducible-builds.org/docs/archives/

- Before

```
+ scanner-image
Sending build context to Docker daemon  131.3MB
Step 1/25 : ARG BASE_REGISTRY=registry.access.redhat.com
Step 2/25 : ARG BASE_IMAGE=ubi8-minimal
Step 3/25 : ARG BASE_TAG=8.7
Step 4/25 : FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 ---> 40b2a5f7e466
Step 5/25 : COPY bundle.tar.gz /
 ---> 58e22baf1e9c
Step 6/25 : WORKDIR /bundle
 ---> Running in 44a4401a5ab0
Removing intermediate container 44a4401a5ab0
 ---> e7a124e6a630
Step 7/25 : RUN microdnf -y install tar gzip && tar -zxf /bundle.tar.gz
 ---> Running in d8c424342f71

(microdnf:7): librhsm-WARNING **: 17:27:07.540: Found 0 entitlement certificates

(microdnf:7): librhsm-WARNING **: 17:27:07.545: Found 0 entitlement certificates
Downloading metadata...
Downloading metadata...
Downloading metadata...
Package                   Repository            Size
Installing:                                         
 gzip-1.9-13.el8_5.x86_64 ubi-8-baseos-rpms 170.8 kB
 tar-2:1.30-6.el8.x86_64  ubi-8-baseos-rpms 858.4 kB
Transaction Summary:
 Installing:        2 packages
 Reinstalling:      0 packages
 Upgrading:         0 packages
 Obsoleting:        0 packages
 Removing:          0 packages
 Downgrading:       0 packages
Downloading packages...
Running transaction test...
Installing: tar;2:1.30-6.el8;x86_64;ubi-8-baseos-rpms
Installing: gzip;1.9-13.el8_5;x86_64;ubi-8-baseos-rpms
Complete.
Removing intermediate container d8c424342f71
 ---> c6ef68332aaa
Step 8/25 : FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS base
 ---> 40b2a5f7e466
Step 9/25 : LABEL name="scanner"       vendor="StackRox"       maintainer="support@stackrox.com"       summary="Image scanner for the StackRox Kubernetes Security Platform"       description="This image supports image scanning in the StackRox Kubernetes Security Platform."
 ---> Using cache
 ---> ad939fadd31f
Step 10/25 : SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 ---> Using cache
 ---> a20bc89364f1
Step 11/25 : COPY scripts /
 ---> Using cache
 ---> ef7026029dc8
Step 12/25 : COPY --from=extracted_bundle /bundle/scanner ./
 ---> Using cache
 ---> f1a28e0a8b34
Step 13/25 : COPY --from=extracted_bundle /bundle/THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 ---> Using cache
 ---> 35547398f254
Step 14/25 : RUN microdnf -y upgrade &&     microdnf -y install xz &&     microdnf -y clean all &&     rpm -e --nodeps $(rpm -qa curl '*dnf*' '*libsolv*' '*hawkey*' 'yum*') &&     rm -rf /var/cache/dnf /var/cache/yum &&     chown -R 65534:65534 /tmp &&     chown -R 65534:65534 /etc/pki /etc/ssl && /save-dir-contents /etc/pki/ca-trust /etc/ssl &&     chmod +rx /scanner
 ---> Using cache
 ---> 0d877c138db1
Step 15/25 : ENV NVD_DEFINITIONS_DIR="/nvd_definitions"
 ---> Using cache
 ---> adca8dd81fd9
Step 16/25 : ENV K8S_DEFINITIONS_DIR="/k8s_definitions"
 ---> Using cache
 ---> 36cbdb02bb14
Step 17/25 : ENV ISTIO_DEFINITIONS_DIR="/istio_definitions"
 ---> Using cache
 ---> 7e146d7b2bf8
Step 18/25 : ENV REPO_TO_CPE_DIR="/repo2cpe"
 ---> Using cache
 ---> 3a47ee2ae22d
Step 19/25 : COPY --chown=65534:65534 --from=extracted_bundle "/bundle${NVD_DEFINITIONS_DIR}/" ".${NVD_DEFINITIONS_DIR}/"
 ---> Using cache
 ---> 53018bc95eb8
Step 20/25 : COPY --chown=65534:65534 --from=extracted_bundle "/bundle${K8S_DEFINITIONS_DIR}/" ".${K8S_DEFINITIONS_DIR}/"
 ---> Using cache
 ---> 7a21c90cea59
Step 21/25 : COPY --chown=65534:65534 --from=extracted_bundle "/bundle${ISTIO_DEFINITIONS_DIR}/" ".${ISTIO_DEFINITIONS_DIR}/"
 ---> Using cache
 ---> 1dcf75a4effa
Step 22/25 : COPY --chown=65534:65534 --from=extracted_bundle "/bundle${REPO_TO_CPE_DIR}/" ".${REPO_TO_CPE_DIR}/"
 ---> Using cache
 ---> 3b172ecca305
Step 23/25 : COPY --chown=65534:65534 --from=extracted_bundle /bundle/genesis_manifests.json ./
 ---> Using cache
 ---> b03474865345
Step 24/25 : USER 65534:65534
 ---> Using cache
 ---> bb57e8ed9cdc
Step 25/25 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Using cache
 ---> 3d5a737eba9a
Successfully built 3d5a737eba9a
Successfully tagged scanner:2.27.x-20-g4afa618981
```

- After 
```
+ scanner-image
Sending build context to Docker daemon  131.3MB
Step 1/25 : ARG BASE_REGISTRY=registry.access.redhat.com
Step 2/25 : ARG BASE_IMAGE=ubi8-minimal
Step 3/25 : ARG BASE_TAG=8.7
Step 4/25 : FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 ---> 40b2a5f7e466
Step 5/25 : COPY bundle.tar.xz /
 ---> Using cache
 ---> 8a96119ff73d
Step 6/25 : WORKDIR /bundle
 ---> Using cache
 ---> 85fcfebd6ec1
Step 7/25 : RUN microdnf -y install tar xz && tar -xf /bundle.tar.xz
 ---> Using cache
 ---> 51f501ef6207
Step 8/25 : FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS base
 ---> 40b2a5f7e466
Step 9/25 : LABEL name="scanner"       vendor="StackRox"       maintainer="support@stackrox.com"       summary="Image scanner for the StackRox Kubernetes Security Platform"       description="This image supports image scanning in the StackRox Kubernetes Security Platform."
 ---> Using cache
 ---> ad939fadd31f
Step 10/25 : SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 ---> Using cache
 ---> a20bc89364f1
Step 11/25 : COPY scripts /
 ---> Using cache
 ---> ef7026029dc8
Step 12/25 : COPY --from=extracted_bundle /bundle/scanner ./
 ---> Using cache
 ---> 8c4b62fcdfbf
Step 13/25 : COPY --from=extracted_bundle /bundle/THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 ---> Using cache
 ---> bf34b3e70530
Step 14/25 : RUN microdnf -y upgrade &&     microdnf -y install xz &&     microdnf -y clean all &&     rpm -e --nodeps $(rpm -qa curl '*dnf*' '*libsolv*' '*hawkey*' 'yum*') &&     rm -rf /var/cache/dnf /var/cache/yum &&     chown -R 65534:65534 /tmp &&     chown -R 65534:65534 /etc/pki /etc/ssl && /save-dir-contents /etc/pki/ca-trust /etc/ssl &&     chmod +rx /scanner
 ---> Using cache
 ---> 1a119095a5a6
Step 15/25 : ENV NVD_DEFINITIONS_DIR="/nvd_definitions"
 ---> Using cache
 ---> cb4b70e07855
Step 16/25 : ENV K8S_DEFINITIONS_DIR="/k8s_definitions"
 ---> Using cache
 ---> ac6622eb3e1b
Step 17/25 : ENV ISTIO_DEFINITIONS_DIR="/istio_definitions"
 ---> Using cache
 ---> 7be37860f492
Step 18/25 : ENV REPO_TO_CPE_DIR="/repo2cpe"
 ---> Using cache
 ---> ee37c52f50f6
Step 19/25 : COPY --chown=65534:65534 --from=extracted_bundle "/bundle${NVD_DEFINITIONS_DIR}/" ".${NVD_DEFINITIONS_DIR}/"
 ---> Using cache
 ---> 2fb3032ce26b
Step 20/25 : COPY --chown=65534:65534 --from=extracted_bundle "/bundle${K8S_DEFINITIONS_DIR}/" ".${K8S_DEFINITIONS_DIR}/"
 ---> Using cache
 ---> 90075517ae6c
Step 21/25 : COPY --chown=65534:65534 --from=extracted_bundle "/bundle${ISTIO_DEFINITIONS_DIR}/" ".${ISTIO_DEFINITIONS_DIR}/"
 ---> Using cache
 ---> d77c1fc55d86
Step 22/25 : COPY --chown=65534:65534 --from=extracted_bundle "/bundle${REPO_TO_CPE_DIR}/" ".${REPO_TO_CPE_DIR}/"
 ---> Using cache
 ---> cb3b9836b1df
Step 23/25 : COPY --chown=65534:65534 --from=extracted_bundle /bundle/genesis_manifests.json ./
 ---> Using cache
 ---> 3f7d9743507a
Step 24/25 : USER 65534:65534
 ---> Using cache
 ---> 04912841905f
Step 25/25 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Using cache
 ---> d9162534660b
Successfully built d9162534660b
Successfully tagged scanner:2.27.x-21-g51d5f2d00f
```
