### PR TITLE
e2e: misc test updates

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -543,6 +543,7 @@ var testCases = []testCase{
 		// This image is older than June 2020, so we need to explicitly request for an uncertified scan.
 		uncertifiedRHEL:          true,
 		checkProvidedExecutables: true,
+		onlyCheckSpecifiedVulns:  true,
 		expectedFeatures: []apiV1.Feature{
 			{
 				Name:          "procps-ng",
@@ -3655,7 +3656,7 @@ For more details about the security issue(s), including the impact, a CVSS score
 				NamespaceName: "rhel:8",
 				VersionFormat: "rpm",
 				Version:       "6.0.6-1.el8_6.x86_64",
-				FixedBy:       "6.0.20-1.el8_8",
+				FixedBy:       "6.0.21-1.el8_8",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "RHBA-2022:5747",
@@ -3694,7 +3695,7 @@ Bug Fix(es) and Enhancement(s):
 				NamespaceName: "rhel:8",
 				VersionFormat: "rpm",
 				Version:       "6.0.6-1.el8_6.x86_64",
-				FixedBy:       "6.0.20-1.el8_8",
+				FixedBy:       "6.0.21-1.el8_8",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "RHBA-2022:5747",


### PR DESCRIPTION
anchore-engine:

This image is affected by CVE-2023-4016. The CVE page says "Out of Support" but it's still vulnerable. The id in the OVAL feed is `oval:com.redhat.cve:def:20234016`, which indicates a vulnerability.

Originally, I was going to add that vulnerability to the list, but the description used some special formatting which seemed annoying to mimic, so I decided to just not check for that vulnerability. Adding this vulnerability did not really add much value anyway