### PR TITLE
chore: fix shellcheck 1091 for all scripts

### DIFF
--- a/.openshift-ci/build/build-bundle.sh
+++ b/.openshift-ci/build/build-bundle.sh
@@ -5,7 +5,9 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/.openshift-ci/build/build-main-and-bundle.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/ci/gcp.sh
 source "$ROOT/scripts/ci/gcp.sh"
+# shellcheck source=../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/.openshift-ci/build/build-db-bundle.sh
+++ b/.openshift-ci/build/build-db-bundle.sh
@@ -5,7 +5,9 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/.openshift-ci/build/build-central-db-bundle.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/ci/gcp.sh
 source "$ROOT/scripts/ci/gcp.sh"
+# shellcheck source=../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/.openshift-ci/build/generate-db-dump.sh
+++ b/.openshift-ci/build/generate-db-dump.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/.openshift-ci/build/generate-genesis-dump.sh
+++ b/.openshift-ci/build/generate-genesis-dump.sh
@@ -3,6 +3,7 @@
 # Execute all steps required to generate the genesis dump
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -7,6 +7,7 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/.openshift-ci/dispatch.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+# shellcheck source=../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/.openshift-ci/nightlies.sh
+++ b/.openshift-ci/nightlies.sh
@@ -8,6 +8,7 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/nightlies/.openshift-ci/nightlies.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+# shellcheck source=../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1091
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/lib.sh
 source "$ROOT/scripts/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/gcp.sh
+++ b/scripts/ci/gcp.sh
@@ -5,6 +5,7 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/scripts/ci/gcp.sh
 
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/ci/lib.sh
 source "$SCRIPTS_ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -4,7 +4,9 @@
 # Copied from https://github.com/stackrox/stackrox/blob/master/scripts/ci/gke.sh
 
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/ci/lib.sh
 source "$SCRIPTS_ROOT/scripts/ci/lib.sh"
+# shellcheck source=../../scripts/ci/gcp.sh
 source "$SCRIPTS_ROOT/scripts/ci/gcp.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/db-integration-tests.sh
+++ b/scripts/ci/jobs/db-integration-tests.sh
@@ -3,7 +3,9 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/scripts/ci/jobs/go-postgres-tests.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
+# shellcheck source=../../../scripts/ci/postgres.sh
 source "$ROOT/scripts/ci/postgres.sh"
 set -euo pipefail
 

--- a/scripts/ci/jobs/diff-dumps.sh
+++ b/scripts/ci/jobs/diff-dumps.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/gcp.sh
 source "$ROOT/scripts/ci/gcp.sh"
+# shellcheck source=../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/e2etests/e2e-tests.sh
+++ b/scripts/ci/jobs/e2etests/e2e-tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../../.. && pwd)"
+# shellcheck source=../../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/e2etests/scale-tests.sh
+++ b/scripts/ci/jobs/e2etests/scale-tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../../.. && pwd)"
+# shellcheck source=../../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/e2etests/slim-e2e-tests.sh
+++ b/scripts/ci/jobs/e2etests/slim-e2e-tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../../.. && pwd)"
+# shellcheck source=../../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -3,6 +3,7 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/scripts/ci/jobs/push-images.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/sanity-check-vuln-updates.sh
+++ b/scripts/ci/jobs/sanity-check-vuln-updates.sh
@@ -13,7 +13,9 @@
 #   gsutil stat "gs://definitions.stackrox.io/*/diff.zip"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/gcp.sh
 source "$ROOT/scripts/ci/gcp.sh"
+# shellcheck source=../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/store-db-dump.sh
+++ b/scripts/ci/jobs/store-db-dump.sh
@@ -3,6 +3,7 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/scripts/ci/jobs/go-postgres-tests.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 set -euo pipefail
 

--- a/scripts/ci/jobs/store-genesis-dump.sh
+++ b/scripts/ci/jobs/store-genesis-dump.sh
@@ -3,6 +3,7 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/scripts/ci/jobs/go-postgres-tests.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 set -euo pipefail
 

--- a/scripts/ci/jobs/style-checks.sh
+++ b/scripts/ci/jobs/style-checks.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/unit-tests.sh
+++ b/scripts/ci/jobs/unit-tests.sh
@@ -3,6 +3,7 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/scripts/ci/jobs/go-unit-tests.sh
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/upload-db-dump.sh
+++ b/scripts/ci/jobs/upload-db-dump.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/gcp.sh
 source "$ROOT/scripts/ci/gcp.sh"
+# shellcheck source=../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/upload-dumps-for-downstream.sh
+++ b/scripts/ci/jobs/upload-dumps-for-downstream.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/gcp.sh
 source "$ROOT/scripts/ci/gcp.sh"
+# shellcheck source=../../../scripts/ci/lib.sh
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/jobs/upload-dumps-for-embedding.sh
+++ b/scripts/ci/jobs/upload-dumps-for-embedding.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
+# shellcheck source=../../../scripts/ci/gcp.sh
 source "$ROOT/scripts/ci/gcp.sh"
+# shellcheck source=../../../scripts/lib.sh
 source "$ROOT/scripts/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -4,6 +4,7 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/scripts/ci/lib.sh
 
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/lib.sh
 source "$SCRIPTS_ROOT/scripts/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/logcheck/check-logs.sh
+++ b/scripts/ci/logcheck/check-logs.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1091
 
 set -euo pipefail
 
@@ -7,6 +6,7 @@ set -euo pipefail
 # Adapted from https://github.com/stackrox/stackrox/blob/master/tests/e2e/lib.sh
 
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../lib.sh
 source "$SCRIPTS_ROOT/lib.sh"
 
 check_stackrox_logs() {

--- a/scripts/ci/postgres.sh
+++ b/scripts/ci/postgres.sh
@@ -3,6 +3,7 @@
 # Adapted from https://github.com/stackrox/stackrox/blob/master/scripts/ci/jobs/go-postgres-tests.sh
 
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/lib.sh
 source "$SCRIPTS_ROOT/scripts/lib.sh"
 
 set -euo pipefail

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -4,6 +4,7 @@
 # Copied from https://github.com/stackrox/stackrox/blob/master/scripts/ci/store-artifacts.sh
 
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/ci/gcp.sh
 source "$SCRIPTS_ROOT/scripts/ci/gcp.sh"
 
 set -euo pipefail


### PR DESCRIPTION
# Description
These changes fix [shellcheck 1091](https://www.shellcheck.net/wiki/SC1091) for all scripts. An important side effect is you can use the Bash LSP to go to functions in scripts.

# Testing Performed
You can check all `.sh` files that violate SC1091 using the following command:
```sh
find . -type f -name "*.sh" -execdir shellcheck -i SC1091 -P SCRIPTDIR -x {} \;
```

No violations appear after these changes.