### PR TITLE
ROX-14459: Alpine 3.17 Support

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -2771,6 +2771,22 @@ var testCases = []testCase{
 		},
 	},
 	{
+		image:                   "alpine:3.17.0",
+		registry:                "https://registry-1.docker.io",
+		source:                  "NVD",
+		onlyCheckSpecifiedVulns: true,
+		namespace:               "alpine:v3.17",
+		expectedFeatures: []apiV1.Feature{
+			{
+				Name:          "apk-tools",
+				NamespaceName: "alpine:v3.17",
+				VersionFormat: "apk",
+				Version:       "2.12.10-r1",
+				AddedBy:       "sha256:c158987b05517b6f2c5913f3acef1f2182a32345a304fe357e3ace5fadcad715",
+			},
+		},
+	},
+	{
 		image:    "quay.io/rhacs-eng/qa:debian-package-removal",
 		registry: "https://quay.io",
 		username: os.Getenv("QUAY_RHACS_ENG_RO_USERNAME"),

--- a/pkg/wellknownnamespaces/set.go
+++ b/pkg/wellknownnamespaces/set.go
@@ -45,6 +45,7 @@ var (
 		"alpine:v3.14",
 		"alpine:v3.15",
 		"alpine:v3.16",
+		"alpine:v3.17",
 		"alpine:edge",
 		"amzn:2018.03",
 		"amzn:2",


### PR DESCRIPTION
Added test and indication that scanning of Alpine v3.17 based images is supported

## Validation
- [X] Verify that `apk` installed package database is in expected location (`/lib/apk/db/installed`) and expected format
- [X] Verify that Scanner detects installed packages and version (via test case)
- [X] Verify that ACS Scanner detects vulnerabilities for installed packages
  - No vulns existed in base packages for `3.17.0` - custom image w/ vuln created and scanned as detailed below

## Custom Image Creation and Scan
**Dockerfile:**
```dockerfile
FROM alpine:3.17.0

RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.3/main" >> /etc/apk/repositories && \
    apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/3.3/main apache2=2.4.27-r1
```
Pushed to `quay.io/dcaravel/sandbox/alpine-apache2:latest`

**Temporary Test Case (added to temp branch in `e2etests/testcase_test.go`):**
```go
{
image:                   "quay.io/dcaravel/sandbox/alpine-apache2:latest",
registry:                "https://quay.io",
source:                  "NVD",
onlyCheckSpecifiedVulns: true,
namespace:               "alpine:v3.17",
expectedFeatures: []apiV1.Feature{
	{
		Name:          "apk-tools",
		NamespaceName: "alpine:v3.17",
		VersionFormat: "apk",
		Version:       "2.12.10-r1",
		AddedBy:       "sha256:c158987b05517b6f2c5913f3acef1f2182a32345a304fe357e3ace5fadcad715",
	},
	{
		Name:          "apache2",
		NamespaceName: "alpine:v3.17",
		VersionFormat: "apk",
		Version:       "2.4.27-r1",
		AddedBy:       "sha256:03d2913fab70ea22c1ed741470ca20814a01e7b13d1c333074d800c144e95c96",
		Vulnerabilities: []apiV1.Vulnerability{
			{
				Name:          "CVE-2022-28330",
				NamespaceName: "alpine:v3.17",
				Description:   "Apache HTTP Server 2.4.53 and earlier on Windows may read beyond bounds when configured to process requests with the mod_isapi module.",
				Link:          "https://www.cve.org/CVERecord?id=CVE-2022-28330",
				Severity:      "Moderate",
				Metadata: map[string]interface{}{
					"NVD": map[string]interface{}{
						"CVSSv3": map[string]interface{}{
							"ExploitabilityScore": 3.9,
							"ImpactScore":         1.4,
							"Score":               5.3,
							"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
						},
						"CVSSv2": map[string]interface{}{
							"ExploitabilityScore": 10.0,
							"ImpactScore":         2.9,
							"Score":               5.0,
							"Vectors":             "AV:N/AC:L/Au:N/C:P/I:N/A:N",
						},
					},
				},
				FixedBy: "2.4.54-r0",
			},
		},
		FixedBy: "2.4.54-r0",
	},
},
},
```

**Successful test:**
```
$ go test -v -tags e2e -count=1 -run='TestImageSanity/quay.io/dcaravel*' ./e2etests/...
=== RUN   TestImageSanity
=== RUN   TestImageSanity/quay.io/dcaravel/sandbox/alpine-apache2:latest
=== RUN   TestImageSanity/quay.io/dcaravel/sandbox/alpine-apache2:latest/apk-tools/2.12.10-r1
=== RUN   TestImageSanity/quay.io/dcaravel/sandbox/alpine-apache2:latest/apache2/2.4.27-r1
--- PASS: TestImageSanity (0.24s)
    --- PASS: TestImageSanity/quay.io/dcaravel/sandbox/alpine-apache2:latest (0.24s)
        --- PASS: TestImageSanity/quay.io/dcaravel/sandbox/alpine-apache2:latest/apk-tools/2.12.10-r1 (0.00s)
        --- PASS: TestImageSanity/quay.io/dcaravel/sandbox/alpine-apache2:latest/apache2/2.4.27-r1 (0.00s)
PASS
ok  	github.com/stackrox/scanner/e2etests	0.490s
```