### PR TITLE
Add usr/share/buildinfo to node scan

### DIFF
--- a/pkg/analyzer/nodes/node.go
+++ b/pkg/analyzer/nodes/node.go
@@ -101,7 +101,8 @@ func extractFilesFromDirectory(root string, matcher matcher.PrefixMatcher) (*fil
 		files: make(map[string]*fileMetadata),
 	}
 	m := metrics.FileExtractionMetrics{}
-	for _, dir := range []string{"etc/", "usr/share/rpm", "var/lib/rpm"} { // TODO(ROX-13771): Use range matcher.GetCommonPrefixDirs() again after fixing
+	// TODO(ROX-13771): Use `range matcher.GetCommonPrefixDirs()` again after fixing.
+	for _, dir := range []string{"etc/", "usr/share/rpm", "var/lib/rpm", "usr/share/buildinfo"} {
 		if err := n.addFiles(filepath.FromSlash(dir), matcher, &m); err != nil {
 			return nil, errors.Wrapf(err, "failed to match filesMap at %q (at %q)", dir, n.root)
 		}

--- a/pkg/analyzer/nodes/node_test.go
+++ b/pkg/analyzer/nodes/node_test.go
@@ -387,6 +387,11 @@ func Test_extractFilesFromDirectory(t *testing.T) {
 						isExtractable: true,
 						isSymlink:     true,
 					},
+					"usr/share/buildinfo/content_manifest.json": {
+						isExecutable:  false,
+						isExtractable: true,
+						isSymlink:     false,
+					},
 				},
 				readError: nil,
 			},
@@ -443,7 +448,8 @@ func makeTestData(t *testing.T) string {
 	// This directory structure mirrors what we have found in RHCOS 4.11.
 	//
 	// * `usr/lib/system-release` contains the distro identification data.
-	// * `etc/redhat-release` is a symlink to `/usr/lib/system-release`
+	// * `etc/redhat-release` is a symlink to `/usr/lib/system-release`.
+	// * `usr/share/buildinfo` contains content manifest json.
 	//
 	//    $ ls -l etc/redhat-release
 	//    total 0
@@ -452,9 +458,14 @@ func makeTestData(t *testing.T) string {
 	rhcosRedhatRelease := filepath.Join(root, "rootfs-rhcos/etc/redhat-release")
 	mkdirs(rhcosRedhatRelease)
 	require.NoError(t, os.Symlink("/usr/lib/system-release", rhcosRedhatRelease))
+
 	rhcosSystemRelease := filepath.Join(root, "rootfs-rhcos/usr/lib/system-release")
 	mkdirs(rhcosSystemRelease)
 	write(rhcosSystemRelease, "Red Hat Enterprise Linux CoreOS release 4.11\n")
+
+	contentManifestJson := filepath.Join(root, "rootfs-rhcos/usr/share/buildinfo/content_manifest.json")
+	mkdirs(contentManifestJson)
+	write(contentManifestJson, `{"content_sets": ["foo", "bar"]}`)
 
 	// This directory structure mirrors what we have found in RHCOS 4.11
 	// except it uses a symlink to a relative path.

--- a/pkg/analyzer/nodes/node_test.go
+++ b/pkg/analyzer/nodes/node_test.go
@@ -463,9 +463,9 @@ func makeTestData(t *testing.T) string {
 	mkdirs(rhcosSystemRelease)
 	write(rhcosSystemRelease, "Red Hat Enterprise Linux CoreOS release 4.11\n")
 
-	contentManifestJson := filepath.Join(root, "rootfs-rhcos/usr/share/buildinfo/content_manifest.json")
-	mkdirs(contentManifestJson)
-	write(contentManifestJson, `{"content_sets": ["foo", "bar"]}`)
+	contentManifestJSON := filepath.Join(root, "rootfs-rhcos/usr/share/buildinfo/content_manifest.json")
+	mkdirs(contentManifestJSON)
+	write(contentManifestJSON, `{"content_sets": ["foo", "bar"]}`)
 
 	// This directory structure mirrors what we have found in RHCOS 4.11
 	// except it uses a symlink to a relative path.


### PR DESCRIPTION
## Description

Explicitly add `usr/share/buildinfo` to the list of directories to detect files in node scanning. UT added to cover the new directory.

In node scan, we hard-code the directories to look for files during detection. To detect content sets, we need to include `usr/share/buildinfo/content_manifests.json`, hence the addition.

## Testing

- UT
- Openshift 4.12 cluster.