### PR TITLE
ROX-21319: Increase DB connection retries

### DIFF
--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -114,7 +114,7 @@ func Boot(config *Config, slimMode bool) {
 	go func() {
 		defer wg.Add(-1)
 		var err error
-		db, err = database.OpenWithRetries(config.Database, true, 18, 10*time.Second)
+		db, err = database.OpenWithRetries(config.Database, true, 60, 15*time.Second)
 		if err != nil {
 			log.WithError(err).Fatal("Failed to open database despite multiple retries...")
 		}

--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -114,7 +114,7 @@ func Boot(config *Config, slimMode bool) {
 	go func() {
 		defer wg.Add(-1)
 		var err error
-		db, err = database.OpenWithRetries(config.Database, true, 60, 15*time.Second)
+		db, err = database.OpenWithRetries(config.Database, true, 30, 10*time.Second)
 		if err != nil {
 			log.WithError(err).Fatal("Failed to open database despite multiple retries...")
 		}


### PR DESCRIPTION
Increase the number of DB connection retries before exiting to be a total of 5 minutes (up from 3 minutes).

--

CI jobs will report failure if a scanner pod restarts, and scanner will exit/restart after 3 minutes currently 

`18 retries * 10 seconds = 180 seconds = 3 minutes`

A [previous CI failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-version-compatibility-tests/1732544504176578560) showed the database available 1 minutes after scanner had exited.

Increasing retries should reduce the frequency of CI failures due to pod restarts.

`30 retries * 10 seconds = 300 seconds = 5 minutes`
