### PR TITLE
ROX-20121: set gRPC max concurrent streams to 100

### DIFF
--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -1,0 +1,33 @@
+package env
+
+import (
+	"strconv"
+)
+
+// IntegerSetting represents an environment variable which should be parsed into an integer.
+type IntegerSetting interface {
+	Setting
+	Int() int
+}
+
+type integerSetting struct {
+	Setting
+	defaultValue int
+}
+
+// Int returns the int object represented by the environment variable.
+func (s *integerSetting) Int() int {
+	v, err := strconv.Atoi(s.Value())
+	if err != nil {
+		return s.defaultValue
+	}
+	return v
+}
+
+// RegisterIntegerSetting globally registers and returns a new integer setting.
+func RegisterIntegerSetting(envVar string, defaultValue int, opts ...SettingOption) IntegerSetting {
+	return &integerSetting{
+		Setting:      RegisterSetting(envVar, append(opts, WithDefault(strconv.Itoa(defaultValue)))...),
+		defaultValue: defaultValue,
+	}
+}

--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -27,7 +27,7 @@ func (s *integerSetting) Int() int {
 // RegisterIntegerSetting globally registers and returns a new integer setting.
 func RegisterIntegerSetting(envVar string, defaultValue int, opts ...SettingOption) IntegerSetting {
 	return &integerSetting{
-		Setting:      RegisterSetting(envVar, append(opts, WithDefault(strconv.Itoa(defaultValue)))...),
+		Setting:      registerSetting(envVar, append(opts, WithDefault(strconv.Itoa(defaultValue)))...),
 		defaultValue: defaultValue,
 	}
 }

--- a/pkg/env/list.go
+++ b/pkg/env/list.go
@@ -1,5 +1,10 @@
 package env
 
+const (
+	// DefaultMaxGrpcConcurrentStreams is the minimum value for concurrent streams recommended by the HTTP/2 spec
+	DefaultMaxGrpcConcurrentStreams = 100
+)
+
 var (
 	// LanguageVulns enables language vulnerabilities.
 	LanguageVulns = RegisterBooleanSetting("ROX_LANGUAGE_VULNS", true, AllowWithoutRox())
@@ -19,4 +24,7 @@ var (
 	// This is ignored if SkipPeerValidation is enabled.
 	// This variable was copied over from the stackrox repo.
 	OpenshiftAPI = RegisterBooleanSetting("ROX_OPENSHIFT_API", false)
+
+	// MaxGrpcConcurrentStreams configures the maximum number of HTTP/2 streams to use with gRPC
+	MaxGrpcConcurrentStreams = RegisterIntegerSetting("ROX_GRPC_MAX_CONCURRENT_STREAMS", DefaultMaxGrpcConcurrentStreams)
 )


### PR DESCRIPTION
- chore: allow integer env vars (#1289)
- ROX-20121: set gRPC max concurrent streams to 100 (#1287)
