### PR TITLE
ROX-14288: Ensure Linux Kernel related packages are not skipped in RHCOS node scanning

### DIFF
--- a/api/v1/models.go
+++ b/api/v1/models.go
@@ -95,9 +95,9 @@ func featureFromDatabaseModel(dbFeatureVersion database.FeatureVersion, uncertif
 	}
 }
 
-// isPackageBlacklistedInScan returns true if the given package name in the
+// isPackageBlocklistedInScan returns true if the given package name in the
 // namespace should be skipped in vulnerability matching scans.
-func isPackageBlacklistedInScan(namespace, pkgName string) bool {
+func isPackageBlocklistedInScan(namespace, pkgName string) bool {
 	// Allow kernel packages in RHCOS.
 	if namespaces.IsRHCOSNamespace(namespace) {
 		return false
@@ -135,7 +135,7 @@ func LayerFromDatabaseModel(db database.Datastore, dbLayer database.Layer, linea
 		for _, dbFeatureVersion := range dbLayer.Features {
 			feature := featureFromDatabaseModel(dbFeatureVersion, opts.GetUncertifiedRHEL(), depMap)
 
-			if isPackageBlacklistedInScan(layer.NamespaceName, feature.Name) {
+			if isPackageBlocklistedInScan(layer.NamespaceName, feature.Name) {
 				continue
 			}
 
@@ -201,7 +201,7 @@ func ComponentsFromDatabaseModel(db database.Datastore, dbLayer *database.Layer,
 		for _, dbFeatureVersion := range dbLayer.Features {
 			feature := featureFromDatabaseModel(dbFeatureVersion, uncertifiedRHEL, depMap)
 
-			if isPackageBlacklistedInScan(dbLayer.Namespace.Name, feature.Name) {
+			if isPackageBlocklistedInScan(dbLayer.Namespace.Name, feature.Name) {
 				continue
 			}
 

--- a/api/v1/models_rhelv2.go
+++ b/api/v1/models_rhelv2.go
@@ -60,7 +60,7 @@ func getFullRHELv2Features(db database.Datastore, pkgEnvs map[int]*database.RHEL
 	for _, pkgEnv := range pkgEnvs {
 		pkg := pkgEnv.Pkg
 
-		if isPackageBlacklistedInScan(pkgEnv.Namespace, pkg.Name) {
+		if isPackageBlocklistedInScan(pkgEnv.Namespace, pkg.Name) {
 			continue
 		}
 

--- a/api/v1/models_rhelv2.go
+++ b/api/v1/models_rhelv2.go
@@ -60,7 +60,7 @@ func getFullRHELv2Features(db database.Datastore, pkgEnvs map[int]*database.RHEL
 	for _, pkgEnv := range pkgEnvs {
 		pkg := pkgEnv.Pkg
 
-		if hasKernelPrefix(pkg.Name) {
+		if isPackageBlacklistedInScan(pkgEnv.Namespace, pkg.Name) {
 			continue
 		}
 


### PR DESCRIPTION
Allowlist `linux` and `kernel` packages when matching vulnerability when the namespace is RHCOS.

Scanner explicitly skips packages prefixed with "linux" or "kernel" to ensure kernel-related vulnerability packages are not reported, as they are irrelevant for images. This is not the case for nodes. We should ensure these are noticed in RHCOS nodes.

## Tests

- UTs.