### PR TITLE
ROX-18001: add drools CPE for CVE-2021-41411

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3972,4 +3972,31 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 			},
 		},
 	},
+	{
+		image:                   "quay.io/rhacs-eng/qa:drools-CVE-2021-41411",
+		registry:                "https://quay.io",
+		username:                os.Getenv("QUAY_RHACS_ENG_RO_USERNAME"),
+		password:                os.Getenv("QUAY_RHACS_ENG_RO_PASSWORD"),
+		source:                  "NVD",
+		onlyCheckSpecifiedVulns: true,
+		expectedFeatures: []apiV1.Feature{
+			{
+				Name:          "drools",
+				VersionFormat: component.JavaSourceType.String(),
+				Version:       "6.4.0.final",
+				Location:      "org.drools.drools-core-6.4.0.Final.jar:drools-core",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:        "CVE-2021-41411",
+						Description: "drools <=7.59.x is affected by an XML External Entity (XXE) vulnerability in KieModuleMarshaller.java. The Validator class is not used correctly, resulting in the XXE injection vulnerability.",
+						Link:        "https://nvd.nist.gov/vuln/detail/CVE-2021-41411",
+						Severity:    "Critical",
+						FixedBy:     "7.6.0",
+					},
+				},
+				FixedBy: "7.6.0",
+				AddedBy: "sha256:e144eb7fd976d07a81b9571592ceb6bdbb1488e5df4623b08a849792ed618920",
+			},
+		},
+	},
 }

--- a/pkg/vulnloader/nvdloader/manual.go
+++ b/pkg/vulnloader/nvdloader/manual.go
@@ -824,4 +824,106 @@ var manuallyEnrichedVulns = map[string]*schema.NVDCVEFeedJSON10DefCVEItem{
 		LastModifiedDate: "2021-02-24T12:15Z",
 		PublishedDate:    "2017-03-11T02:59Z",
 	},
+	// CVE-2021-41411 was not being detected for `org.drools.drools-core-6.4.0.Final.jar`.
+	// This entry adds an additional CPE URI (in addition to what exists in NVD) to
+	// enable matching.
+	"CVE-2021-41411": {
+		CVE: &schema.CVEJSON40{
+			CVEDataMeta: &schema.CVEJSON40CVEDataMeta{
+				ASSIGNER: "cve@mitre.org",
+				ID:       "CVE-2021-41411",
+			},
+			DataFormat:  "MITRE",
+			DataType:    "CVE",
+			DataVersion: "4.0",
+			Description: &schema.CVEJSON40Description{
+				DescriptionData: []*schema.CVEJSON40LangString{
+					{
+						Lang:  "en",
+						Value: "drools <=7.59.x is affected by an XML External Entity (XXE) vulnerability in KieModuleMarshaller.java. The Validator class is not used correctly, resulting in the XXE injection vulnerability.",
+					},
+				},
+			},
+			Problemtype: &schema.CVEJSON40Problemtype{
+				ProblemtypeData: []*schema.CVEJSON40ProblemtypeProblemtypeData{
+					{
+						Description: []*schema.CVEJSON40LangString{
+							{
+								Lang:  "en",
+								Value: "CWE-611",
+							},
+						},
+					},
+				},
+			},
+			References: &schema.CVEJSON40References{
+				ReferenceData: []*schema.CVEJSON40Reference{
+					{
+						Name:      "https://github.com/kiegroup/drools/pull/3808",
+						Refsource: "MISC",
+						Tags:      []string{"Patch", "Third Party Advisory"},
+						URL:       "https://github.com/kiegroup/drools/pull/3808",
+					},
+				},
+			},
+		},
+		Configurations: &schema.NVDCVEFeedJSON10DefConfigurations{
+			CVEDataVersion: "4.0",
+			Nodes: []*schema.NVDCVEFeedJSON10DefNode{
+				{
+					CPEMatch: []*schema.NVDCVEFeedJSON10DefCPEMatch{
+						{
+							Cpe23Uri:            `cpe:2.3:a:redhat:drools:*:*:*:*:*:*:*:*`,
+							VersionEndExcluding: "7.6.0",
+							Vulnerable:          true,
+						},
+						{
+							Cpe23Uri:            `cpe:2.3:a:drools:drools:*:*:*:*:*:*:*:*`,
+							VersionEndExcluding: "7.6.0",
+							Vulnerable:          true,
+						},
+					},
+					Operator: "OR",
+				},
+			},
+		},
+		Impact: &schema.NVDCVEFeedJSON10DefImpact{
+			BaseMetricV2: &schema.NVDCVEFeedJSON10DefImpactBaseMetricV2{
+				CVSSV2: &schema.CVSSV20{
+					AccessComplexity:      "LOW",
+					AccessVector:          "NETWORK",
+					Authentication:        "NONE",
+					AvailabilityImpact:    "PARTIAL",
+					BaseScore:             7.5,
+					ConfidentialityImpact: "PARTIAL",
+					IntegrityImpact:       "PARTIAL",
+					VectorString:          "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+					Version:               "2.0",
+				},
+				ExploitabilityScore: 10,
+				ImpactScore:         6.4,
+				Severity:            "HIGH",
+			},
+			BaseMetricV3: &schema.NVDCVEFeedJSON10DefImpactBaseMetricV3{
+				CVSSV3: &schema.CVSSV30{
+					AttackComplexity:      "LOW",
+					AttackVector:          "NETWORK",
+					AvailabilityImpact:    "HIGH",
+					BaseScore:             9.8,
+					BaseSeverity:          "CRITICAL",
+					ConfidentialityImpact: "HIGH",
+					IntegrityImpact:       "HIGH",
+					PrivilegesRequired:    "NONE",
+					Scope:                 "UNCHANGED",
+					UserInteraction:       "NONE",
+					VectorString:          "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					Version:               "3.1",
+				},
+				ExploitabilityScore: 3.9,
+				ImpactScore:         5.9,
+			},
+		},
+		LastModifiedDate: "2022-06-28T13:56Z",
+		PublishedDate:    "2022-06-16T10:15Z",
+	},
 }


### PR DESCRIPTION
CVE was not being matched with drool's jars due to vendor name mismatch.

## Testing
- Added test case to `e2etests/testcase_test.go`
- Tested local deploy with modified version of `TestGRPCGetImageVulnerabilities` to only execute newly added test
  - Verified test failed
- Added manual entry to `pkg/vulnloader/nvdloader/manual.go` with additional CPE based on NVD entry from `2021.json` in dump 
- Rebuilt `build-updater` and ran it to produce new dumps
- Verified `2021.json` had new CPE for CVE
- Rebuilt scanner `make image`, and deployed locally `make deploy-local`
- Retested via modified version of `TestGRPCGetImageVulnerabilities`
  - Verified test succeeded