### PR TITLE
Include latest v4 vulnerability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -512,3 +512,13 @@ jobs:
 
       - name: upload-dumps-for-downstream
         run: ./scripts/ci/jobs/upload-dumps-for-embedding.sh
+
+  send-notification:
+    needs:
+      - diff-dumps
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - name: Send Slack notification on workflow failure
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"<${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Workflow ${{ github.workflow }}> failed in repository ${{ github.repository }}: Failed to update offline vulnerabilities"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}

--- a/scripts/ci/jobs/diff-dumps.sh
+++ b/scripts/ci/jobs/diff-dumps.sh
@@ -92,7 +92,43 @@ upload_offline_dump() {
     if is_in_PR_context; then
         cmd+=(echo "Would do")
     fi
+    curl --silent --show-error --max-time 60 --retry 3 --create-dirs -o out/RELEASE_VERSION.txt https://raw.githubusercontent.com/stackrox/stackrox/master/scanner/updater/version/RELEASE_VERSION
+    version_file="out/RELEASE_VERSION.txt"
+    # Use grep to extract X.Y versions, sort them, and get the last one as the latest
+    latest_version=$(grep -oE '^[0-9]+\.[0-9]+' "$version_file" | sort -V | tail -n 1)
+
+    file_to_check="scanner-v4-defs-${latest_version}.zip"
+    
+    curl --silent --show-error --max-time 60 --retry 3 -o $file_to_check https://storage.googleapis.com/scanner-v4-test/offline-bundles/$file_to_check
+
+    if [ -f "$file_to_check" ]; then
+        # If the file exists, add it to scanner-vuln-updates.zip
+        zip scanner-vuln-updates.zip "$file_to_check"
+        echo "$file_to_check added to scanner-vuln-updates.zip"
+    else
+        echo "$file_to_check does not exist."
+    fi
     "${cmd[@]}" gsutil cp scanner-vuln-updates.zip gs://scanner-support-public/offline/v1/scanner-vuln-updates.zip
+}
+
+upload_v4_versioned_vuln() {
+    info "Uploading offline dump"
+    cmd=()
+    if is_in_PR_context; then
+        cmd+=(echo "Would do")
+    fi
+    cd /tmp/offline-dump
+    version_file="out/RELEASE_VERSION.txt"
+    versions=$(grep -oE '^[0-9]+\.[0-9]+' "$version_file" | sort -V)
+    while IFS= read -r version; do
+        echo "$version"
+        if curl --silent --show-error --max-time 60 --retry 3 -o "scanner-v4-defs-${version}.zip" "https://storage.googleapis.com/scanner-v4-test/offline-bundles/scanner-v4-defs-${version}.zip"; then
+            zip scanner-vulns-${version}.zip scanner-defs.zip k8s-istio.zip scanner-v4-defs-${version}.zip
+            "${cmd[@]}" gsutil cp scanner-vulns-${version}.zip gs://scanner-support-public/offline/v1/${version}/scanner-vulns-${version}.zip
+        else
+            echo "Failed to download scanner-v4-defs-${version}.zip, skipping..."
+        fi
+    done <<< "$versions"
 }
 
 diff_dumps() {
@@ -114,6 +150,8 @@ diff_dumps() {
     # Upload offline dump
     setup_gcp "${SCANNER_GCP_SERVICE_ACCOUNT_CREDS}"
     upload_offline_dump
+
+    upload_v4_versioned_vuln
 }
 
 diff_dumps "$*"

--- a/scripts/ci/jobs/diff-dumps.sh
+++ b/scripts/ci/jobs/diff-dumps.sh
@@ -112,14 +112,14 @@ upload_offline_dump() {
 }
 
 upload_v4_versioned_vuln() {
-    info "Uploading offline dump"
+    info "Uploading v4 offline dump"
     cmd=()
     if is_in_PR_context; then
         cmd+=(echo "Would do")
     fi
     cd /tmp/offline-dump
     version_file="out/RELEASE_VERSION.txt"
-    versions=$(grep -oE '^[0-9]+\.[0-9]+' "$version_file" | sort -V)
+    versions=$(grep -oE '^[0-9]+\.[0-9]+' "$version_file" | sort -V | uniq)
     while IFS= read -r version; do
         echo "$version"
         if curl --silent --show-error --max-time 60 --retry 3 -o "scanner-v4-defs-${version}.zip" "https://storage.googleapis.com/scanner-v4-test/offline-bundles/scanner-v4-defs-${version}.zip"; then

--- a/scripts/ci/jobs/diff-dumps.sh
+++ b/scripts/ci/jobs/diff-dumps.sh
@@ -107,6 +107,7 @@ upload_offline_dump() {
         echo "$file_to_check added to scanner-vuln-updates.zip"
     else
         echo "$file_to_check does not exist."
+        exit 1
     fi
     "${cmd[@]}" gsutil cp scanner-vuln-updates.zip gs://scanner-support-public/offline/v1/scanner-vuln-updates.zip
 }


### PR DESCRIPTION
Generate scanner-vuln-update including v4 vulnerability of latest version
 Currently I can only verify scanner v2 work with new **_scanner-vuln-updates.zip_**, more V4 related tests will be done in ROX-21981
## Test
1. Make sure the zip is containing scanner v4 stuff:
```
ls -lh scanner-vuln-updates.zip 
-rw-r--r-- 1 yili staff 272M Feb 14 15:04 scanner-vuln-updates.zip
```
```
unzip -l scanner-vuln-updates.zip
Archive:  scanner-vuln-updates.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
140154404  02-14-2024 11:41   scanner-defs.zip
   248088  02-14-2024 11:41   k8s-istio.zip
144211510  02-14-2024 11:41   scanner-v4-defs-4.3.zip
---------                     -------
284614002                     3 files
```

2. Upload to Central:
```
yli3-mac:stackrox yili$ curl --insecure -u admin:[PWD] -F "file=@scanner-vuln-updates.zip" https://localhost:8000/api/extensions/scannerdefinitions -v
*   Trying [::1]:8000...
* connect to ::1 port 8000 failed: Connection refused
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Request CERT (13):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Certificate (11):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: OU=CENTRAL_SERVICE; CN=CENTRAL_SERVICE: Central; serialNumber=16561514245731368659
*  start date: Feb 14 20:08:00 2024 GMT
*  expire date: Feb 13 21:08:00 2025 GMT
*  issuer: CN=StackRox Certificate Authority; serialNumber=1018846594209314016
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
* using HTTP/2
* Server auth using Basic with user 'admin'
* [HTTP/2] [1] OPENED stream for https://localhost:8000/api/extensions/scannerdefinitions
* [HTTP/2] [1] [:method: POST]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: localhost:8000]
* [HTTP/2] [1] [:path: /api/extensions/scannerdefinitions]
* [HTTP/2] [1] [authorization: Basic YWRtaW46SzNEWGJmZ3NlNVR0UzQ3c01ibG5PZTBqVQ==]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [content-length: 284614740]
* [HTTP/2] [1] [content-type: multipart/form-data; boundary=------------------------GlBMII0WAr7HTBb57GfFwh]
> POST /api/extensions/scannerdefinitions HTTP/2
> Host: localhost:8000
> Authorization: Basic YWRtaW46SzNEWGJmZ3NlNVR0UzQ3c01ibG5PZTBqVQ==
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Length: 284614740
> Content-Type: multipart/form-data; boundary=------------------------GlBMII0WAr7HTBb57GfFwh
> 
* We are completely uploaded and fine
< HTTP/2 200 
< vary: Accept-Encoding
< content-type: text/plain; charset=utf-8
< content-length: 57
< date: Wed, 14 Feb 2024 21:19:38 GMT
< 
* Connection #0 to host localhost left intact
Successfully stored the offline vulnerability definitions
```