### PR TITLE
Use downstream API to allow use of go1.19 memory mgmt changes to GC

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -22,6 +22,14 @@ spec:
         image: {{ .Values.scannerImage}}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
These changes are mirrored in https://github.com/stackrox/stackrox/pull/4662 but should get this to run on scale env, e2e tests, etc