### PR TITLE
Support RHEL content sets in a call to GetNodeVulnerabilities

### DIFF
--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -299,7 +299,7 @@ func (s *serviceImpl) getNodeInventoryVulns(components *v1.Components, isUncerti
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	log.Debugf("Scanned %d components from NodeInventory and returning %d features", len(components.GetRhelComponents()), len(layer.Features))
+	log.Infof("Matched vulnerabilities on %d RHEL components in node inventory", len(components.GetRhelComponents()))
 	return features.ConvertFeatures(layer.Features), nil
 }
 

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -291,7 +291,9 @@ func (s *serviceImpl) getNodeInventoryVulns(components *v1.Components, isUncerti
 	cpes := s.repoToCPE.Get(components.GetRhelContentSets())
 	log.Debugf("Converted content sets '%v' to CPEs '%v'", components.GetRhelContentSets(), cpes)
 	for _, comp := range components.GetRhelComponents() {
-		comp.Cpes = append(comp.Cpes, cpes...)
+		// TODO(ROX-14414): Handle situation when CPEs are provided in parallel to content sets
+		// Overwrite any potential CPEs and stick to content sets to sanitize the API input
+		comp.Cpes = cpes
 	}
 	layer, err := apiV1.GetVulnerabilitiesForComponents(s.db, components, isUncertifiedRHEL)
 	if err != nil {

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -2,6 +2,7 @@ package nodescan
 
 import (
 	"context"
+	"github.com/stackrox/scanner/pkg/repo2cpe"
 	"sort"
 	"strings"
 
@@ -35,22 +36,24 @@ type Service interface {
 }
 
 // NewService returns the service for node scanning
-func NewService(db database.Datastore, nvdCache nvdtoolscache.Cache, k8sCache k8scache.Cache) Service {
+func NewService(db database.Datastore, nvdCache nvdtoolscache.Cache, k8sCache k8scache.Cache, repoToCPE *repo2cpe.Mapping) Service {
 	return &serviceImpl{
-		version:  version.Version,
-		db:       db,
-		nvdCache: nvdCache,
-		k8sCache: k8sCache,
+		version:   version.Version,
+		db:        db,
+		nvdCache:  nvdCache,
+		k8sCache:  k8sCache,
+		repoToCPE: repoToCPE,
 	}
 }
 
 type serviceImpl struct {
 	v1.UnimplementedNodeScanServiceServer
 
-	version  string
-	db       database.Datastore
-	nvdCache nvdtoolscache.Cache
-	k8sCache k8scache.Cache
+	version   string
+	db        database.Datastore
+	nvdCache  nvdtoolscache.Cache
+	k8sCache  k8scache.Cache
+	repoToCPE *repo2cpe.Mapping
 }
 
 func filterInvalidVulns(vulns []*v1.Vulnerability) []*v1.Vulnerability {
@@ -273,15 +276,29 @@ func (s *serviceImpl) GetNodeVulnerabilities(_ context.Context, req *v1.GetNodeV
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	// Handle the new format of the request and scan node inventory additionally
+	// Scan Components containing pkgs from NodeInventory
 	if req.GetComponents() != nil {
-		layer, err := apiV1.GetVulnerabilitiesForComponents(s.db, req.GetComponents(), common.HasUncertifiedRHEL(req.GetNotes()))
-		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+		if resp.Features, err = s.getNodeInventoryVulns(req.GetComponents(), common.HasUncertifiedRHEL(req.GetNotes())); err != nil {
+			return nil, err
 		}
-		resp.Features = features.ConvertFeatures(layer.Features)
 	}
 	return resp, nil
+}
+
+func (s *serviceImpl) getNodeInventoryVulns(components *v1.Components, isUncertifiedRHEL bool) ([]*v1.Feature, error) {
+	log.Debugf("Scanning NodeInventory")
+	// Convert content sets to CPEs
+	cpes := s.repoToCPE.Get(components.GetRhelContentSets())
+	log.Debugf("Converted content sets '%v' to CPEs '%v'", components.GetRhelContentSets(), cpes)
+	for _, comp := range components.GetRhelComponents() {
+		comp.Cpes = append(comp.Cpes, cpes...)
+	}
+	layer, err := apiV1.GetVulnerabilitiesForComponents(s.db, components, isUncertifiedRHEL)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	log.Debugf("Scanned %d components from NodeInventory and returning %d features", len(components.GetRhelComponents()), len(layer.Features))
+	return features.ConvertFeatures(layer.Features), nil
 }
 
 // RegisterServiceServer registers this service with the given gRPC Server.

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/stackrox/scanner/pkg/repo2cpe"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -22,6 +21,7 @@ import (
 	"github.com/stackrox/scanner/ext/versionfmt"
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
 	k8scache "github.com/stackrox/scanner/k8s/cache"
+	"github.com/stackrox/scanner/pkg/repo2cpe"
 	"github.com/stackrox/scanner/pkg/version"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -2,10 +2,10 @@ package nodescan
 
 import (
 	"context"
-	"github.com/stackrox/scanner/pkg/repo2cpe"
 	"sort"
 	"strings"
 
+	"github.com/stackrox/scanner/pkg/repo2cpe"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"

--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -189,7 +189,7 @@ func Boot(config *Config, slimMode bool) {
 		ping.NewService(),
 		imagescan.NewService(db, nvdVulnCache),
 		orchestratorscan.NewService(db, k8sVulnCache, istioVulnCache),
-		nodescan.NewService(db, nvdVulnCache, k8sVulnCache),
+		nodescan.NewService(db, nvdVulnCache, k8sVulnCache, repoToCPE),
 		vulndefs.NewService(db),
 	)
 	go grpcAPI.Start()

--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -51,13 +51,6 @@ var vulnTar = &v1.Vulnerability{
 }
 
 func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
-	// From: https://www.redhat.com/security/data/metrics/repository-to-cpe.json
-	// "rhel-8-for-x86_64-appstream-rpms": {"cpes": ["cpe:/a:redhat:enterprise_linux:8::appstream", "cpe:/a:redhat:rhel:8.3::appstream"]},
-	// "rhel-8-for-x86_64-baseos-rpms": {"cpes": ["cpe:/o:redhat:enterprise_linux:8::baseos", "cpe:/o:redhat:rhel:8.3::baseos"]}
-	cpes := []string{
-		"cpe:/a:redhat:enterprise_linux:8::appstream", "cpe:/a:redhat:rhel:8.3::appstream",
-		"cpe:/a:redhat:enterprise_linux:8::baseos", "cpe:/a:redhat:rhel:8.3::baseos",
-	}
 	return &v1.GetNodeVulnerabilitiesRequest{
 		OsImage:          "Red Hat Enterprise Linux CoreOS 45.82.202008101249-0 (Ootpa)",
 		KernelVersion:    "0.0.1", // dummy value - out of scope for this test
@@ -78,7 +71,7 @@ func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
 					Version:   "1.3.5-7.el8",
 					Arch:      "x86_64",
 					Module:    "", // must be empty, otherwise scanner does not return any vulns
-					Cpes:      cpes,
+					Cpes:      []string{},
 					AddedBy:   "",
 				},
 				{
@@ -88,7 +81,7 @@ func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
 					Version:   "1.27.1.el8",
 					Arch:      "x86_64",
 					Module:    "",
-					Cpes:      cpes,
+					Cpes:      []string{},
 					AddedBy:   "",
 				},
 				{
@@ -98,11 +91,12 @@ func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
 					Version:   "2022g.el8",
 					Arch:      "noarch",
 					Module:    "",
-					Cpes:      cpes,
+					Cpes:      []string{},
 					AddedBy:   "",
 				},
 			},
 			LanguageComponents: nil,
+			RhelContentSets:    []string{"rhel-8-for-x86_64-appstream-rpms", "rhel-8-for-x86_64-baseos-rpms"},
 		},
 	}
 }


### PR DESCRIPTION
As a result of https://github.com/stackrox/scanner/pull/1053 we decided that `Analyze` will not provide CPEs but instead would include RHEL content sets. This PR adapts the `GetNodeVulnerabilities` to that change, so that content sets are translated to CPEs in Scanner.

## How tested
- [x] CI with the e2e test that covers the `GetNodeVulnerabilities`
- [x] Manually deployed to local cluster (along with https://github.com/stackrox/stackrox/pull/4430) and saw that feature works - see screenshot

![Screenshot 2023-01-18 at 18 05 45](https://user-images.githubusercontent.com/114479/213247999-c1851d1b-aaa4-4af3-959e-cc2525bf4b9f.png)

