### PR TITLE
ROX-16310 - Fix GetImageComponents ManifestList Not Found

### DIFF
--- a/api/v1/imagescan/service.go
+++ b/api/v1/imagescan/service.go
@@ -176,7 +176,7 @@ func (s *serviceImpl) getImageComponents(_ context.Context, req *v1.GetImageComp
 		return nil, err
 	}
 
-	// If a digest was provided as part of the request, that same digest must be used in the call to getLayers.
+	// If a digest was provided as part of the request, that same digest must be used in the call to getLayer.
 	// A different digest will result in a NotFound error (observed when the request digest represents a ManifestList)
 	//
 	// server.processImage will ensure image.SHA is populated with the digest from request if exists, otherwise will be first layer digest

--- a/api/v1/imagescan/service.go
+++ b/api/v1/imagescan/service.go
@@ -170,7 +170,7 @@ func (s *serviceImpl) GetImageComponents(ctx context.Context, req *v1.GetImageCo
 	}, nil
 }
 
-func (s *serviceImpl) getImageComponents(ctx context.Context, req *v1.GetImageComponentsRequest, uncertifiedRHEL bool) (*apiV1.ComponentsEnvelope, error) {
+func (s *serviceImpl) getImageComponents(_ context.Context, req *v1.GetImageComponentsRequest, uncertifiedRHEL bool) (*apiV1.ComponentsEnvelope, error) {
 	image, _, err := s.processImage(req.GetImage(), req.GetRegistry(), uncertifiedRHEL)
 	if err != nil {
 		return nil, err

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -2447,6 +2447,15 @@ var testCases = []testCase{
 		namespace:       "centos:7",
 	},
 	{
+		// Added to ensure no errors when analzying an image using the digest of a ManifestList
+		image:           "registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.74.1@sha256:8e455c6f7ee571cc8c565b2f2b1ff712f05ade5cef0c34d528d2955253469992",
+		registry:        "https://registry.redhat.io",
+		username:        os.Getenv("REDHAT_USERNAME"),
+		password:        os.Getenv("REDHAT_PASSWORD"),
+		uncertifiedRHEL: false,
+		namespace:       "rhel:8",
+	},
+	{
 		// Had an issue where Scanner claimed jq 6.1-r1 was vulnerable to
 		// a CVE fixed in 1.6_rc1-r0. We do NOT expect this version of
 		// jq to be vulnerable to this CVE (CVE-2016-4074).


### PR DESCRIPTION
GRPC Invocations of `GetImageComponents` (`proto/scanner/api/v1/image_scan_service.proto`) will fail with a `NotFound` error if the request contains a digest the represents a `ManifestList` (observed during testing of on-prem local registry scanning)

This change ensures that the digest passed in the request is also used when obtaining layer data

See [ROX-16310](https://issues.redhat.com/browse/ROX-16310) for more details