### PR TITLE
remove grpc-middleware direct dependency

### DIFF
--- a/api/grpc/grpc.go
+++ b/api/grpc/grpc.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/NYTimes/gziphandler"
-	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	log "github.com/sirupsen/logrus"
@@ -61,7 +60,7 @@ func (a *apiImpl) connectToLocalEndpoint() (*grpc.ClientConn, error) {
 }
 
 func (a *apiImpl) Start() {
-	grpcServer := grpc.NewServer(grpcmiddleware.WithUnaryServerChain(a.config.UnaryInterceptors...))
+	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(a.config.UnaryInterceptors...))
 	for _, serv := range a.apiServices {
 		serv.RegisterServiceServer(grpcServer)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.5.9
 	github.com/gorilla/mux v1.8.0
-	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/guregu/null v4.0.0+incompatible
@@ -55,6 +54,7 @@ require (
 
 require (
 	github.com/containers/storage v1.45.3 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 )


### PR DESCRIPTION
Dependabot made a PR #1138 to update that `grpc-middlware` but CI was failing because the new version deprecated `grpcmiddleware .WithUnaryServerChain` in favor of `grpc.ChainUnaryInterceptor`. This PR makes this replacement.

See https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware#WithUnaryServerChain for more information.