### PR TITLE
fix: Expected fixedby version for jenkins-2-plugins

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3882,7 +3882,7 @@ Applications using RegexRequestMatcher with '.' in the regular expression are po
 				VersionFormat: "rpm",
 				Version:       "4.10.1650890594-1.el8.noarch",
 				AddedBy:       "sha256:3fa3f612bdcb92746bf76be1b9c9e1c1c80de777aedaf48b7068f4a129ded3c2",
-				FixedBy:       "4.10.1681719745-1.el8",
+				FixedBy:       "4.10.1684982411-1.el8",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "CVE-2021-26291",


### PR DESCRIPTION
Our E2E tests rely on live vulnerability data that can change with time. Some RHSA (I believe https://access.redhat.com/errata/RHSA-2023:3362) was issued that affected `jenkins-2-plugins`, changing the expected `fixedBy` version of the package/feature -- it was bumped to a later version that fixes the mentioned CVE (https://access.redhat.com/security/cve/CVE-2023-1370).

```
{Failed      grpc_full_test.go:102: 
        	Error Trace:	/go/src/github.com/stackrox/scanner/e2etests/grpc_full_test.go:102
        	Error:      	Not equal: 
        	            	expected: scannerV1.Feature{Name:"jenkins-2-plugins", Version:"4.10.1650890594-1.el8.noarch", FeatureType:"rpm", AddedByLayer:"sha256:3fa3f612bdcb92746bf76be1b9c9e1c1c80de777aedaf48b7068f4a129ded3c2", Location:"", Vulnerabilities:[]*scannerV1.Vulnerability(nil), FixedBy:"4.10.1681719745-1.el8", ProvidedExecutables:[]*scannerV1.Executable(nil), XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0}
        	            	actual  : scannerV1.Feature{Name:"jenkins-2-plugins", Version:"4.10.1650890594-1.el8.noarch", FeatureType:"rpm", AddedByLayer:"sha256:3fa3f612bdcb92746bf76be1b9c9e1c1c80de777aedaf48b7068f4a129ded3c2", Location:"", Vulnerabilities:[]*scannerV1.Vulnerability(nil), FixedBy:"4.10.1684982411-1.el8", ProvidedExecutables:[]*scannerV1.Executable(nil), XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -7,3 +7,3 @@
        	            	  Vulnerabilities: ([]*scannerV1.Vulnerability) <nil>,
        	            	- FixedBy: (string) (len=21) "4.10.1681719745-1.el8",
        	            	+ FixedBy: (string) (len=21) "4.10.1684982411-1.el8",
        	            	  ProvidedExecutables: ([]*scannerV1.Executable) <nil>,
        	Test:       	TestGRPCGetImageVulnerabilities/quay.io/rhacs-eng/qa:ose-jenkins/jenkins-2-plugins/4.10.1650890594-1.el8.noarch}
```