### PR TITLE
ROX-15044: Bump nvtools to fix NVD CPE version padded with zeros

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -197,7 +197,7 @@ replace (
 	// BE SURE TO KEEP THIS UP-TO-DATE.
 	github.com/blevesearch/bleve => github.com/stackrox/bleve v0.0.0-20220907150529-4ecbd2543f9e
 
-	github.com/facebookincubator/nvdtools => github.com/stackrox/nvdtools v0.0.0-20220608171543-e758756071a0
+	github.com/facebookincubator/nvdtools => github.com/stackrox/nvdtools v0.0.0-20230214202552-24e684e3ad9d
 	github.com/fullsailor/pkcs7 => github.com/stackrox/pkcs7 v0.0.0-20220914154527-cfdb0aa47179
 	github.com/gogo/protobuf => github.com/connorgorman/protobuf v1.2.2-0.20210115205927-b892c1b298f7
 	github.com/heroku/docker-registry-client => github.com/stackrox/docker-registry-client v0.0.0-20220204234128-07f109db0819

--- a/go.sum
+++ b/go.sum
@@ -1017,8 +1017,8 @@ github.com/stackrox/istio-cves v0.0.0-20221007013142-0bde9b541ec8 h1:rUIvoAHokPc
 github.com/stackrox/istio-cves v0.0.0-20221007013142-0bde9b541ec8/go.mod h1:ZF7mH4kH1G+82HxR3uFDHvyLG8eCOdrh1RDyQcTGkBA=
 github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d h1:88Iui7fSMKgXvpyfBlbP3qosrqyv3qMgOJ6JJ4V4tFQ=
 github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d/go.mod h1:GJwFpFwCxiYhgpJWrAkM+v9Z9gpgtyWxkRdK4JjsOIg=
-github.com/stackrox/nvdtools v0.0.0-20220608171543-e758756071a0 h1:hLexaI/zJBDP4OlxN1za3IJM7cfH+Kie7F/wdWn3xGA=
-github.com/stackrox/nvdtools v0.0.0-20220608171543-e758756071a0/go.mod h1:AIeN7k60Q/kcW9aeiMpA0PY8CU3zsrLV0UhIksolMn4=
+github.com/stackrox/nvdtools v0.0.0-20230214202552-24e684e3ad9d h1:sc34LMHnCCvnDBWmFmDnm2ph+IU7zMXR3kummBnkP5g=
+github.com/stackrox/nvdtools v0.0.0-20230214202552-24e684e3ad9d/go.mod h1:AIeN7k60Q/kcW9aeiMpA0PY8CU3zsrLV0UhIksolMn4=
 github.com/stackrox/stackrox v0.0.0-20221004225457-0e5037e513f1 h1:/dkkUSV4CAEIT1gKDR+XF1eGw7dmnHMLMrsmW5RDALs=
 github.com/stackrox/stackrox v0.0.0-20221004225457-0e5037e513f1/go.mod h1:wqJK92FalO/obU7Et5frBaryzeSzdXUQVFZRwm7PM2Y=
 github.com/stackrox/zap v1.15.1-0.20200720133746-810fd602fd0f h1:Ofa3PAa609eSHcHP2kCJDUWUnuEWfiqXhsuppk/QtOE=


### PR DESCRIPTION
This is a follow up on https://github.com/stackrox/nvdtools/pull/8

When numeric parts are compared, 0's are padded to the left to ensure they have the same length. When all components are the same, the code relies on the string length, but the padded zeros are ignored, resulting in incorrect results.

## Tests

CI