### PR TITLE
Improve FixedBy assertion

### DIFF
--- a/e2etests/grpc_full_test.go
+++ b/e2etests/grpc_full_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stackrox/scanner/api/v1/features"
@@ -99,8 +100,8 @@ func verifyImage(t *testing.T, imgScan *v1.Image, test testCase) {
 			if feature.GetFixedBy() != matching.GetFixedBy() {
 				var vulns []string
 				for _, v := range matching.GetVulnerabilities() {
-					if v.GetFixedBy() == matching.GetFixedBy() {
-						vulns = append(vulns, v.GetName())
+					if strings.Contains(v.GetFixedBy(), matching.GetFixedBy()) {
+						vulns = append(vulns, fmt.Sprintf("%s (FixedBy: %s)", v.GetName(), v.GetFixedBy()))
 					}
 				}
 				assert.Equalf(t, len(vulns), 0, "FixedBy: expecting %q, but found %q: Probably due to the following "+

--- a/e2etests/grpc_full_test.go
+++ b/e2etests/grpc_full_test.go
@@ -95,6 +95,19 @@ func verifyImage(t *testing.T, imgScan *v1.Image, test testCase) {
 					assert.Truef(t, foundMatch, "Expected to find %s in scan results", expectedVuln.Name)
 				}
 			}
+			// Check feature FixedBy, and provide the related vulnerability if they differ.
+			if feature.GetFixedBy() != matching.GetFixedBy() {
+				var vulns []string
+				for _, v := range matching.GetVulnerabilities() {
+					if v.GetFixedBy() == matching.GetFixedBy() {
+						vulns = append(vulns, v.GetName())
+					}
+				}
+				assert.Equalf(t, len(vulns), 0, "FixedBy: expecting %q, but found %q: Probably due to the following "+
+					"vulnerabilities (verify if test case needs an update, or if it's a bug): %v)",
+					feature.GetFixedBy(), matching.GetFixedBy(), vulns)
+			}
+
 			feature.Vulnerabilities = nil
 			matching.Vulnerabilities = nil
 

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3510,7 +3510,7 @@ var testCases = []testCase{
 				NamespaceName: "rhel:9",
 				Version:       "1:3.0.1-23.el9_0.x86_64",
 				VersionFormat: "rpm",
-				FixedBy:       "1:3.0.7-6.el9_2",
+				FixedBy:       "1:3.0.7-16.el9_2",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "RHSA-2022:7288",
@@ -3552,7 +3552,7 @@ For more details about the security issue(s), including the impact, a CVSS score
 				NamespaceName: "rhel:9",
 				Version:       "1:3.0.1-23.el9_0.x86_64",
 				VersionFormat: "rpm",
-				FixedBy:       "1:3.0.7-6.el9_2",
+				FixedBy:       "1:3.0.7-16.el9_2",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "RHSA-2022:7288",
@@ -3655,6 +3655,7 @@ For more details about the security issue(s), including the impact, a CVSS score
 				NamespaceName: "rhel:8",
 				VersionFormat: "rpm",
 				Version:       "6.0.6-1.el8_6.x86_64",
+				FixedBy:       "6.0.18-1.el8_8",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "RHBA-2022:5747",
@@ -3686,7 +3687,6 @@ Bug Fix(es) and Enhancement(s):
 						FixedBy: "0:6.0.7-1.el8_6",
 					},
 				},
-				FixedBy: "6.0.18-1.el8_8",
 				AddedBy: "sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723",
 			},
 			{
@@ -3694,6 +3694,7 @@ Bug Fix(es) and Enhancement(s):
 				NamespaceName: "rhel:8",
 				VersionFormat: "rpm",
 				Version:       "6.0.6-1.el8_6.x86_64",
+				FixedBy:       "6.0.18-1.el8_8",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "RHBA-2022:5747",
@@ -3725,7 +3726,6 @@ Bug Fix(es) and Enhancement(s):
 						FixedBy: "0:6.0.7-1.el8_6",
 					},
 				},
-				FixedBy: "6.0.18-1.el8_8",
 				AddedBy: "sha256:16e1dc59de605089610e3be2c77f3cde5eed99b523a0d7a3e3a2f65fa7c60723",
 			},
 		},
@@ -3882,7 +3882,7 @@ Applications using RegexRequestMatcher with '.' in the regular expression are po
 				VersionFormat: "rpm",
 				Version:       "4.10.1650890594-1.el8.noarch",
 				AddedBy:       "sha256:3fa3f612bdcb92746bf76be1b9c9e1c1c80de777aedaf48b7068f4a129ded3c2",
-				FixedBy:       "4.10.1684982411-1.el8",
+				FixedBy:       "4.10.1685679861-1.el8",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "CVE-2021-26291",


### PR DESCRIPTION
Add a custom assertion message pointing out which potential vulnerabilities bumped up the FixedBy, so we can check if a bump in the test is necessary or if it's a bug in FixedBy logic.

## Tests

CI.
