### PR TITLE
ROX-20122: set gRPC max concurrent streams to 100

### DIFF
--- a/api/grpc/grpc.go
+++ b/api/grpc/grpc.go
@@ -60,7 +60,10 @@ func (a *apiImpl) connectToLocalEndpoint() (*grpc.ClientConn, error) {
 }
 
 func (a *apiImpl) Start() {
-	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(a.config.UnaryInterceptors...))
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(a.config.UnaryInterceptors...),
+		grpc.MaxConcurrentStreams(100),
+	)
 	for _, serv := range a.apiServices {
 		serv.RegisterServiceServer(grpcServer)
 	}

--- a/api/grpc/grpc.go
+++ b/api/grpc/grpc.go
@@ -20,24 +20,19 @@ import (
 )
 
 const (
-	localEndpoint                   = "127.0.0.1:8444"
-	defaultGrpcMaxConcurrentStreams = 100 // HTTP/2 spec recommendation for minimum value
+	localEndpoint = "127.0.0.1:8444"
 )
 
 func init() {
 	grpcprometheus.EnableHandlingTimeHistogram()
 }
 
-var (
-	maxGrpcConcurrentStreamsSetting = env.RegisterIntegerSetting("ROX_GRPC_MAX_CONCURRENT_STREAMS", defaultGrpcMaxConcurrentStreams)
-)
-
 func maxGrpcConcurrentStreams() uint32 {
-	if maxGrpcConcurrentStreamsSetting.Int() < 0 {
-		return defaultGrpcMaxConcurrentStreams
+	if env.MaxGrpcConcurrentStreams.Int() <= 0 {
+		return env.DefaultMaxGrpcConcurrentStreams
 	}
 
-	return uint32(maxGrpcConcurrentStreamsSetting.Int())
+	return uint32(env.MaxGrpcConcurrentStreams.Int())
 }
 
 // NewAPI creates a new gRPC API instantiation

--- a/pkg/env/list.go
+++ b/pkg/env/list.go
@@ -2,6 +2,11 @@ package env
 
 import "time"
 
+const (
+	// DefaultMaxGrpcConcurrentStreams is the minimum value for concurrent streams recommended by the HTTP/2 spec
+	DefaultMaxGrpcConcurrentStreams = 100
+)
+
 var (
 	// LanguageVulns enables language vulnerabilities.
 	LanguageVulns = RegisterBooleanSetting("ROX_LANGUAGE_VULNS", true, AllowWithoutRox())
@@ -38,4 +43,7 @@ var (
 	// ActiveVulnMgmt is the same flag in Central that determines if active vulnerability management should be
 	// enabled and executables should be pulled from the database
 	ActiveVulnMgmt = RegisterBooleanSetting("ROX_ACTIVE_VULN_MGMT", false)
+
+	// MaxGrpcConcurrentStreams configures the maximum number of HTTP/2 streams to use with gRPC
+	MaxGrpcConcurrentStreams = RegisterIntegerSetting("ROX_GRPC_MAX_CONCURRENT_STREAMS", DefaultMaxGrpcConcurrentStreams)
 )


### PR DESCRIPTION
As part of the mitigation for [cve-2023-44487](https://access.redhat.com/security/cve/cve-2023-44487), some projects have decided to reduce MaxConcurrentStreams to 100 (this is the minimum recommended value in the HTTP/2 standard - default is 250).

This PR applies this change to the Scanner gRPC server.
