### PR TITLE
Update e2e Jenkins FixedBy version to 4.10.1681719745-1.el8

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3882,7 +3882,7 @@ Applications using RegexRequestMatcher with '.' in the regular expression are po
 				VersionFormat: "rpm",
 				Version:       "4.10.1650890594-1.el8.noarch",
 				AddedBy:       "sha256:3fa3f612bdcb92746bf76be1b9c9e1c1c80de777aedaf48b7068f4a129ded3c2",
-				FixedBy:       "4.10.1680703106-1.el8",
+				FixedBy:       "4.10.1681719745-1.el8",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "CVE-2021-26291",


### PR DESCRIPTION
Updating FixedBy to fix CI error(s):

```
{Failed      sanity_test.go:126: 
        	Error Trace:	/go/src/github.com/stackrox/scanner/e2etests/sanity_test.go:126
        	Error:      	Not equal: 
        	            	expected: v1.Feature{Name:"jenkins-2-plugins", NamespaceName:"rhel:8", VersionFormat:"rpm", Version:"4.10.1650890594-1.el8.noarch", Vulnerabilities:[]v1.Vulnerability(nil), AddedBy:"sha256:3fa3f612bdcb92746bf76be1b9c9e1c1c80de777aedaf48b7068f4a129ded3c2", Location:"", FixedBy:"4.10.1680703106-1.el8", Executables:[]*scannerV1.Executable(nil)}
        	            	actual  : v1.Feature{Name:"jenkins-2-plugins", NamespaceName:"rhel:8", VersionFormat:"rpm", Version:"4.10.1650890594-1.el8.noarch", Vulnerabilities:[]v1.Vulnerability(nil), AddedBy:"sha256:3fa3f612bdcb92746bf76be1b9c9e1c1c80de777aedaf48b7068f4a129ded3c2", Location:"", FixedBy:"4.10.1681719745-1.el8", Executables:[]*scannerV1.Executable(nil)}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -8,3 +8,3 @@
        	            	  Location: (string) "",
        	            	- FixedBy: (string) (len=21) "4.10.1680703106-1.el8",
        	            	+ FixedBy: (string) (len=21) "4.10.1681719745-1.el8",
        	            	  Executables: ([]*scannerV1.Executable) <nil>
        	Test:       	TestImageSanity/quay.io/rhacs-eng/qa:ose-jenkins/jenkins-2-plugins/4.10.1650890594-1.el8.noarch}
```