### PR TITLE
[DO NOT MERGE] ROX-16170: gracefully shutdown node inventory when not on openshift or rhcos

### DIFF
--- a/api/v1/nodeinventory/service.go
+++ b/api/v1/nodeinventory/service.go
@@ -51,7 +51,7 @@ func (s *serviceImpl) GetNodeInventory(_ context.Context, _ *v1.GetNodeInventory
 		log.Errorf("error analyzing node %q: %v", s.nodeName, err)
 		switch {
 		case errors.Is(err, detection.ErrNodeScanningUnavailable):
-			log.Infof("Replying and gracefully shutting down the container because it is not RHCOS")
+			log.Infof("Gracefully shutting down the container because it is not RHCOS")
 			defer s.shutdownContainer()
 			return nil, err
 		default:


### PR DESCRIPTION
This PR is to gracefully shut down the `node-inventory` container when we discover that it runs on something different than Openshift or RHCOS. This is to save resources and not run a container that does nothing.

## Tested
- On colima (non-openshift) - the `node-inventory` quits gracefully, scanner deployment stays (even after force-rescanning image).
- On openshift - both `node-inventory` and scanner deployments continue working. 

See below for screenshots from the tests.