### PR TITLE
ROX-21387: batch insert vulns

### DIFF
--- a/pkg/vulndump/batch_loader.go
+++ b/pkg/vulndump/batch_loader.go
@@ -1,0 +1,85 @@
+package vulndump
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/stackrox/scanner/database"
+)
+
+const defaultBatchSize = 10_000
+
+// osLoader batch loads OS-level vulnerabilities into a buffer.
+type osLoader struct {
+	rc io.ReadCloser
+
+	dec *json.Decoder
+
+	batchSize int
+	buf       []database.Vulnerability
+	done      bool
+	err       error
+}
+
+func newOSLoader(source io.ReadCloser) (*osLoader, error) {
+	// See https://pkg.go.dev/encoding/json#example-Decoder.Decode-Stream
+	// for an example of how this decoder will be used.
+	dec := json.NewDecoder(source)
+	// Read the initial token, "[".
+	_, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	return &osLoader{
+		rc:        source,
+		dec:       dec,
+		batchSize: defaultBatchSize,
+		buf:       make([]database.Vulnerability, 0, defaultBatchSize),
+	}, nil
+}
+
+// Next loads the next batch of vulnerabilities and returns
+// whether it was successful or not.
+func (l *osLoader) Next() bool {
+	if l.done || l.err != nil {
+		return false
+	}
+
+	l.buf = l.buf[:0]
+	for i := 0; i < l.batchSize; i++ {
+		if !l.dec.More() {
+			// JSON array has no more values.
+			l.done = true
+			return true
+		}
+		l.buf = append(l.buf, database.Vulnerability{})
+		if err := l.dec.Decode(&l.buf[i]); err != nil {
+			l.err = err
+			return false
+		}
+	}
+
+	return true
+}
+
+// Vulns returns the "next" bath of vulnerabilities.
+// It is expected to be called once for each successful call to Next.
+func (l *osLoader) Vulns() []database.Vulnerability {
+	return l.buf
+}
+
+// Err returns the error associated with loading vulnerabilities.
+// It is expected to be non-nil upon an unsuccessful call to Next.
+func (l *osLoader) Err() error {
+	return l.err
+}
+
+// Close closes the loader.
+func (l *osLoader) Close() error {
+	l.buf = nil // hint to GC to clean this.
+	// Don't bother reading the final token, "]",
+	// as it is possible there was a failure reading
+	// the JSON array. Just close the file.
+	return l.rc.Close()
+}

--- a/pkg/vulndump/batch_loader_test.go
+++ b/pkg/vulndump/batch_loader_test.go
@@ -1,0 +1,111 @@
+package vulndump
+
+import (
+	"archive/zip"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/scanner/pkg/ziputil"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	defURL     = "https://definitions.stackrox.io/93AEC554-29EE-4E24-96D6-744092A98444/diff.zip"
+	offlineURL = "https://install.stackrox.io/scanner/scanner-vuln-updates.zip"
+)
+
+func mustFetchOSVulns(b *testing.B) *os.File {
+	f, err := os.Create(filepath.Join(b.TempDir(), "vulns.zip"))
+	require.NoError(b, err)
+
+	c := &http.Client{Timeout: 30 * time.Second}
+	resp, err := c.Get(defURL)
+	require.NoError(b, err)
+	defer utils.IgnoreError(resp.Body.Close)
+
+	_, err = io.Copy(f, resp.Body)
+	require.NoError(b, err)
+
+	return f
+}
+
+func mustFetchOfflineOSVulns(b *testing.B) *os.File {
+	tmpPath := filepath.Join(b.TempDir(), "tmp.zip")
+	tmpF, err := os.Create(tmpPath)
+	require.NoError(b, err)
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+	defer utils.IgnoreError(tmpF.Close)
+
+	c := &http.Client{Timeout: 30 * time.Second}
+	resp, err := c.Get(offlineURL)
+	require.NoError(b, err)
+	defer utils.IgnoreError(resp.Body.Close)
+
+	_, err = io.Copy(tmpF, resp.Body)
+	require.NoError(b, err)
+
+	tmpZIP, err := zip.OpenReader(tmpPath)
+	require.NoError(b, err)
+	defer utils.IgnoreError(tmpZIP.Close)
+	rc, err := ziputil.OpenFile(&tmpZIP.Reader, "scanner-defs.zip")
+	require.NoError(b, err)
+	defer utils.IgnoreError(rc.Close)
+
+	f, err := os.Create(filepath.Join(b.TempDir(), "vulns.zip"))
+	require.NoError(b, err)
+
+	_, err = io.Copy(f, rc)
+	require.NoError(b, err)
+
+	return f
+}
+
+func BenchmarkOSLoader(b *testing.B) {
+	f := mustFetchOSVulns(b)
+	defer utils.IgnoreError(f.Close)
+
+	benchmarkOSLoader(b, f)
+}
+
+func BenchmarkOSLoader_Offline(b *testing.B) {
+	f := mustFetchOfflineOSVulns(b)
+	defer utils.IgnoreError(f.Close)
+
+	benchmarkOSLoader(b, f)
+}
+
+func benchmarkOSLoader(b *testing.B, f *os.File) {
+	zipR, err := zip.OpenReader(f.Name())
+	require.NoError(b, err)
+	defer utils.IgnoreError(zipR.Close)
+	vulnsF, err := ziputil.OpenFile(&zipR.Reader, OSVulnsFileName)
+	require.NoError(b, err)
+	defer utils.IgnoreError(vulnsF.Close)
+
+	runtime.GC()
+
+	loader, err := newOSLoader(vulnsF)
+	require.NoError(b, err)
+	defer func() {
+		require.NoError(b, loader.Close())
+	}()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var n int
+		for loader.Next() {
+			vulns := loader.Vulns()
+			n += len(vulns)
+		}
+		require.NoError(b, loader.Err())
+		b.Logf("Loaded %d vulns", n)
+	}
+}

