### PR TITLE
http(metrics): disallow auto HTTP/2 enablement

### DIFF
--- a/pkg/clairify/metrics/server.go
+++ b/pkg/clairify/metrics/server.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 
@@ -37,6 +38,8 @@ func NewHTTPServer(config *api.Config) *HTTPServer {
 		server: &http.Server{
 			Addr:    addr,
 			Handler: mux,
+			// Setting TLSNextProto to a non-nil empty map disables automatic HTTP/2 support.
+			TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 		},
 	}
 }

--- a/pkg/clairify/server/server.go
+++ b/pkg/clairify/server/server.go
@@ -306,6 +306,7 @@ func (s *Server) Start() error {
 	if err != nil {
 		return err
 	}
+	// This explicitly disables automatic HTTP/2 support.
 	tlsConfig.NextProtos = nil
 
 	listener, err = tls.Listen("tcp", s.endpoint, tlsConfig)


### PR DESCRIPTION
disallow HTTP/2 for the metrics server, as it's not required.