### PR TITLE
ROX-13107: Add missing content sets to the hard coded list for RHCOS 4.7, 4.8 and 4.9.

### DIFF
--- a/pkg/analyzer/detection/detection.go
+++ b/pkg/analyzer/detection/detection.go
@@ -145,14 +145,21 @@ func getHardcodedRHCOSContentSets(files analyzer.Files) ([]string, error) {
 	}
 	// Format the content sets based on the metadata found.
 	rhelSuffix := strings.Replace(metadata["RHEL_VERSION"], ".", "_DOT_", 1)
-	return []string{
-		// The mapping from RHCOS version to RHEL minor releases can be found here:
-		// https://access.redhat.com/articles/6907891
+	sets := []string{
+		// RHEL8.
 		fmt.Sprintf("rhel-8-for-x86_64-baseos-eus-rpms__%s", rhelSuffix),
 		fmt.Sprintf("rhel-8-for-x86_64-appstream-eus-rpms__%s", rhelSuffix),
+		fmt.Sprintf("rhel-8-for-x86_64-nfv-tus-rpms__%s", rhelSuffix),
+		// Fast datapath.
 		"fast-datapath-for-rhel-8-x86_64-rpms",
+		// Openshift RHOCP.
 		fmt.Sprintf("rhocp-%s-for-rhel-8-x86_64-rpms", metadata["OPENSHIFT_VERSION"]),
-	}, nil
+	}
+	if metadata["VERSION_ID"] != "4.7" {
+		// This is only specified for 4.8 and 4.9
+		sets = append(sets, "advanced-virt-for-rhel-8-x86_64-eus-rpms")
+	}
+	return sets, nil
 }
 
 // isRPMVersionInInterval checks if the provided rpm version is within the specified interval

--- a/pkg/analyzer/detection/detection_test.go
+++ b/pkg/analyzer/detection/detection_test.go
@@ -100,12 +100,12 @@ OSTREE_VERSION='49.84.202212201621-0'
 ID="rhcos"
 VERSION_ID="4.7"
 OPENSHIFT_VERSION="4.7"
-RHEL_VERSION="8.4"
+RHEL_VERSION="8.3"
 `,
 			want: []string{
-				"rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_4",
-				"rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_4",
-				"rhel-8-for-x86_64-nfv-tus-rpms__8_DOT_4",
+				"rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_3",
+				"rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_3",
+				"rhel-8-for-x86_64-nfv-tus-rpms__8_DOT_3",
 				"fast-datapath-for-rhel-8-x86_64-rpms",
 				"rhocp-4.7-for-rhel-8-x86_64-rpms",
 			},

--- a/pkg/analyzer/detection/detection_test.go
+++ b/pkg/analyzer/detection/detection_test.go
@@ -88,8 +88,26 @@ OSTREE_VERSION='49.84.202212201621-0'
 			want: []string{
 				"rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_4",
 				"rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_4",
+				"rhel-8-for-x86_64-nfv-tus-rpms__8_DOT_4",
 				"fast-datapath-for-rhel-8-x86_64-rpms",
 				"rhocp-4.9-for-rhel-8-x86_64-rpms",
+				"advanced-virt-for-rhel-8-x86_64-eus-rpms",
+			},
+		},
+		{
+			name: "when ocp/4.7 then should not use advanced-virt",
+			osReleaseContents: `
+ID="rhcos"
+VERSION_ID="4.7"
+OPENSHIFT_VERSION="4.7"
+RHEL_VERSION="8.4"
+`,
+			want: []string{
+				"rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_4",
+				"rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_4",
+				"rhel-8-for-x86_64-nfv-tus-rpms__8_DOT_4",
+				"fast-datapath-for-rhel-8-x86_64-rpms",
+				"rhocp-4.7-for-rhel-8-x86_64-rpms",
 			},
 		},
 		{


### PR DESCRIPTION
## Description

Add missing content sets to the hard-coded list for RHCOS 4.7, 4.8, and 4.9.

The additional content sets were found after the following steps, which I would like reviewers to also perform for validity:

1. In the corp network, you can inspect the RHCOS source code to determine which RPM repositories were enabled during the build [on gitlab](https://gitlab.cee.redhat.com/coreos/redhat-coreos/).
2. For each of the branches: 4.7, 4.8 and 4.9:
   1. Open all the `*.repo` files.
   2. For each repository, confirm the content set:
      a. Open https://www.redhat.com/security/data/metrics/repository-to-cpe.json
      b. Replace the architecture with `x86_64`, and grep for the repository path.
      c. Copy the content set name for the entry found.

Notice that for 4.7, `advanced-virt-for-rhel-8-x86_64-eus-rpms` is not used, and the code acts accordingly.

## Tests

- UTs.