### PR TITLE
ROX-13107: Hardcode content sets in RHCOS 4.7 to 4.9

### DIFF
--- a/pkg/analyzer/detection/detection.go
+++ b/pkg/analyzer/detection/detection.go
@@ -156,7 +156,7 @@ func getHardcodedRHCOSContentSets(files analyzer.Files) ([]string, error) {
 }
 
 // isRPMVersionInInterval checks if the provided rpm version is within the specified interval
-// `(minExcluded, maxIncluded]`.
+// `[minIncluded, maxExcluded)`.
 func isRPMVersionInInterval(version, minIncluded, maxExcluded string) (bool, error) {
 	cmp, err := versionfmt.Compare(versionfmtrpm.ParserName, version, minIncluded)
 	if err != nil {

--- a/pkg/analyzer/detection/detection_test.go
+++ b/pkg/analyzer/detection/detection_test.go
@@ -1,9 +1,12 @@
 package detection
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/pkg/analyzer"
+	"github.com/stackrox/scanner/pkg/tarutil"
 )
 
 func Test_isCertifiedRHELNamespace(t *testing.T) {
@@ -42,6 +45,107 @@ func Test_isCertifiedRHELNamespace(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isCertifiedRHELNamespace(tt.namespace); got != tt.want {
 				t.Errorf("isCertifiedRHELNamespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getHardcodedRHCOSContentSets(t *testing.T) {
+	type args struct {
+		files analyzer.Files
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+		// If specified, sets args.files["etc/os-release"].
+		osReleaseContents string
+	}{
+		{
+			name: "when ocp/4.9 then valid",
+			osReleaseContents: `
+NAME="Red Hat Enterprise Linux CoreOS"
+VERSION="49.84.202212201621-0"
+ID="rhcos"
+ID_LIKE="rhel fedora"
+VERSION_ID="4.9"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="Red Hat Enterprise Linux CoreOS 49.84.202212201621-0 (Ootpa)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:8::coreos"
+HOME_URL="https://www.redhat.com/"
+DOCUMENTATION_URL="https://docs.openshift.com/container-platform/4.9/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
+REDHAT_BUGZILLA_PRODUCT_VERSION="4.9"
+REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
+REDHAT_SUPPORT_PRODUCT_VERSION="4.9"
+OPENSHIFT_VERSION="4.9"
+RHEL_VERSION="8.4"
+OSTREE_VERSION='49.84.202212201621-0'
+`,
+			want: []string{
+				"rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_4",
+				"rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_4",
+				"fast-datapath-for-rhel-8-x86_64-rpms",
+				"rhocp-4.9-for-rhel-8-x86_64-rpms",
+			},
+		},
+		{
+			name: "when not RHCOS then error",
+			osReleaseContents: `
+ID="rhel"
+VERSION_ID="4.9"
+OPENSHIFT_VERSION="4.9"
+RHEL_VERSION="8.4"
+`,
+			wantErr: true,
+		},
+		{
+			name: "when missing ID then error",
+			osReleaseContents: `
+VERSION_ID="4.9"
+OPENSHIFT_VERSION="4.9"
+RHEL_VERSION="8.4"
+`,
+			wantErr: true,
+		},
+		{
+			name: "when version 4.6 then ignored",
+			osReleaseContents: `
+ID=rhcos
+VERSION_ID="4.6"
+OPENSHIFT_VERSION="A.B"
+RHEL_VERSION="X.Y"
+`,
+			wantErr: false,
+		},
+		{
+			name: "when version 4.10 then ignored",
+			osReleaseContents: `
+ID=rhcos
+VERSION_ID="4.10"
+OPENSHIFT_VERSION="A.B"
+RHEL_VERSION="X.Y"
+`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		if tt.osReleaseContents != "" {
+			tt.args.files = tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
+				"etc/os-release": {Contents: []byte(tt.osReleaseContents)},
+			})
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getHardcodedRHCOSContentSets(tt.args.files)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getHardcodedRHCOSContentSets() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getHardcodedRHCOSContentSets() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/osrelease/osrelease.go
+++ b/pkg/osrelease/osrelease.go
@@ -32,6 +32,10 @@ func GetOSReleaseMap(data []byte, fields ...string) map[string]string {
 	for scanner.Scan() {
 		line := scanner.Text()
 		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			// Ignore malformed or empty lines.
+			continue
+		}
 		key := parts[0]
 		if len(fields) == 0 || fieldsSet.Contains(key) {
 			osReleaseMap[key] = strings.Replace(strings.ToLower(strings.TrimSpace(parts[1])), `"`, "", -1)

--- a/pkg/osrelease/osrelease.go
+++ b/pkg/osrelease/osrelease.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/scanner/ext/featurens/util"
 )
 
@@ -15,19 +16,26 @@ var (
 
 // GetOSAndVersionFromOSRelease returns the value of ID= and VERSION_ID= from /etc/os-release formatted data
 func GetOSAndVersionFromOSRelease(data []byte) (os, version string) {
+	m := GetOSReleaseMap(data, "ID", "VERSION_ID")
+	return util.NormalizeOSName(m["ID"]), m["VERSION_ID"]
+}
+
+// GetOSReleaseMap returns a map where keys and value are extracted from the
+// given os-release data. If `fields` is specified, only those fields are
+// returned. If None found empty map is returned.
+func GetOSReleaseMap(data []byte, fields ...string) map[string]string {
+	fieldsSet := set.NewStringSet(fields...)
+	osReleaseMap := make(map[string]string)
+	// The format of os-release is a newline-separated list of
+	// environment-like shell-compatible variable assignments.
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	for scanner.Scan() {
 		line := scanner.Text()
-
-		r := osPattern.FindStringSubmatch(line)
-		if len(r) == 2 {
-			os = strings.Replace(strings.ToLower(r[1]), "\"", "", -1)
-		}
-
-		r = versionPattern.FindStringSubmatch(line)
-		if len(r) == 2 {
-			version = strings.Replace(strings.ToLower(r[1]), "\"", "", -1)
+		parts := strings.SplitN(line, "=", 2)
+		key := parts[0]
+		if len(fields) == 0 || fieldsSet.Contains(key) {
+			osReleaseMap[key] = strings.Replace(strings.ToLower(strings.TrimSpace(parts[1])), `"`, "", -1)
 		}
 	}
-	return util.NormalizeOSName(os), version
+	return osReleaseMap
 }

--- a/pkg/osrelease/osrelease_test.go
+++ b/pkg/osrelease/osrelease_test.go
@@ -1,0 +1,65 @@
+package osrelease
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetOSReleaseMap(t *testing.T) {
+	type args struct {
+		data   []byte
+		fields []string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		want          map[string]string
+		osReleaseData string
+	}{
+		{
+			name: "when line that is not sh assignment then ignored",
+			want: map[string]string{
+				"FOO": "bar",
+				"BAR": "foo",
+			},
+			osReleaseData: `
+FOO=BAR
+FOOZ
+BAR=foo
+`,
+		},
+		{
+			name: "when empty line that is not sh assignment then ignored",
+			want: map[string]string{
+				"FOO": "bar",
+				"BAR": "foo",
+			},
+			osReleaseData: `
+FOO=BAR
+
+BAR=foo
+`,
+		},
+		{
+			name: "when assignment without value then value is empty",
+			want: map[string]string{
+				"FOO": "bar",
+				"BAR": "",
+			},
+			osReleaseData: `
+FOO=bar
+BAR=
+`,
+		},
+	}
+	for _, tt := range tests {
+		if tt.osReleaseData != "" {
+			tt.args.data = []byte(tt.osReleaseData)
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetOSReleaseMap(tt.args.data, tt.args.fields...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetOSReleaseMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Hardcode content sets and use standard CPE resolution logic to provide CPE info on older OpenShifts (4.7, 4.8, 4.9). Other versions are ignored, and no content sets are returned.

OpenShift 4.10 onwards provides `/root/content_manifests/*.json.` -- the manifest that lists repositories used to install packages in the O.S. used to find CPEs to match against OVAL. But OCP < 4.10 does not. Nevertheless, we can construct the content sets by hand by following the rules used by RHCOS itself. This will allow scanner to match vulnerabilities for OCP 4.7, 4.8 and 4.9.

## Tests

- UTs
- Deployment to Openshift 4.9. Added a debug line to Compliance:
  
  ```
  collection/nodeinventorizer: 2023/01/31 08:04:25.319831 nodeinventory.go:33: Debug: Content sets found under /host: [rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_4 rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_4 fast-datapath-for-rhel-8-x86_64-rpms rhocp-4.9-for-rhel-8-x86_64-rpms]
  ```
  
   Which maps correctly to the information found in `etc/os-release`:
   
   ```
   $ cat /host/etc/os-release 
  NAME="Red Hat Enterprise Linux CoreOS"
  VERSION="49.84.202212201621-0"
  ID="rhcos"
  ID_LIKE="rhel fedora"
  VERSION_ID="4.9"
  PLATFORM_ID="platform:el8"
  PRETTY_NAME="Red Hat Enterprise Linux CoreOS 49.84.202212201621-0 (Ootpa)"
  ANSI_COLOR="0;31"
  CPE_NAME="cpe:/o:redhat:enterprise_linux:8::coreos"
  HOME_URL="https://www.redhat.com/"
  DOCUMENTATION_URL="https://docs.openshift.com/container-platform/4.9/"
  BUG_REPORT_URL="https://bugzilla.redhat.com/"
  REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
  REDHAT_BUGZILLA_PRODUCT_VERSION="4.9"
  REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
  REDHAT_SUPPORT_PRODUCT_VERSION="4.9"
  OPENSHIFT_VERSION="4.9"
  RHEL_VERSION="8.4"
  OSTREE_VERSION='49.84.202212201621-0'
  ```