### PR TITLE
Set the OS from the scanned namespace

### DIFF
--- a/api/v1/nodescan/service.go
+++ b/api/v1/nodescan/service.go
@@ -247,7 +247,8 @@ func (s *serviceImpl) GetNodeVulnerabilities(ctx context.Context, req *v1.GetNod
 	}
 
 	resp := &v1.GetNodeVulnerabilitiesResponse{
-		ScannerVersion: s.version,
+		ScannerVersion:  s.version,
+		OperatingSystem: req.GetComponents().GetNamespace(),
 	}
 
 	if !wellknownnamespaces.IsRHCOSNamespace(req.GetComponents().GetNamespace()) || len(req.GetComponents().GetRhelContentSets()) == 0 {

--- a/pkg/analyzer/nodes/node_test.go
+++ b/pkg/analyzer/nodes/node_test.go
@@ -447,7 +447,7 @@ func Test_extractFilesFromDirectory_Context(t *testing.T) {
 		{
 			name:            "context cancellation should return early with error",
 			root:            testDataRoot,
-			ctxDeadline:     5 * time.Microsecond,
+			ctxDeadline:     0 * time.Microsecond,
 			expectedErr:     context.DeadlineExceeded,
 			expectNilResult: true,
 		},


### PR DESCRIPTION
Set the operating system namespace in the `GetNodeVulnerabilities` response based on the scanned namespace.

Before, in "V1 node scanning" (aka. legacy node scanning), the namespace was determined from the Operating System Image name. But host-level scanning detects the "scanned namespace" in the node itself during node analysis. That namespace should be the authoritative string.

The [scan operating system](https://github.com/stackrox/stackrox/blob/62d79bce3df1d0bc689ea500b144b9a445da4b63/pkg/scanners/clairify/convert.go#L93-L92) is pulled from this. Since it's empty, the components list is missing "Operating System" column:

![image](https://user-images.githubusercontent.com/291493/227047215-c2cca752-3604-4c18-a5fa-a77f76b16459.png)

## Tests

CI.

Deploy to `jvdm-argilo`:

![image](https://user-images.githubusercontent.com/291493/227069222-46787da2-9558-4f77-9d3a-6fa41a20b6af.png)
