### PR TITLE
ROX-17114: Fix misattribution of Java versions when there are multiple matching lines

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -4016,4 +4016,71 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 			},
 		},
 	},
+	{
+		image:                   "quay.io/rhacs-eng/qa:tomcat-9.0.59",
+		registry:                "https://quay.io",
+		username:                os.Getenv("QUAY_RHACS_ENG_RO_USERNAME"),
+		password:                os.Getenv("QUAY_RHACS_ENG_RO_PASSWORD"),
+		source:                  "NVD",
+		namespace:               "alpine:v3.15",
+		onlyCheckSpecifiedVulns: true,
+		expectedFeatures: []apiV1.Feature{
+			{
+				Name:          "tomcat",
+				VersionFormat: component.JavaSourceType.String(),
+				Version:       "9.0.59",
+				Location:      "tomcat-embed-core-9.0.59.jar",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:        "CVE-2022-29885",
+						Description: "The documentation of Apache Tomcat 10.1.0-M1 to 10.1.0-M14, 10.0.0-M1 to 10.0.20, 9.0.13 to 9.0.62 and 8.5.38 to 8.5.78 for the EncryptInterceptor incorrectly stated it enabled Tomcat clustering to run over an untrusted network. This was not correct. While the EncryptInterceptor does provide confidentiality and integrity protection, it does not protect against all risks associated with running over any untrusted network, particularly DoS risks.",
+						Link:        "https://nvd.nist.gov/vuln/detail/CVE-2022-29885",
+						Severity:    "Important",
+						FixedBy:     "", // This should be fixed, but NVD did not set this properly.
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 10.0,
+									"ImpactScore":         2.9,
+									"Score":               5.0,
+									"Vectors":             "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 3.9,
+									"ImpactScore":         3.6,
+									"Score":               7.5,
+									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+								},
+							},
+						},
+					},
+					{
+						Name:        "CVE-2023-28708",
+						Description: "When using the RemoteIpFilter with requests received from a reverse proxy via HTTP that include the X-Forwarded-Proto header set to https, session cookies created by Apache Tomcat 11.0.0-M1 to 11.0.0.-M2, 10.1.0-M1 to 10.1.5, 9.0.0-M1 to 9.0.71 and 8.5.0 to 8.5.85 did not include the secure attribute. This could result in the user agent transmitting the session cookie over an insecure channel.",
+						Link:        "https://nvd.nist.gov/vuln/detail/CVE-2023-28708",
+						Severity:    "Moderate",
+						FixedBy:     "9.0.72",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 2.8,
+									"ImpactScore":         1.4,
+									"Score":               4.3,
+									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+								},
+							},
+						},
+					},
+				},
+				FixedBy: "9.0.72",
+				AddedBy: "sha256:97444f2bde8fa4fdfb6ec630b24fbdf95017c6813f4b5e68e64a4280b276eff2",
+			},
+		},
+	},
 }

--- a/pkg/analyzer/java/parse_manifest_test.go
+++ b/pkg/analyzer/java/parse_manifest_test.go
@@ -7,8 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testTomcat10ManifestMF = `
-Manifest-Version: 1.0
+const testTomcat10ManifestMF = `Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: tomcat-embed-core
 Bundle-SymbolicName: org.apache.tomcat-embed-core
@@ -39,8 +38,7 @@ Specification-Vendor: Eclipse Foundation
 Specification-Version: 3.0
 `
 
-const testTomcat9ManifestMF = `
-Manifest-Version: 1.0
+const testTomcat9ManifestMF = `Manifest-Version: 1.0
 Automatic-Module-Name: org.apache.tomcat.embed.core
 Bnd-LastModified: 1593547891735
 Bundle-ManifestVersion: 2

--- a/pkg/analyzer/java/parse_manifest_test.go
+++ b/pkg/analyzer/java/parse_manifest_test.go
@@ -2,11 +2,11 @@ package java
 
 import (
 	"bytes"
-	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-const testManifestMF = `
+const testTomcat10ManifestMF = `
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: tomcat-embed-core
@@ -38,12 +38,135 @@ Specification-Vendor: Eclipse Foundation
 Specification-Version: 3.0
 `
 
