### PR TITLE
Fix 4.7 known fixed vulns and max patch

### DIFF
--- a/e2etests/orchestrator_scan_test.go
+++ b/e2etests/orchestrator_scan_test.go
@@ -99,9 +99,9 @@ func TestGRPCGetOpenShiftVulnerabilities(t *testing.T) {
 		},
 		{
 			addressFamily: "4.7",
-			maxPatch:      12,
+			maxPatch:      32,
 			step:          1,
-			knownFixed:    3,
+			knownFixed:    4,
 		},
 	}
 
@@ -152,6 +152,12 @@ func TestGRPCGetOpenShiftVulnerabilities(t *testing.T) {
 				}
 
 				lastPatch = patch
+			}
+
+			// Log remaining vulns for easy debugging.
+			t.Logf("Remaining vulns at %s.%d:", c.addressFamily, c.maxPatch)
+			for name, vuln := range vulnNameMap {
+				t.Logf("- %q (FixedBy: %s)", name, vuln.GetFixedBy())
 			}
 
 			// Check for regression. All vulns known to be fixed should not be unfixed.


### PR DESCRIPTION
## Description

E2E is failing because the number of expected fixed vulns for Openshift 4.7 has changed. The current fix bumps the max patch release to the latest and expects all remaining vulns to be fixed. Also, add a log line to help debug the issue in future failures.

The test bumps the patch version and tracks which vulnerabilities were fixed between them. Ultimately, it accounts for the total number of vulnerabilities fixed against the original value and expects the total to be lower.

The actual reason why the number of vulnerabilities changed is currently unknown to me.

Before the fix, these were the remaining vulns:

```
=== RUN   TestGRPCGetOpenShiftVulnerabilities/case-4.7
    orchestrator_scan_test.go:146: Remaining vulns at 4.7.4:
    orchestrator_scan_test.go:148: - "RHBA-2021:2979" (FixedBy: 4.7.23)
    orchestrator_scan_test.go:148: - "RHSA-2021:1150" (FixedBy: 4.7.7)
    orchestrator_scan_test.go:148: - "RHSA-2021:3635" (FixedBy: 4.7.32)
```

## Tests

CI
