### PR TITLE
go: bump go to 1.20.10

### DIFF
--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -10,4 +10,4 @@
 # - `make update` and commit the results
 # - run `/test pj-rehearse-max` on the openshift/release PR to validate the change
 
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.59
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61

--- a/.openshift-ci/build/Dockerfile.build-bundle
+++ b/.openshift-ci/build/Dockerfile.build-bundle
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.59
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/.openshift-ci/build/Dockerfile.build-db-bundle
+++ b/.openshift-ci/build/Dockerfile.build-db-bundle
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.59
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/.openshift-ci/build/Dockerfile.generate-db-dump
+++ b/.openshift-ci/build/Dockerfile.generate-db-dump
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.59
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/.openshift-ci/build/Dockerfile.generate-genesis-dump
+++ b/.openshift-ci/build/Dockerfile.generate-genesis-dump
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.59
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-scanner-build-0.3.59
+scanner-build-0.3.61


### PR DESCRIPTION
See https://github.com/stackrox/scanner/pull/1181 for how Go version bump was previously done

See https://github.com/stackrox/rox-ci-image/releases/tag/0.3.61 for what's new in this CI image