### PR TITLE
fix: Expected fixedby version for `sandbox-dotnet-60-runtime`

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3686,7 +3686,7 @@ Bug Fix(es) and Enhancement(s):
 						FixedBy: "0:6.0.7-1.el8_6",
 					},
 				},
-				FixedBy: "6.0.13-1.el8_7",
+				FixedBy: "6.0.18-1.el8_8",
 				AddedBy: "sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723",
 			},
 			{
@@ -3725,7 +3725,7 @@ Bug Fix(es) and Enhancement(s):
 						FixedBy: "0:6.0.7-1.el8_6",
 					},
 				},
-				FixedBy: "6.0.13-1.el8_7",
+				FixedBy: "6.0.18-1.el8_8",
 				AddedBy: "sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723",
 			},
 		},


### PR DESCRIPTION
Update fixed by versions for `dotnet-runtime-6.0` and `aspnetcore-runtime-6.0` due to https://access.redhat.com/errata/RHSA-2023:3582

CI failures:

```
github.com/stackrox/scanner/e2etests: TestImageSanity/quay.io/rhacs-eng/qa:sandbox-dotnet-60-runtime-6.0-15.20220620151726/aspnetcore-runtime-6.0/6.0.6-1.el8_6.x86_64 expand_less | 0s


{Failed      sanity_test.go:126: 
        	Error Trace:	/go/src/github.com/stackrox/scanner/e2etests/sanity_test.go:126
        	Error:      	Not equal: 
        	            	expected: v1.Feature{Name:"aspnetcore-runtime-6.0", NamespaceName:"rhel:8", VersionFormat:"rpm", Version:"6.0.6-1.el8_6.x86_64", Vulnerabilities:[]v1.Vulnerability(nil), AddedBy:"sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723", Location:"", FixedBy:"6.0.13-1.el8_7", Executables:[]*scannerV1.Executable(nil)}
        	            	actual  : v1.Feature{Name:"aspnetcore-runtime-6.0", NamespaceName:"rhel:8", VersionFormat:"rpm", Version:"6.0.6-1.el8_6.x86_64", Vulnerabilities:[]v1.Vulnerability(nil), AddedBy:"sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723", Location:"", FixedBy:"6.0.18-1.el8_8", Executables:[]*scannerV1.Executable(nil)}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -8,3 +8,3 @@
        	            	  Location: (string) "",
        	            	- FixedBy: (string) (len=14) "6.0.13-1.el8_7",
        	            	+ FixedBy: (string) (len=14) "6.0.18-1.el8_8",
        	            	  Executables: ([]*scannerV1.Executable) <nil>
        	Test:       	TestImageSanity/quay.io/rhacs-eng/qa:sandbox-dotnet-60-runtime-6.0-15.20220620151726/aspnetcore-runtime-6.0/6.0.6-1.el8_6.x86_64}
```

```
github.com/stackrox/scanner/e2etests: TestImageSanity/quay.io/rhacs-eng/qa:sandbox-dotnet-60-runtime-6.0-15.20220620151726/dotnet-runtime-6.0/6.0.6-1.el8_6.x86_64 

{Failed      sanity_test.go:126: 
        	Error Trace:	/go/src/github.com/stackrox/scanner/e2etests/sanity_test.go:126
        	Error:      	Not equal: 
        	            	expected: v1.Feature{Name:"dotnet-runtime-6.0", NamespaceName:"rhel:8", VersionFormat:"rpm", Version:"6.0.6-1.el8_6.x86_64", Vulnerabilities:[]v1.Vulnerability(nil), AddedBy:"sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723", Location:"", FixedBy:"6.0.13-1.el8_7", Executables:[]*scannerV1.Executable(nil)}
        	            	actual  : v1.Feature{Name:"dotnet-runtime-6.0", NamespaceName:"rhel:8", VersionFormat:"rpm", Version:"6.0.6-1.el8_6.x86_64", Vulnerabilities:[]v1.Vulnerability(nil), AddedBy:"sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723", Location:"", FixedBy:"6.0.18-1.el8_8", Executables:[]*scannerV1.Executable(nil)}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -8,3 +8,3 @@
        	            	  Location: (string) "",
        	            	- FixedBy: (string) (len=14) "6.0.13-1.el8_7",
        	            	+ FixedBy: (string) (len=14) "6.0.18-1.el8_8",
        	            	  Executables: ([]*scannerV1.Executable) <nil>
        	Test:       	TestImageSanity/quay.io/rhacs-eng/qa:sandbox-dotnet-60-runtime-6.0-15.20220620151726/dotnet-runtime-6.0/6.0.6-1.el8_6.x86_64}
```
