### PR TITLE
ROX-19942: support usr/lib/redhat-release and RHEL Atomic Host release

### DIFF
--- a/ext/featurens/osrelease/osrelease.go
+++ b/ext/featurens/osrelease/osrelease.go
@@ -32,11 +32,12 @@ var (
 	blocklistFilenames = []string{
 		"etc/alpine-release",
 		"etc/centos-release",
+		"usr/lib/centos-release",
 		"etc/fedora-release",
 		"etc/oracle-release",
 		"etc/redhat-release",
+		"usr/lib/redhat-release",
 		"etc/rocky-release",
-		"usr/lib/centos-release",
 	}
 
 	// RequiredFilenames defines the names of the files required to identify the release.
@@ -50,7 +51,7 @@ func init() {
 }
 
 func (d detector) Detect(files analyzer.Files, _ *featurens.DetectorOptions) *database.Namespace {
-	var OS, version string
+	var os, version string
 
 	for _, filePath := range blocklistFilenames {
 		if _, hasFile := files.Get(filePath); hasFile {
@@ -64,14 +65,14 @@ func (d detector) Detect(files analyzer.Files, _ *featurens.DetectorOptions) *da
 			continue
 		}
 
-		OS, version = osrelease.GetOSAndVersionFromOSRelease(f.Contents)
+		os, version = osrelease.GetOSAndVersionFromOSRelease(f.Contents)
 	}
 
 	// Determine the VersionFormat.
 	// This intentionally does not support alpine,
 	// as this detector does not handle alpine correctly.
 	var versionFormat string
-	switch OS {
+	switch os {
 	case "debian", "ubuntu":
 		versionFormat = dpkg.ParserName
 	case "centos", "rhel", "amzn", "oracle":
@@ -80,9 +81,9 @@ func (d detector) Detect(files analyzer.Files, _ *featurens.DetectorOptions) *da
 		return nil
 	}
 
-	if OS != "" && version != "" {
+	if os != "" && version != "" {
 		return &database.Namespace{
-			Name:          OS + ":" + version,
+			Name:          os + ":" + version,
 			VersionFormat: versionFormat,
 		}
 	}

--- a/ext/featurens/osrelease/osrelease_test.go
+++ b/ext/featurens/osrelease/osrelease_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/scanner/database"
 	"github.com/stackrox/scanner/ext/featurens"
 	"github.com/stackrox/scanner/ext/versionfmt/dpkg"
+	"github.com/stackrox/scanner/ext/versionfmt/rpm"
 	"github.com/stackrox/scanner/pkg/analyzer"
 	"github.com/stackrox/scanner/pkg/tarutil"
 )
@@ -86,6 +87,30 @@ REDHAT_BUGZILLA_PRODUCT="Fedora"
 REDHAT_BUGZILLA_PRODUCT_VERSION=20
 REDHAT_SUPPORT_PRODUCT="Fedora"
 REDHAT_SUPPORT_PRODUCT_VERSION=20`)},
+			}),
+		},
+		{
+			ExpectedNamespace: &database.Namespace{Name: "rhel:7", VersionFormat: rpm.ParserName},
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
+				"etc/os-release": {Contents: []byte(
+					`NAME="Red Hat Enterprise Linux Atomic Host"
+VERSION="7.9"
+ID="rhel"
+ID_LIKE="fedora"
+VARIANT="Atomic Host"
+VARIANT_ID=atomic.host
+VERSION_ID="7.9"
+PRETTY_NAME="Red Hat Enterprise Linux Atomic Host 7.9"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:7.9:GA:atomic-host"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
+REDHAT_BUGZILLA_PRODUCT_VERSION="7.9"
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="7.9"
+`)},
 			}),
 		},
 		{

--- a/ext/featurens/redhatrelease/redhatrelease.go
+++ b/ext/featurens/redhatrelease/redhatrelease.go
@@ -33,12 +33,20 @@ var (
 	amazonReleaseRegexp = regexp.MustCompile(`(?P<os>Amazon) (Linux release|Linux AMI release) (?P<version>[\d]+\.[\d]+|[\d]+)`)
 	oracleReleaseRegexp = regexp.MustCompile(`(?P<os>Oracle) (Linux Server release) (?P<version>[\d]+)`)
 	centosReleaseRegexp = regexp.MustCompile(`(?P<os>[^\s]*) (Linux release|release) (?P<version>[\d]+)`)
-	redhatReleaseRegexp = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (Client release|Server release|Workstation release|release) (?P<version>[\d]+)`)
+	redhatReleaseRegexp = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (Client release|Atomic Host release|Server release|Workstation release|release) (?P<version>[\d]+)`)
 	rhcosReleaseRegexp  = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (CoreOS release) (?P<version>[\d]+[\.]?[\d]*)`) // RHCOS can differ a lot between minor versions, so we also keep the minor for it
 	rockyReleaseRegexp  = regexp.MustCompile(`(?P<os>Rocky) (Linux release) (?P<version>[\d]+)`)
 
 	// RequiredFilenames defines the names of the files required to identify the RHEL-based release.
-	RequiredFilenames = []string{"etc/oracle-release", "etc/centos-release", "etc/redhat-release", "etc/rocky-release", "etc/system-release"}
+	RequiredFilenames = []string{
+		"etc/centos-release",
+		"usr/lib/centos-release",
+		"etc/oracle-release",
+		"etc/redhat-release",
+		"usr/lib/redhat-release",
+		"etc/rocky-release",
+		"etc/system-release",
+	}
 )
 
 type detector struct{}

