### PR TITLE
chore: account for OpenShift 4.14

### DIFF
--- a/pkg/cpeutils/utils.go
+++ b/pkg/cpeutils/utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Note: this must be updated with each new OpenShift release.
-const maxKnownOpenShift4MinorVersion = 13
+const maxKnownOpenShift4MinorVersion = 14
 
 // *** START Regex-related consts/vars. ***
 

--- a/pkg/cpeutils/utils_test.go
+++ b/pkg/cpeutils/utils_test.go
@@ -83,6 +83,7 @@ func TestGetAllOpenShift4CPEs(t *testing.T) {
 				"cpe:/a:redhat:openshift:4.11",
 				"cpe:/a:redhat:openshift:4.12",
 				"cpe:/a:redhat:openshift:4.13",
+				"cpe:/a:redhat:openshift:4.14",
 			},
 		},
 		{
@@ -102,6 +103,7 @@ func TestGetAllOpenShift4CPEs(t *testing.T) {
 				"cpe:/a:redhat:openshift:4.11::el8",
 				"cpe:/a:redhat:openshift:4.12::el8",
 				"cpe:/a:redhat:openshift:4.13::el8",
+				"cpe:/a:redhat:openshift:4.14::el8",
 			},
 		},
 		{
@@ -121,6 +123,7 @@ func TestGetAllOpenShift4CPEs(t *testing.T) {
 				"cpe:/a:redhat:openshift:4.11::el9",
 				"cpe:/a:redhat:openshift:4.12::el9",
 				"cpe:/a:redhat:openshift:4.13::el9",
+				"cpe:/a:redhat:openshift:4.14::el9",
 			},
 		},
 		{


### PR DESCRIPTION
OpenShift 4.14 went GA, so we need to make sure we can find all vulns for it. This codepath is not used at this time, but it's possible it would be needed were the OpenShift CPE changed. It is here for that safety.