### PR TITLE
Test_getFullRHELv2Features compare slices with assert.ElementsMatchf

### DIFF
--- a/api/v1/models_rhelv2_test.go
+++ b/api/v1/models_rhelv2_test.go
@@ -339,7 +339,7 @@ func Test_getFullRHELv2Features(t *testing.T) {
 			if !tt.wantErr(t, err, fmt.Sprintf("getFullRHELv2Features(%v, %v, %v)", tt.args.db, tt.args.pkgEnvs, tt.args.execsPopulated)) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "getFullRHELv2Features(%v, %v, %v)", tt.args.db, tt.args.pkgEnvs, tt.args.execsPopulated)
+			assert.ElementsMatchf(t, tt.want, got, "getFullRHELv2Features(%v, %v, %v)", tt.args.db, tt.args.pkgEnvs, tt.args.execsPopulated)
 		})
 	}
 }


### PR DESCRIPTION
assert.Equalf works iff the order is the same. Use  assert.ElementsMatchf so we don't have to care about the ordering