### PR TITLE
Update max known OpenShift version to 4.13

### DIFF
--- a/pkg/cpeutils/utils.go
+++ b/pkg/cpeutils/utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Note: this must be updated with each new OpenShift release.
-const maxKnownOpenShift4MinorVersion = 12
+const maxKnownOpenShift4MinorVersion = 13
 
 // *** START Regex-related consts/vars. ***
 

--- a/pkg/cpeutils/utils_test.go
+++ b/pkg/cpeutils/utils_test.go
@@ -63,6 +63,7 @@ func TestGetAllOpenShift4CPEs(t *testing.T) {
 				"cpe:/a:redhat:openshift:4.10",
 				"cpe:/a:redhat:openshift:4.11",
 				"cpe:/a:redhat:openshift:4.12",
+				"cpe:/a:redhat:openshift:4.13",
 			},
 		},
 		{
@@ -81,6 +82,7 @@ func TestGetAllOpenShift4CPEs(t *testing.T) {
 				"cpe:/a:redhat:openshift:4.10::el8",
 				"cpe:/a:redhat:openshift:4.11::el8",
 				"cpe:/a:redhat:openshift:4.12::el8",
+				"cpe:/a:redhat:openshift:4.13::el8",
 			},
 		},
 	}


### PR DESCRIPTION
OpenShift 4.13 is now the max known OpenShift version.

This actually is not needed at this time, as the CPEs in the OVAL v2 feeds specify this for us; however, we still have this to protect from potential future OVAL v2 changes.

Currently, the OVAL v2 feed for unfixable OpenShift vulns give us CPEs of the form:
`cpe:/a:redhat:openshift:4.13`, but there were talks of changing it to `cpe:/a:redhat:openshift:4`. We have this variable to capture what we know to be the latest version of OpenShift in case this change happens...