--- a/ext/featurens/redhatrelease/redhatrelease_test.go
+++ b/ext/featurens/redhatrelease/redhatrelease_test.go
@@ -106,6 +106,12 @@ func TestDetector(t *testing.T) {
 			}),
 		},
 		{
+			ExpectedNamespace: &database.Namespace{Name: "rhel:7", VersionFormat: rpm.ParserName},
+			Files: tarutil.CreateNewLayerFiles(map[string]analyzer.FileData{
+				"etc/redhat-release": {Contents: []byte(`Red Hat Enterprise Linux Atomic Host release 7.9`)},
+			}),
+		},
+		{
 			ExpectedNamespace: nil,
 			Files:             tarutil.CreateNewLayerFiles(nil),
 		},

--- a/pkg/osrelease/osrelease.go
+++ b/pkg/osrelease/osrelease.go
@@ -2,22 +2,26 @@ package osrelease
 
 import (
 	"bufio"
-	"regexp"
 	"strings"
 
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/scanner/ext/featurens/util"
 )
 
-var (
-	osPattern      = regexp.MustCompile(`^ID=(.*)`)
-	versionPattern = regexp.MustCompile(`^VERSION_ID=(.*)`)
-)
-
 // GetOSAndVersionFromOSRelease returns the value of ID= and VERSION_ID= from /etc/os-release formatted data
 func GetOSAndVersionFromOSRelease(data []byte) (os, version string) {
 	m := GetOSReleaseMap(data, "ID", "VERSION_ID")
-	return util.NormalizeOSName(m["ID"]), m["VERSION_ID"]
+
+	os = util.NormalizeOSName(m["ID"])
+	version = m["VERSION_ID"]
+	switch os {
+	case "centos", "rhel":
+		// Only use the major version.
+		version, _, _ = strings.Cut(version, ".")
+	default:
+	}
+
+	return os, version
 }
 
 // GetOSReleaseMap returns a map where keys and value are extracted from the


### PR DESCRIPTION
It is possible an official Red Hat container image has `etc/redhat-release` as a symlink to `usr/lib/redhat-release` instead of being a regular file. This PR adds `usr/lib/redhat-release` as a file to track.

It also updates the `etc/os-release` support for RHEL/CentOS in case there may be some other case we miss. The update ensures only the major version of the release is returned when reading a RHEL or CentOS namespace from `etc/os-release`.