-func TestStopOnceFirstKeyIsFound(t *testing.T) {
-	manifestBytes := bytes.NewBuffer([]byte(testManifestMF))
-	manifest, err := parseManifestMFFromReader("", manifestBytes)
-	if err != nil {
-		panic(err)
-	}
+const testTomcat9ManifestMF = `
+Manifest-Version: 1.0
+Automatic-Module-Name: org.apache.tomcat.embed.core
+Bnd-LastModified: 1593547891735
+Bundle-ManifestVersion: 2
+Bundle-Name: tomcat-embed-core
+Bundle-SymbolicName: org.apache.tomcat-embed-core
+Bundle-Version: 9.0.37
+Created-By: 1.8.0_252 (AdoptOpenJDK)
+DSTAMP: 20200630
+Implementation-Title: Apache Tomcat
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 9.0.37
+Private-Package: org.apache.naming.factory.webservices,org.apache.tomc
+ at.util.bcel,org.apache.tomcat.util.http.fileupload.impl,org.apache.t
+ omcat.util.http.fileupload.util.mime,org.apache.tomcat.util.json,org.
+ apache.tomcat.util.modeler.modules,org.apache.tomcat.util.net.jsse,or
+ g.apache.tomcat.util.threads.res
+Provide-Capability: osgi.contract;osgi.contract=JavaJASPIC;version:Lis
+ t<Version>="1.1,1";uses:="javax.security.auth.message,javax.security.
+ auth.message.callback,javax.security.auth.message.config,javax.securi
+ ty.auth.message.module",osgi.contract;osgi.contract=JavaServlet;versi
+ on:List<Version>="4.0,3.1,3,2.5";uses:="javax.servlet,javax.servlet.a
+ nnotation,javax.servlet.descriptor,javax.servlet.http,javax.servlet.r
+ esources"
+Require-Capability: osgi.contract;osgi.contract=JavaAnnotation;filter:
+ ="(&(osgi.contract=JavaAnnotation)(version=1.3.0))",osgi.ee;filter:="
+ (&(osgi.ee=JavaSE)(version=1.8))"
+Specification-Title: Apache Tomcat
+Specification-Vendor: Apache Software Foundation
+Specification-Version: 9.0
+TODAY: June 30 2020
+Tool: Bnd-5.1.1.202006162103
+TSTAMP: 2109
+X-Compile-Source-JDK: 8
+X-Compile-Target-JDK: 8
 
-	fmt.Printf("%+v\n", manifest)
+Name: javax/security/auth/message/
+Implementation-Title: javax.security.auth.message
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 1.1.FR
+Specification-Title: Java Authentication SPI for Containers
+Specification-Vendor: Sun Microsystems, Inc.
+Specification-Version: 1.1
+
+Name: javax/security/auth/message/callback/
+Implementation-Title: javax.security.auth.message
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 1.1.FR
+Specification-Title: Java Authentication SPI for Containers
+Specification-Vendor: Sun Microsystems, Inc.
+Specification-Version: 1.1
+
+Name: javax/security/auth/message/config/
+Implementation-Title: javax.security.auth.message
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 1.1.FR
+Specification-Title: Java Authentication SPI for Containers
+Specification-Vendor: Sun Microsystems, Inc.
+Specification-Version: 1.1
+
+Name: javax/security/auth/message/module/
+Implementation-Title: javax.security.auth.message
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 1.1.FR
+Specification-Title: Java Authentication SPI for Containers
+Specification-Vendor: Sun Microsystems, Inc.
+Specification-Version: 1.1
+
+Name: javax/servlet/
+Implementation-Title: javax.servlet
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 4.0.FR
+Specification-Title: Java API for Servlets
+Specification-Vendor: Sun Microsystems, Inc.
+Specification-Version: 4.0
+
+Name: javax/servlet/annotation/
+Implementation-Title: javax.servlet
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 4.0.FR
+Specification-Title: Java API for Servlets
+Specification-Vendor: Sun Microsystems, Inc.
+Specification-Version: 4.0
+
+Name: javax/servlet/descriptor/
+Implementation-Title: javax.servlet
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 4.0.FR
+Specification-Title: Java API for Servlets
+Specification-Vendor: Sun Microsystems, Inc.
+Specification-Version: 4.0
+
+Name: javax/servlet/http/
+Implementation-Title: javax.servlet
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 4.0.FR
+Specification-Title: Java API for Servlets
+Specification-Vendor: Sun Microsystems, Inc.
+Specification-Version: 4.0
+
+Name: javax/servlet/resources/
+Implementation-Title: javax.servlet
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 4.0.FR
+Specification-Title: Java API for Servlets
+Specification-Vendor: Sun Microsystems, Inc.
+Specification-Version: 4.0
+`
+
+func TestStopOnceFirstKeyIsFound(t *testing.T) {
+	manifest, err := parseManifestMFFromReader("", bytes.NewBufferString(testTomcat9ManifestMF))
+	assert.NoError(t, err)
+	assert.Equal(t, "9.0", manifest.specificationVersion)
+	assert.Equal(t, "Apache Software Foundation", manifest.specificationVendor)
+	assert.Equal(t, "9.0.37", manifest.implementationVersion)
+	assert.Equal(t, "Apache Software Foundation", manifest.implementationVendor)
+	assert.Equal(t, "", manifest.implementationVendorID)
+	assert.Equal(t, "tomcat-embed-core", manifest.bundleName)
+	assert.Equal(t, "org.apache.tomcat-embed-core", manifest.bundleSymbolicName)
+
+	manifest, err = parseManifestMFFromReader("", bytes.NewBufferString(testTomcat10ManifestMF))
+	assert.NoError(t, err)
+
+	assert.Equal(t, "10.1", manifest.specificationVersion)
+	assert.Equal(t, "Apache Software Foundation", manifest.specificationVendor)
+	assert.Equal(t, "10.1.8", manifest.implementationVersion)
+	assert.Equal(t, "Apache Software Foundation", manifest.implementationVendor)
+	assert.Equal(t, "", manifest.implementationVendorID)
+	assert.Equal(t, "tomcat-embed-core", manifest.bundleName)
+	assert.Equal(t, "org.apache.tomcat-embed-core", manifest.bundleSymbolicName)
 }

--- a/pkg/analyzer/java/parse_manifest_test.go
+++ b/pkg/analyzer/java/parse_manifest_test.go
@@ -1,0 +1,49 @@
+package java
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+const testManifestMF = `
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: tomcat-embed-core
+Bundle-SymbolicName: org.apache.tomcat-embed-core
+Bundle-Version: 10.1.8
+Implementation-Title: Apache Tomcat
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 10.1.8
+Specification-Title: Apache Tomcat
+Specification-Vendor: Apache Software Foundation
+Specification-Version: 10.1
+X-Compile-Source-JDK: 11
+X-Compile-Target-JDK: 11
+
+Name: jakarta/security/auth/message/
+Implementation-Title: jakarta.security.auth.message
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 3.0
+Specification-Title: Jakarta Authentication SPI for Containers
+Specification-Vendor: Eclipse Foundation
+Specification-Version: 3.0
+
+Name: jakarta/security/auth/message/callback/
+Implementation-Title: jakarta.security.auth.message
+Implementation-Vendor: Apache Software Foundation
+Implementation-Version: 3.0
+Specification-Title: Jakarta Authentication SPI for Containers
+Specification-Vendor: Eclipse Foundation
+Specification-Version: 3.0
+`
+
+func TestStopOnceFirstKeyIsFound(t *testing.T) {
+	manifestBytes := bytes.NewBuffer([]byte(testManifestMF))
+	manifest, err := parseManifestMFFromReader("", manifestBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", manifest)
+}

--- a/pkg/analyzer/java/parse_manifest_test.go
+++ b/pkg/analyzer/java/parse_manifest_test.go
@@ -2,8 +2,9 @@ package java
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const testTomcat10ManifestMF = `

--- a/pkg/analyzer/java/parse_manifests.go
+++ b/pkg/analyzer/java/parse_manifests.go
@@ -86,7 +86,7 @@ LOOP:
 		// The main section will not contain "Name", and the individual sections must start with "Name".
 		// Therefore, we know we are done with the main section once we see "Name".
 		//
-		// See the JAR specification: https://docs.oracle.com/en/java/javase/20/docs/specs/jar/jar.html#name-value-pairs-and-sections.
+		// See the JAR specification: https://docs.oracle.com/en/java/javase/20/docs/specs/jar/jar.html#jar-manifest
 		case "Name":
 			break LOOP
 		case "Specification-Version":


### PR DESCRIPTION
So we don't stop early if we have matched all the possible key lines in the manifest.mf file. This file can contain many entries and this will cause us to attribute the data to a wrong version