### PR TITLE
ROX-18202: Fix language layer error due to unique constraint

### DIFF
--- a/database/pgsql/migrations/00020_languagelayer_lineage_pk.go
+++ b/database/pgsql/migrations/00020_languagelayer_lineage_pk.go
@@ -1,0 +1,14 @@
+package migrations
+
+import "github.com/remind101/migrate"
+
+func init() {
+	RegisterMigration(migrate.Migration{
+		ID: 20,
+		Up: migrate.Queries([]string{
+			`ALTER TABLE LanguageLayer DROP CONSTRAINT IF EXISTS languagelayer_pkey`,
+			`ALTER TABLE LanguageLayer DROP CONSTRAINT IF EXISTS languagelayer_layer_name_key`,
+			`ALTER TABLE LanguageLayer ADD PRIMARY KEY (layer_name, lineage)`,
+		}),
+	})
+}

--- a/e2etests/vuln_test.go
+++ b/e2etests/vuln_test.go
@@ -334,6 +334,24 @@ func TestDistrolessVulnImages(t *testing.T) {
 				{"base-files", "9.9+deb9u13", []expectedVuln{}},
 			},
 		},
+		{
+			image: "quay.io/rhacs-eng/sandbox:drools-debian",
+			expectedFeatures: []feature{
+				{"drools", "6.4.0.final", []expectedVuln{
+					{name: "CVE-2021-41411", fixedBy: ""},
+				},
+				},
+			},
+		},
+		{
+			image: "quay.io/rhacs-eng/qa:drools-ubi-minimal",
+			expectedFeatures: []feature{
+				{"drools", "6.4.0.final", []expectedVuln{
+					{name: "CVE-2021-41411", fixedBy: ""},
+				},
+				},
+			},
+		},
 	} {
 		t.Run(testCase.image, func(t *testing.T) {
 			testSingleVulnImage(testCase, t)

--- a/e2etests/vuln_test.go
+++ b/e2etests/vuln_test.go
@@ -242,6 +242,24 @@ func TestStackroxVulnImages(t *testing.T) {
 				},
 			},
 		},
+		{
+			image: "quay.io/rhacs-eng/qa:drools-debian",
+			expectedFeatures: []feature{
+				{"drools", "6.4.0.final", []expectedVuln{
+					{name: "CVE-2021-41411", fixedBy: ""},
+				},
+				},
+			},
+		},
+		{
+			image: "quay.io/rhacs-eng/qa:drools-ubi-minimal",
+			expectedFeatures: []feature{
+				{"drools", "6.4.0.final", []expectedVuln{
+					{name: "CVE-2021-41411", fixedBy: ""},
+				},
+				},
+			},
+		},
 	} {
 		t.Run(testCase.image, func(t *testing.T) {
 			testSingleVulnImage(testCase, t)
@@ -332,24 +350,6 @@ func TestDistrolessVulnImages(t *testing.T) {
 				{"netbase", "5.4", []expectedVuln{}},
 				{"tzdata", "2020a-0+deb9u1", []expectedVuln{}},
 				{"base-files", "9.9+deb9u13", []expectedVuln{}},
-			},
-		},
-		{
-			image: "quay.io/rhacs-eng/sandbox:drools-debian",
-			expectedFeatures: []feature{
-				{"drools", "6.4.0.final", []expectedVuln{
-					{name: "CVE-2021-41411", fixedBy: ""},
-				},
-				},
-			},
-		},
-		{
-			image: "quay.io/rhacs-eng/qa:drools-ubi-minimal",
-			expectedFeatures: []feature{
-				{"drools", "6.4.0.final", []expectedVuln{
-					{name: "CVE-2021-41411", fixedBy: ""},
-				},
-				},
 			},
 		},
 	} {


### PR DESCRIPTION
The issue was laid out in the doc by David. Basically what's happening is that the sample images have layers that are identical so they have the same "layer_name" which is the digest, but the lineage is different. This means that if you have identical layers with vulns that have different lineages (or parent layers) then the second insertion is due to the conflict on the layer_name (insert does on conflict do nothing). This change makes it so that table is keyed on layer_name and lineage, effectively only deduping layers with the exact same parents (which is good because we don't need to reinsert the layers). The unit test should test this case

~Note: for some reason, this does not work on scratch, but I find that less pressing because it seems to be when the language vuln is simply in the base layer~

~This is fixed by always evaluating language vulns even if there are no db features~