### PR TITLE
Reduce race condition likelihood, remove redundant diff download

### DIFF
--- a/scripts/ci/jobs/sanity-check-vuln-updates.sh
+++ b/scripts/ci/jobs/sanity-check-vuln-updates.sh
@@ -102,8 +102,8 @@ function run_tests_for_diff_id {
   diff_archive_cloudflare=/tmp/diff1.zip
   diff_archive_gcs=/tmp/diff2.zip
 
-  curl_verbose_cloudflare=$(curl -s -H 'Accept-encoding: gzip' -o "$diff_archive_cloudflare" -v "$url_cloudflare" 2>&1 \
-    | sed -e "s#^< ##g; s#\r##g;") \
+  curl_verbose_cloudflare=$(curl -s -H 'Accept-encoding: gzip' -o "$diff_archive_cloudflare" \
+    -v "$url_cloudflare" 2>&1 | sed -e "s#^< ##g; s#\r##g;") \
     || bash_exit_failure "curl failed on $url_cloudflare"
   cache_control_gcs_https=$(curl -s -H 'Accept-encoding: gzip' -o "$diff_archive_gcs" \
     -v "$url_gcs_https" 2>&1 | grep "cache-control" | sed -e "s#^< ##g; s#\r##g;") \
@@ -113,7 +113,7 @@ function run_tests_for_diff_id {
   md5sum_gcs_https=$(md5sum "$diff_archive_gcs" | awk '{print $1}')
 
   metadata_cloudflare=$(unzip -q -c "$diff_archive_cloudflare" manifest.json | jq -cr '.' && rm -f $diff_archive_cloudflare) \
-    || bash_exit_failure "manifest extraction failed on $diff_archive_cloudflare"
+    || bash_exit_failure "metadata extraction failed on $diff_archive_cloudflare"
   metadata_gcs_https=$(unzip -q -c "$diff_archive_gcs" manifest.json | jq -cr '.' && rm -f "$diff_archive_gcs") \
     || bash_exit_failure "metadata extraction failed on $diff_archive_gcs"
 


### PR DESCRIPTION
This change will reduce (not eliminate) the likelihood of a race condition that occurs when the `definitions.stackrox.io` GCS bucket is updated after the `sanity-check-vuln-updates` job has started.  It does this by using the `age` of the GCS `diff.zip` as close to the 1hr age check as possible (instead of the `age` determined when the job started)

The CloudFlare `age` header is now also logged for future troubleshooting / logic as necessary, it will help determine the actual cache age (for the particular CloudFlare node)
    
Additionally, each diff was being downloaded multiple times (back to back), once for extracting a manifest, and the other for extracting headers.  This PR removes the redundant download (`wget`) which should reduce bandwidth and potentially speed up the job