### PR TITLE
chore(scanner-db): update GPG key link

### DIFF
--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=extracted_bundle /bundle/etc/postgresql.conf /bundle/etc/pg_hba.conf
 
 ARG POSTGRESQL_ARCH=x86_64
 
-RUN curl -sSLf https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-${PG_MAJOR} -o /tmp/pg_repo.key && \
+RUN curl -sSLf https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL -o /tmp/pg_repo.key && \
     rpm --import /tmp/pg_repo.key && \
     curl -sSLf https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${POSTGRESQL_ARCH}/pgdg-redhat-repo-latest.noarch.rpm -o /tmp/pg_repo.rpm && \
     rpm -i /tmp/pg_repo.rpm && \

--- a/image/db/rhel/Dockerfile.slim
+++ b/image/db/rhel/Dockerfile.slim
@@ -25,7 +25,7 @@ COPY --from=extracted_bundle /bundle/etc/postgresql.conf /bundle/etc/pg_hba.conf
 
 ARG POSTGRESQL_ARCH=x86_64
 
-RUN curl -sSLf https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-${PG_MAJOR} -o /tmp/pg_repo.key && \
+RUN curl -sSLf https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL -o /tmp/pg_repo.key && \
     rpm --import /tmp/pg_repo.key && \
     curl -sSLf https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${POSTGRESQL_ARCH}/pgdg-redhat-repo-latest.noarch.rpm -o /tmp/pg_repo.rpm && \
     rpm -i /tmp/pg_repo.rpm && \


### PR DESCRIPTION
Scanner DB stopped building. Not sure when it started, but I noticed it today. The issue is Postgres moved the location of the GPG key. This PR updates the URL used to download the GPG key