### PR TITLE
fix: Update E2E test after changes in vulnerability data

### DIFF
--- a/e2etests/node_scan_rhcos_test.go
+++ b/e2etests/node_scan_rhcos_test.go
@@ -22,9 +22,9 @@ var vulnLibksba = &v1.Vulnerability{
 		LastModifiedDateTime: "",
 		CvssV2:               nil,
 		CvssV3: &v1.CVSSMetadata{
-			Score:               8.1,
-			Vector:              "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
-			ExploitabilityScore: 2.2,
+			Vector:              "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+			Score:               9.8,
+			ExploitabilityScore: 3.9,
 			ImpactScore:         5.9,
 		},
 	},
@@ -187,11 +187,15 @@ func assertEquals(t *testing.T, name, version string, expected, got []*v1.Vulner
 // assertExists asserts that all 'needles' exist in 'haystack'
 func assertExists(t *testing.T, name, version string, needles, haystack []*v1.Vulnerability) {
 	assert.GreaterOrEqual(t, len(haystack), len(needles), "Expected to find at least %d vulnerabilities for feature '%s:%s'", len(needles), name, version)
-	// Prune last modified time
+	// Create a map to check haystack, and prune last modified time.
+	haystackByName := make(map[string]*v1.Vulnerability)
 	for _, v := range haystack {
 		v.MetadataV2.LastModifiedDateTime = ""
+		haystackByName[v.Name] = v
 	}
 	for _, v := range needles {
-		assert.Contains(t, haystack, v)
+		h, ok := haystackByName[v.Name]
+		assert.True(t, ok, "vulnerabilities for %s-%s does not contain %s", name, version, v.Name)
+		assert.Exactly(t, v, h, "vulnerability %s for %s-%s is different from expected", v.Name, name, version)
 	}
 }

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3873,7 +3873,7 @@ Applications using RegexRequestMatcher with '.' in the regular expression are po
 				VersionFormat: "rpm",
 				Version:       "4.10.1650890594-1.el8.noarch",
 				AddedBy:       "sha256:3fa3f612bdcb92746bf76be1b9c9e1c1c80de777aedaf48b7068f4a129ded3c2",
-				FixedBy:       "4.10.1670851835-1.el8",
+				FixedBy:       "4.10.1675144701-1.el8",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "CVE-2021-26291",


### PR DESCRIPTION
Update to latest vuln data. Change RHCOS E2E assertion to show diffs when comparing vulns.

Our E2E tests rely on live vulnerability data that can change with time. In this case two changes happened:

1. https://access.redhat.com/errata/RHSA-2023:0560 was issued on 2023-02-08 affecting `jenkins-2-plugins`, that changed the `fixedBy` version of the package/feature -- it was bumped to a later version that fixes the mentioned RHSA.
2. https://access.redhat.com/errata/RHSA-2022:7089 has CVSS score data updated.

The changes to assertion were done to help identifying changes in future failures.

## Tests

CI is green. 