### PR TITLE
fix test on package jackson-databind 2.9.10.4

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -1991,7 +1991,7 @@ var testCases = []testCase{
 				},
 				AddedBy:  "sha256:36e8e9714b9a509fae9e515ff16237928c3d809f5ae228b14d2f7d7605c02623",
 				Location: "jars/jackson-databind-2.9.10.4.jar",
-				FixedBy:  "2.12.7.1",
+				FixedBy:  "2.16.0",
 			},
 		},
 		unexpectedFeatures: []apiV1.Feature{


### PR DESCRIPTION
Fix the test in scanning package:
"Name": "jackson-databind",
"VersionFormat": "JavaSourceType",
"Version": "2.9.10.4"