--- a/pkg/vulndump/loader_test.go
+++ b/pkg/vulndump/loader_test.go
@@ -1,0 +1,40 @@
+package vulndump
+
+import (
+	"archive/zip"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkLoadOSVulnsFromDump(b *testing.B) {
+	f := mustFetchOSVulns(b)
+	defer utils.IgnoreError(f.Close)
+
+	benchmarkLoadOSVulnsFromDump(b, f)
+}
+
+func BenchmarkLoadOSVulnsFromDump_Offline(b *testing.B) {
+	f := mustFetchOfflineOSVulns(b)
+	defer utils.IgnoreError(f.Close)
+
+	benchmarkLoadOSVulnsFromDump(b, f)
+}
+
+func benchmarkLoadOSVulnsFromDump(b *testing.B, f *os.File) {
+	zipR, err := zip.OpenReader(f.Name())
+	require.NoError(b, err)
+	defer utils.IgnoreError(zipR.Close)
+
+	runtime.GC()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vulns, err := LoadOSVulnsFromDump(&zipR.Reader)
+		require.NoError(b, err)
+		b.Logf("Loaded %d vulns", len(vulns))
+	}
+}


### PR DESCRIPTION
```
$ go test -run=^$ -bench=^BenchmarkLoadOSVulnsFromDump$ -benchmem ./pkg/vulndump/
goos: darwin
goarch: amd64
pkg: github.com/stackrox/scanner/pkg/vulndump
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
BenchmarkLoadOSVulnsFromDump-8   	       1	4358242218 ns/op	1314951824 B/o 8285803 allocs/op
--- BENCH: BenchmarkLoadOSVulnsFromDump-8
    loader_test.go:26: Loaded 134043 vulns
PASS
ok  	github.com/stackrox/scanner/pkg/vulndump	5.990s



$ go test -run=^$ -bench=^BenchmarkOSLoader$ -benchmem ./pkg/vulndump/
goos: darwin
goarch: amd64
pkg: github.com/stackrox/scanner/pkg/vulndump
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
BenchmarkOSLoader-8   	       1	4075758627 ns/op	702698568 B/op	 8285718 allocs/op
--- BENCH: BenchmarkOSLoader-8
    batch_loader_test.go:57: Loaded 134043 vulns
PASS
ok  	github.com/stackrox/scanner/pkg/vulndump	5.450s
```

The batched implementation uses a little over half of the memory/op than the original implementation.

I also ran an experiment where I ran the current implementation and the implementation from this PR. In each separate cluster, I ran StackRox in offline-mode, and I uploaded the latest "offline" vuln dump to Central. From there I found the current implementation stayed at around 3.5G for about 20 minutes, while this PR's implementation hovered around 700MB for a few minutes before going back down to about 500MB, which is its steady-state. This is a rather significant memory reduction.