### PR TITLE
ROX-14592: Ensure that RHCOS Node scan is not skipped by Scanner

### DIFF
--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -265,14 +265,15 @@ func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNod
 }
 
 func (s *serviceImpl) getNodeVulnerabilitiesLegacy(_ context.Context, req *v1.GetNodeVulnerabilitiesRequest) (*v1.GetNodeVulnerabilitiesResponse, error) {
-	resp := &v1.GetNodeVulnerabilitiesResponse{
-		ScannerVersion: s.version,
-	}
 	if stringutils.AtLeastOneEmpty(req.GetKernelVersion(), req.GetOsImage()) {
 		return nil, status.Error(codes.InvalidArgument, "both os image and kernel version are required")
 	}
 
 	var err error
+	resp := &v1.GetNodeVulnerabilitiesResponse{
+		ScannerVersion: s.version,
+	}
+
 	resp.OperatingSystem, resp.KernelVulnerabilities, resp.KernelComponent, err = s.evaluateLinuxKernelVulns(req)
 	switch err {
 	case nil: // Normal

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -250,7 +250,8 @@ func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNod
 	}
 
 	if !wellknownnamespaces.IsRHCOSNamespace(req.GetComponents().GetNamespace()) {
-		// Non-RHCOS system detected, we can provide list of pkgs but cannot scan them -> setting a note to inform the user
+		// Non-RHCOS system with node inventory detected!
+		// We can provide a list of pkgs but cannot scan them -> setting a note to inform the user.
 		resp.NodeNotes = append(resp.GetNodeNotes(), v1.NodeNote_NODE_UNSUPPORTED)
 	}
 

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stackrox/scanner/ext/versionfmt"
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
 	k8scache "github.com/stackrox/scanner/k8s/cache"
-	"github.com/stackrox/scanner/pkg/env"
+	featureFlags "github.com/stackrox/scanner/pkg/features"
 	"github.com/stackrox/scanner/pkg/repo2cpe"
 	"github.com/stackrox/scanner/pkg/version"
 	"github.com/stackrox/scanner/pkg/wellknownnamespaces"
@@ -242,7 +242,7 @@ func (s *serviceImpl) getRuntimeVulns(containerRuntime *v1.GetNodeVulnerabilitie
 
 func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNodeVulnerabilitiesRequest) (*v1.GetNodeVulnerabilitiesResponse, error) {
 	// If NodeInventory is empty `req.GetComponents() == nil` then fallback to v1 scanning
-	if req.GetComponents() == nil || !env.RHCOSNodeScanning.Enabled() {
+	if req.GetComponents() == nil || !featureFlags.RHCOSNodeScanning.Enabled() {
 		return s.getNodeVulnerabilitiesLegacy(ctx, req)
 	}
 

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -241,6 +241,7 @@ func (s *serviceImpl) getRuntimeVulns(containerRuntime *v1.GetNodeVulnerabilitie
 }
 
 func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNodeVulnerabilitiesRequest) (*v1.GetNodeVulnerabilitiesResponse, error) {
+	log.Infof("Received call to GetNodeVulnerabilities. RHCOSNodeScanning=%t (%s)", env.RHCOSNodeScanning.Enabled(), env.RHCOSNodeScanning.Value())
 	// If NodeInventory is empty `req.GetComponents() == nil` then fallback to v1 scanning
 	if req.GetComponents() == nil || !env.RHCOSNodeScanning.Enabled() {
 		return s.getNodeVulnerabilitiesLegacy(ctx, req)

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -13,6 +13,7 @@ import (
 	apiV1 "github.com/stackrox/scanner/api/v1"
 	"github.com/stackrox/scanner/api/v1/common"
 	"github.com/stackrox/scanner/api/v1/convert"
+	"github.com/stackrox/scanner/api/v1/features"
 	"github.com/stackrox/scanner/cpe/nvdtoolscache"
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/kernelparser"
@@ -20,7 +21,7 @@ import (
 	"github.com/stackrox/scanner/ext/versionfmt"
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
 	k8scache "github.com/stackrox/scanner/k8s/cache"
-	"github.com/stackrox/scanner/pkg/features"
+	featureFlags "github.com/stackrox/scanner/pkg/features"
 	"github.com/stackrox/scanner/pkg/repo2cpe"
 	"github.com/stackrox/scanner/pkg/version"
 	"google.golang.org/grpc"
@@ -247,7 +248,7 @@ func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNod
 		ScannerVersion: s.version,
 	}
 	// If NodeInventory is empty `req.GetComponents() == nil` then fallback to v1 scanning
-	if req.GetComponents() == nil || !features.RHCOSNodeScanning.Enabled() {
+	if req.GetComponents() == nil || !featureFlags.RHCOSNodeScanning.Enabled() {
 		return s.getNodeVulnerabilitiesLegacy(ctx, req, resp)
 	}
 
@@ -297,6 +298,7 @@ func (s *serviceImpl) getNodeVulnerabilitiesLegacy(_ context.Context, req *v1.Ge
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+	return resp, nil
 }
 
 func (s *serviceImpl) getNodeInventoryVulns(components *v1.Components, isUncertifiedRHEL bool) ([]*v1.Feature, error) {

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -241,12 +241,13 @@ func (s *serviceImpl) getRuntimeVulns(containerRuntime *v1.GetNodeVulnerabilitie
 }
 
 func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNodeVulnerabilitiesRequest) (*v1.GetNodeVulnerabilitiesResponse, error) {
-	resp := &v1.GetNodeVulnerabilitiesResponse{
-		ScannerVersion: s.version,
-	}
 	// If NodeInventory is empty `req.GetComponents() == nil` then fallback to v1 scanning
 	if req.GetComponents() == nil || !featureFlags.RHCOSNodeScanning.Enabled() {
-		return s.getNodeVulnerabilitiesLegacy(ctx, req, resp)
+		return s.getNodeVulnerabilitiesLegacy(ctx, req)
+	}
+
+	resp := &v1.GetNodeVulnerabilitiesResponse{
+		ScannerVersion: s.version,
 	}
 
 	if !wellknownnamespaces.IsRHCOSNamespace(req.GetComponents().GetNamespace()) {
@@ -263,7 +264,10 @@ func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNod
 	return resp, nil
 }
 
-func (s *serviceImpl) getNodeVulnerabilitiesLegacy(_ context.Context, req *v1.GetNodeVulnerabilitiesRequest, resp *v1.GetNodeVulnerabilitiesResponse) (*v1.GetNodeVulnerabilitiesResponse, error) {
+func (s *serviceImpl) getNodeVulnerabilitiesLegacy(_ context.Context, req *v1.GetNodeVulnerabilitiesRequest) (*v1.GetNodeVulnerabilitiesResponse, error) {
+	resp := &v1.GetNodeVulnerabilitiesResponse{
+		ScannerVersion: s.version,
+	}
 	if stringutils.AtLeastOneEmpty(req.GetKernelVersion(), req.GetOsImage()) {
 		return nil, status.Error(codes.InvalidArgument, "both os image and kernel version are required")
 	}

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -24,6 +24,7 @@ import (
 	featureFlags "github.com/stackrox/scanner/pkg/features"
 	"github.com/stackrox/scanner/pkg/repo2cpe"
 	"github.com/stackrox/scanner/pkg/version"
+	"github.com/stackrox/scanner/pkg/wellknownnamespaces"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -239,10 +240,6 @@ func (s *serviceImpl) getRuntimeVulns(containerRuntime *v1.GetNodeVulnerabilitie
 	return nil, nil
 }
 
-func isRHCOS(ns string) bool {
-	return strings.HasPrefix(ns, "rhcos")
-}
-
 func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNodeVulnerabilitiesRequest) (*v1.GetNodeVulnerabilitiesResponse, error) {
 	resp := &v1.GetNodeVulnerabilitiesResponse{
 		ScannerVersion: s.version,
@@ -252,8 +249,8 @@ func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNod
 		return s.getNodeVulnerabilitiesLegacy(ctx, req, resp)
 	}
 
-	if !isRHCOS(req.GetComponents().GetNamespace()) {
-		// Non-RHCOS system detecetd, we can provide list of pkgs but cannot scan them, thus a node to inform the user
+	if !wellknownnamespaces.IsRHCOSNamespace(req.GetComponents().GetNamespace()) {
+		// Non-RHCOS system detected, we can provide list of pkgs but cannot scan them -> setting a note to inform the user
 		resp.NodeNotes = append(resp.GetNodeNotes(), v1.NodeNote_NODE_UNSUPPORTED)
 	}
 

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stackrox/scanner/ext/versionfmt"
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
 	k8scache "github.com/stackrox/scanner/k8s/cache"
-	featureFlags "github.com/stackrox/scanner/pkg/features"
+	"github.com/stackrox/scanner/pkg/env"
 	"github.com/stackrox/scanner/pkg/repo2cpe"
 	"github.com/stackrox/scanner/pkg/version"
 	"github.com/stackrox/scanner/pkg/wellknownnamespaces"
@@ -242,7 +242,7 @@ func (s *serviceImpl) getRuntimeVulns(containerRuntime *v1.GetNodeVulnerabilitie
 
 func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNodeVulnerabilitiesRequest) (*v1.GetNodeVulnerabilitiesResponse, error) {
 	// If NodeInventory is empty `req.GetComponents() == nil` then fallback to v1 scanning
-	if req.GetComponents() == nil || !featureFlags.RHCOSNodeScanning.Enabled() {
+	if req.GetComponents() == nil || !env.RHCOSNodeScanning.Enabled() {
 		return s.getNodeVulnerabilitiesLegacy(ctx, req)
 	}
 

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -241,7 +241,6 @@ func (s *serviceImpl) getRuntimeVulns(containerRuntime *v1.GetNodeVulnerabilitie
 }
 
 func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNodeVulnerabilitiesRequest) (*v1.GetNodeVulnerabilitiesResponse, error) {
-	log.Infof("Received call to GetNodeVulnerabilities. RHCOSNodeScanning=%t (%s)", env.RHCOSNodeScanning.Enabled(), env.RHCOSNodeScanning.Value())
 	// If NodeInventory is empty `req.GetComponents() == nil` then fallback to v1 scanning
 	if req.GetComponents() == nil || !env.RHCOSNodeScanning.Enabled() {
 		return s.getNodeVulnerabilitiesLegacy(ctx, req)

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -251,8 +251,9 @@ func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNod
 	}
 
 	if !wellknownnamespaces.IsRHCOSNamespace(req.GetComponents().GetNamespace()) || len(req.GetComponents().GetRhelContentSets()) == 0 {
-		// Non-RHCOS system with node inventory detected!
-		// We can provide a list of pkgs but cannot scan them -> setting a note to inform the user.
+		// Node components exist in the request, but we cannot perform vulnerability matching
+		// if (a.) it's not an RHCOS namespace or (b.) if it is an RHCOS namespace missing content
+		// sets. The latter occurs for RHCOS versions we don't support.
 		resp.NodeNotes = append(resp.GetNodeNotes(), v1.NodeNote_NODE_UNSUPPORTED)
 	}
 

--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -250,7 +250,7 @@ func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNod
 		ScannerVersion: s.version,
 	}
 
-	if !wellknownnamespaces.IsRHCOSNamespace(req.GetComponents().GetNamespace()) {
+	if !wellknownnamespaces.IsRHCOSNamespace(req.GetComponents().GetNamespace()) || len(req.GetComponents().GetRhelContentSets()) == 0 {
 		// Non-RHCOS system with node inventory detected!
 		// We can provide a list of pkgs but cannot scan them -> setting a note to inform the user.
 		resp.NodeNotes = append(resp.GetNodeNotes(), v1.NodeNote_NODE_UNSUPPORTED)

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
               fieldPath: metadata.name
         - name: ROX_SKIP_PEER_VALIDATION
           value: "true"
+        - name: ROX_RHCOS_NODE_SCANNING
+          value: "true"
         resources:
           limits:
             cpu: 2

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
               fieldPath: metadata.name
         - name: ROX_SKIP_PEER_VALIDATION
           value: "true"
+        - name: ROX_RHCOS_NODE_SCANNING
+          value: "false"
         resources:
           limits:
             cpu: 2

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -28,8 +28,6 @@ spec:
               fieldPath: metadata.name
         - name: ROX_SKIP_PEER_VALIDATION
           value: "true"
-        - name: ROX_RHCOS_NODE_SCANNING
-          value: "false"
         resources:
           limits:
             cpu: 2

--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -103,9 +103,8 @@ func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
 }
 
 func TestGRPCGetRHCOSNodeVulnerabilities(t *testing.T) {
-	if !features.RHCOSNodeScanning.Enabled() {
-		t.Skip("This test requires ROX_RHCOS_NODE_SCANNING=true")
-	}
+	// Enable feature flag only for the scope of this test
+	t.Setenv(features.RHCOSNodeScanning.EnvVar(), "true")
 	conn := connectToScanner(t)
 	client := v1.NewNodeScanServiceClient(conn)
 

--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -105,6 +105,7 @@ func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
 func TestGRPCGetRHCOSNodeVulnerabilities(t *testing.T) {
 	// Enable feature flag only for the scope of this test
 	t.Setenv(env.RHCOSNodeScanning.EnvVar(), "true")
+	t.Logf("FF RHCOSNodeScanning set to: %t (%s)", env.RHCOSNodeScanning.Enabled(), env.RHCOSNodeScanning.Value())
 	conn := connectToScanner(t)
 	client := v1.NewNodeScanServiceClient(conn)
 

--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
-	"github.com/stackrox/scanner/pkg/features"
+	"github.com/stackrox/scanner/pkg/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -104,7 +104,7 @@ func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
 
 func TestGRPCGetRHCOSNodeVulnerabilities(t *testing.T) {
 	// Enable feature flag only for the scope of this test
-	t.Setenv(features.RHCOSNodeScanning.EnvVar(), "true")
+	t.Setenv(env.RHCOSNodeScanning.EnvVar(), "true")
 	conn := connectToScanner(t)
 	client := v1.NewNodeScanServiceClient(conn)
 

--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -5,6 +5,7 @@ package e2etests
 
 import (
 	"context"
+	"github.com/stackrox/scanner/pkg/features"
 	"testing"
 
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
@@ -153,6 +154,9 @@ func TestGRPCGetRHCOSNodeVulnerabilities(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := c
+			if !features.RHCOSNodeScanning.Enabled() {
+				t.Skip("This test requires ROX_RHCOS_NODE_SCANNING=true")
+			}
 			gotResponse, err := client.GetNodeVulnerabilities(context.Background(), c.request)
 			require.NoError(t, err)
 			assert.Len(t, gotResponse.GetFeatures(), len(c.expectedFeatures), "Unexpected number of features") // unusual got-expected order of Len

--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -105,7 +105,6 @@ func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
 func TestGRPCGetRHCOSNodeVulnerabilities(t *testing.T) {
 	// Enable feature flag only for the scope of this test
 	t.Setenv(env.RHCOSNodeScanning.EnvVar(), "true")
-	t.Logf("FF RHCOSNodeScanning set to: %t (%s)", env.RHCOSNodeScanning.Enabled(), env.RHCOSNodeScanning.Value())
 	conn := connectToScanner(t)
 	client := v1.NewNodeScanServiceClient(conn)
 

--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -5,10 +5,10 @@ package e2etests
 
 import (
 	"context"
-	"github.com/stackrox/scanner/pkg/features"
 	"testing"
 
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
+	"github.com/stackrox/scanner/pkg/features"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -103,6 +103,9 @@ func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
 }
 
 func TestGRPCGetRHCOSNodeVulnerabilities(t *testing.T) {
+	if !features.RHCOSNodeScanning.Enabled() {
+		t.Skip("This test requires ROX_RHCOS_NODE_SCANNING=true")
+	}
 	conn := connectToScanner(t)
 	client := v1.NewNodeScanServiceClient(conn)
 
@@ -150,13 +153,9 @@ func TestGRPCGetRHCOSNodeVulnerabilities(t *testing.T) {
 			expectedNotes:    nil,
 		},
 	}
-
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := c
-			if !features.RHCOSNodeScanning.Enabled() {
-				t.Skip("This test requires ROX_RHCOS_NODE_SCANNING=true")
-			}
 			gotResponse, err := client.GetNodeVulnerabilities(context.Background(), c.request)
 			require.NoError(t, err)
 			assert.Len(t, gotResponse.GetFeatures(), len(c.expectedFeatures), "Unexpected number of features") // unusual got-expected order of Len

--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
-	"github.com/stackrox/scanner/pkg/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,8 +102,6 @@ func buildRequest(notes []v1.Note) *v1.GetNodeVulnerabilitiesRequest {
 }
 
 func TestGRPCGetRHCOSNodeVulnerabilities(t *testing.T) {
-	// Enable feature flag only for the scope of this test
-	t.Setenv(env.RHCOSNodeScanning.EnvVar(), "true")
 	conn := connectToScanner(t)
 	client := v1.NewNodeScanServiceClient(conn)
 

--- a/pkg/env/list.go
+++ b/pkg/env/list.go
@@ -19,7 +19,4 @@ var (
 	// This is ignored if SkipPeerValidation is enabled.
 	// This variable was copied over from the stackrox repo.
 	OpenshiftAPI = RegisterBooleanSetting("ROX_OPENSHIFT_API", false)
-
-	// RHCOSNodeScanning enables phase 1 functions of "Full host level vulnerability scanning for RHCOS nodes" (ROX-10818)
-	RHCOSNodeScanning = RegisterBooleanSetting("ROX_RHCOS_NODE_SCANNING", false)
 )

--- a/pkg/env/list.go
+++ b/pkg/env/list.go
@@ -19,4 +19,7 @@ var (
 	// This is ignored if SkipPeerValidation is enabled.
 	// This variable was copied over from the stackrox repo.
 	OpenshiftAPI = RegisterBooleanSetting("ROX_OPENSHIFT_API", false)
+
+	// RHCOSNodeScanning enables phase 1 functions of "Full host level vulnerability scanning for RHCOS nodes" (ROX-10818)
+	RHCOSNodeScanning = RegisterBooleanSetting("ROX_RHCOS_NODE_SCANNING", false)
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -5,4 +5,6 @@ var (
 	ContinueUnknownOS = registerFeature("Enable continuation upon detecting unknown OS", "ROX_CONTINUE_UNKNOWN_OS", true)
 	// RHEL9Scanning enables support for scanning RHEL9-based images.
 	RHEL9Scanning = registerFeature("Enable support for scanning RHEL9 images", "ROX_RHEL9_SCANNING", true)
+	// RHCOSNodeScanning enables phase 1 functions of "Full host level vulnerability scanning for RHCOS nodes" (ROX-10818)
+	RHCOSNodeScanning = registerFeature("Enable RHCOS node scanning of OS and installed packages", "ROX_RHCOS_NODE_SCANNING", false)
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -5,4 +5,7 @@ var (
 	ContinueUnknownOS = registerFeature("Enable continuation upon detecting unknown OS", "ROX_CONTINUE_UNKNOWN_OS", true)
 	// RHEL9Scanning enables support for scanning RHEL9-based images.
 	RHEL9Scanning = registerFeature("Enable support for scanning RHEL9 images", "ROX_RHEL9_SCANNING", true)
+
+	// RHCOSNodeScanning enables phase 1 functions of "Full host level vulnerability scanning for RHCOS nodes" (ROX-10818)
+	RHCOSNodeScanning = registerFeature("Enabling Full host level vulnerability scanning for RHCOS nodes", "ROX_RHCOS_NODE_SCANNING", false)
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -5,6 +5,4 @@ var (
 	ContinueUnknownOS = registerFeature("Enable continuation upon detecting unknown OS", "ROX_CONTINUE_UNKNOWN_OS", true)
 	// RHEL9Scanning enables support for scanning RHEL9-based images.
 	RHEL9Scanning = registerFeature("Enable support for scanning RHEL9 images", "ROX_RHEL9_SCANNING", true)
-	// RHCOSNodeScanning enables phase 1 functions of "Full host level vulnerability scanning for RHCOS nodes" (ROX-10818)
-	RHCOSNodeScanning = registerFeature("Enable RHCOS node scanning of OS and installed packages", "ROX_RHCOS_NODE_SCANNING", false)
 )


### PR DESCRIPTION
## Problem
Currently Scanner does not run v1 Node Scan when RHCOS is detected. It displays the following warning when Node Scanning is run on RHCOS:

![Screenshot 2023-01-27 at 11 29 16](https://user-images.githubusercontent.com/114479/215066988-1bfb9ad8-707d-43e2-b3b5-4d42368538f4.png)

This is by design as the v1 scan data from NVD was inaccurate and lead to confusion of users.

## Goal
The goal of this ticket is to disable v1 Node Scan when RHCOS is detected and provide v2 scan instead.
This contains:

- remove the quit-early branch if RHCOS is detected
- do not run v1 scan if and only if: 
    - (1) the FF is enabled, 
    - (2) node inventory is present, 
    - (3) RHCOS system is detected. (Note that 2 implies 3).

## How This was tested?

- [x] CI
    - ⚠️ I needed to skip the existing e2e tests if the feature flag it disabled. Otherwise they fail. I know this isn't great, but if someone knows a solution to enabling the FF in the e2e tests, then please let me know. 
- [x] Run the e2e test `TestGRPCGetRHCOSNodeVulnerabilities` locally with feature flag enabled. 

```
$ go test -tags e2e -timeout=10s -count=1 -v -run ^TestGRPCGetRHCOSNodeVulnerabilities$  github.com/stackrox/scanner/e2etests
=== RUN   TestGRPCGetRHCOSNodeVulnerabilities
=== RUN   TestGRPCGetRHCOSNodeVulnerabilities/Uncertified_scan_is_unsupported_for_RHCOS_and_returns_no_features
=== RUN   TestGRPCGetRHCOSNodeVulnerabilities/Selected_vulnerabilities_should_be_returned_by_the_certified_scan
--- PASS: TestGRPCGetRHCOSNodeVulnerabilities (0.05s)
    --- PASS: TestGRPCGetRHCOSNodeVulnerabilities/Uncertified_scan_is_unsupported_for_RHCOS_and_returns_no_features (0.02s)
    --- PASS: TestGRPCGetRHCOSNodeVulnerabilities/Selected_vulnerabilities_should_be_returned_by_the_certified_scan (0.02s)
PASS
ok  	github.com/stackrox/scanner/e2etests	0.583s
```
- [x] Deployed with feature flag disabled and made sure that nothing that should work is broken
- [x] Deployed along with https://github.com/stackrox/stackrox/pull/4492 and seen this in the UI (still no vulns, but for that, we need content sets)

![Screenshot 2023-01-27 at 13 26 01](https://user-images.githubusercontent.com/114479/215087078-39cd656e-bbe4-48c7-982f-c1dc06e38796.png)


## What I observed in the UI

- `kernel` component is empty - this should be fixed in https://issues.redhat.com/browse/ROX-14288

![Screenshot 2023-01-27 at 13 37 47](https://user-images.githubusercontent.com/114479/215088964-31a26c9f-ca7a-46f5-8eb0-09a93ab494c4.png)


- Kubelet is present in the node inventory as: `kubelet v1.24.6+5658434`
- Kube-proxy is present in the node inventory as: `kube-proxy v1.24.6+5658434`
- Kernel is provided in the node overview


![Screenshot 2023-01-27 at 13 36 41](https://user-images.githubusercontent.com/114479/215088825-cc22eea3-7d94-4126-a6c6-e43b3f234234.png)
