### PR TITLE
Fix CVE-2021-26291 not found

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3876,31 +3876,6 @@ Applications using RegexRequestMatcher with '.' in the regular expression are po
 				FixedBy:       "4.10.1675407676-1.el8",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
-						Name:          "CVE-2021-26291",
-						NamespaceName: "rhel:8",
-						Description: `DOCUMENTATION: A flaw was found in maven. Repositories that are defined in a dependency’s Project Object Model (pom), which may be unknown to users, are used by default resulting in potential risk if a malicious actor takes over that repository or is able to insert themselves into a position to pretend to be that repository. The highest threat from this vulnerability is to data confidentiality and integrity. 
-            
-            MITIGATION: To avoid possible man-in-the-middle related attacks with this flaw, ensure any linked repositories in maven POMs use https and not http.`,
-						Link:     "https://access.redhat.com/security/cve/CVE-2021-26291",
-						Severity: "Moderate",
-						Metadata: map[string]interface{}{
-							"Red Hat": map[string]interface{}{
-								"CVSSv2": map[string]interface{}{
-									"ExploitabilityScore": 0.0,
-									"ImpactScore":         0.0,
-									"Score":               0.0,
-									"Vectors":             "",
-								},
-								"CVSSv3": map[string]interface{}{
-									"ExploitabilityScore": 2.2,
-									"ImpactScore":         5.2,
-									"Score":               7.4,
-									"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
-								},
-							},
-						},
-					},
-					{
 						Name:          "RHSA-2022:6531",
 						NamespaceName: "rhel:8",
 						Description: `Red Hat OpenShift Container Platform is Red Hat's cloud computing


### PR DESCRIPTION
RHEL8 based images that have `jenkins-2-plugins` appears to no longer be affected by this CVE

This CVE is not listed for `jenkins-2-plugins` in the RHEL8 unpatched feeds:
- `RHEL8-openshift-4-including-unpatched.json`
- `RHEL8-rhel-8-including-unpatched.json`

However it is listed for `jenkins-2-plugins` in the `RHEL9-openshift-4-including-unpatched.json` feed:

```json
{
            "name": "CVE-2022-25177",
            "title": "",
            "description": "DOCUMENTATION: A flaw was found in Jenkins. The Pipeline: Shared Groovy Libraries follows symbolic links to locations outside of the expected Pipeline library when reading files using the libraryResource step. This flaw allows attackers who can configure Pipelines to read arbitrary files on the Jenkins controller file system.",
            "issued": "0001-01-01T00:00:00Z",
            "updated": "2022-07-28T00:00:00Z",
            "link": "https://access.redhat.com/security/cve/CVE-2022-25177",
            "severity": "Moderate",
            "cvssv3": "6.5/CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
            "cpes": [
                "cpe:/a:redhat:openshift:4.0",
                "cpe:/a:redhat:openshift:4.1",
                "cpe:/a:redhat:openshift:4.2",
                "cpe:/a:redhat:openshift:4.3",
                "cpe:/a:redhat:openshift:4.4",
                "cpe:/a:redhat:openshift:4.5",
                "cpe:/a:redhat:openshift:4.6",
                "cpe:/a:redhat:openshift:4.7",
                "cpe:/a:redhat:openshift:4.8",
                "cpe:/a:redhat:openshift:4.9",
                "cpe:/a:redhat:openshift:4.10",
                "cpe:/a:redhat:openshift:4.11",
                "cpe:/a:redhat:openshift:4.12",
                "cpe:/a:redhat:openshift:4.0::el9",
                "cpe:/a:redhat:openshift:4.1::el9",
                "cpe:/a:redhat:openshift:4.2::el9",
                "cpe:/a:redhat:openshift:4.3::el9",
                "cpe:/a:redhat:openshift:4.4::el9",
                "cpe:/a:redhat:openshift:4.5::el9",
                "cpe:/a:redhat:openshift:4.6::el9",
                "cpe:/a:redhat:openshift:4.7::el9",
                "cpe:/a:redhat:openshift:4.8::el9",
                "cpe:/a:redhat:openshift:4.9::el9",
                "cpe:/a:redhat:openshift:4.10::el9",
                "cpe:/a:redhat:openshift:4.11::el9",
                "cpe:/a:redhat:openshift:4.12::el9"
            ],
            "package_info": null,
            "packages": [
                {
                    "name": "jenkins-2-plugins",
                    "resolution_state": "Affected",
                    "fixed_in_version": ""
                }
            ]
        },
```