### PR TITLE
ROX-20122: set gRPC max concurrent streams to 100

### DIFF
--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -1,0 +1,33 @@
+package env
+
+import (
+	"strconv"
+)
+
+// IntegerSetting represents an environment variable which should be parsed into an integer.
+type IntegerSetting interface {
+	Setting
+	Int() int
+}
+
+type integerSetting struct {
+	Setting
+	defaultValue int
+}
+
+// Int returns the int object represented by the environment variable.
+func (s *integerSetting) Int() int {
+	v, err := strconv.Atoi(s.Value())
+	if err != nil {
+		return s.defaultValue
+	}
+	return v
+}
+
+// RegisterIntegerSetting globally registers and returns a new integer setting.
+func RegisterIntegerSetting(envVar string, defaultValue int, opts ...SettingOption) IntegerSetting {
+	return &integerSetting{
+		Setting:      RegisterSetting(envVar, append(opts, WithDefault(strconv.Itoa(defaultValue)))...),
+		defaultValue: defaultValue,
+	}
+}

--- a/pkg/env/list.go
+++ b/pkg/env/list.go
@@ -2,6 +2,11 @@ package env
 
 import "time"
 
+const (
+	// DefaultMaxGrpcConcurrentStreams is the minimum value for concurrent streams recommended by the HTTP/2 spec
+	DefaultMaxGrpcConcurrentStreams = 100
+)
+
 var (
 	// LanguageVulns enables language vulnerabilities.
 	LanguageVulns = RegisterBooleanSetting("ROX_LANGUAGE_VULNS", true, AllowWithoutRox())
@@ -34,4 +39,7 @@ var (
 
 	// NodeScanningMaxBackoff is the upper boundary of backoff. Defaults to 5m in seconds, being 50% of Kubernetes restart policy stability timer.
 	NodeScanningMaxBackoff = registerDurationSetting("ROX_NODE_SCANNING_MAX_BACKOFF", 300*time.Second)
+
+	// MaxGrpcConcurrentStreams configures the maximum number of HTTP/2 streams to use with gRPC
+	MaxGrpcConcurrentStreams = RegisterIntegerSetting("ROX_GRPC_MAX_CONCURRENT_STREAMS", DefaultMaxGrpcConcurrentStreams)
 )


### PR DESCRIPTION
- chore: allow integer env vars (#1289)
- ROX-20122: set gRPC max concurrent streams to 100 (#1287)
