### PR TITLE
chore: Override `cpu` `requests` for bad days in Konflux

### DIFF
--- a/.tekton/scanner-db-pull-request.yaml
+++ b/.tekton/scanner-db-pull-request.yaml
@@ -63,14 +63,6 @@ spec:
         secretName: '{{ git_auth_secret }}'
 
   taskRunSpecs:
-    - pipelineTaskName: build-container
-      stepSpecs:
-        # Provision more CPU to speed up build compared to the defaults.
-        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
-        - name: build
-          computeResources:
-            requests:
-              cpu: 1
     - pipelineTaskName: clamav-scan
       stepSpecs:
         # Provision more CPU to speed up ClamAV scan compared to the defaults.

--- a/.tekton/scanner-db-pull-request.yaml
+++ b/.tekton/scanner-db-pull-request.yaml
@@ -64,30 +64,44 @@ spec:
 
   taskRunSpecs:
     - pipelineTaskName: build-container
-      stepSpecs: # v1 style
-        - name: build
-          computeResources:
-            requests:
-              cpu: 1
-      stepOverrides: # v1beta1 style
-        - name: build
-          resources:
-            requests:
-              cpu: 1
+      computeResources:
+        limits:
+          cpu: 3
+          memory: 4Gi
+        requests:
+          cpu: 3
+          memory: 4Gi
+#      stepSpecs: # v1 style
+#        - name: build
+#          computeResources:
+#            requests:
+#              cpu: 1
+#      stepOverrides: # v1beta1 style
+#        - name: build
+#          resources:
+#            requests:
+#              cpu: 1
     # This overrides clamav scan requested resources to make the task run faster.
     - pipelineTaskName: clamav-scan
-      stepSpecs: # v1 style
-        - name: extract-and-scan-image
-          computeResources:
-            requests:
-              cpu: 1
-              memory: 3Gi
-      stepOverrides: # v1beta1 style
-        - name: extract-and-scan-image
-          resources:
-            requests:
-              cpu: 1
-              memory: 3Gi
+      computeResources:
+        limits:
+          cpu: 1
+          memory: 4Gi
+        requests:
+          cpu: 1
+          memory: 4Gi
+#      stepSpecs: # v1 style
+#        - name: extract-and-scan-image
+#          computeResources:
+#            requests:
+#              cpu: 1
+#              memory: 3Gi
+#      stepOverrides: # v1beta1 style
+#        - name: extract-and-scan-image
+#          resources:
+#            requests:
+#              cpu: 1
+#              memory: 3Gi
 
   pipelineSpec:
 

--- a/.tekton/scanner-db-pull-request.yaml
+++ b/.tekton/scanner-db-pull-request.yaml
@@ -64,18 +64,18 @@ spec:
 
   taskRunSpecs:
     - pipelineTaskName: build-container
-      computeResources:
-        limits:
-          cpu: 3
-          memory: 4Gi
-        requests:
-          cpu: 3
-          memory: 4Gi
-#      stepSpecs: # v1 style
-#        - name: build
-#          computeResources:
-#            requests:
-#              cpu: 1
+#      computeResources:
+#        limits:
+#          cpu: 3
+#          memory: 4Gi
+#        requests:
+#          cpu: 3
+#          memory: 4Gi
+      stepSpecs: # v1 style
+        - name: build
+          computeResources:
+            requests:
+              cpu: 1
 #      stepOverrides: # v1beta1 style
 #        - name: build
 #          resources:
@@ -83,19 +83,19 @@ spec:
 #              cpu: 1
     # This overrides clamav scan requested resources to make the task run faster.
     - pipelineTaskName: clamav-scan
-      computeResources:
-        limits:
-          cpu: 2
-          memory: 4Gi
+#      computeResources:
+#        limits:
+#          cpu: 2
+#          memory: 4Gi
 #        requests:
 #          cpu: 1
 #          memory: 4Gi
-#      stepSpecs: # v1 style
-#        - name: extract-and-scan-image
-#          computeResources:
-#            requests:
-#              cpu: 1
-#              memory: 3Gi
+      stepSpecs: # v1 style
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              cpu: 1
+              memory: 3Gi
 #      stepOverrides: # v1beta1 style
 #        - name: extract-and-scan-image
 #          resources:

--- a/.tekton/scanner-db-pull-request.yaml
+++ b/.tekton/scanner-db-pull-request.yaml
@@ -64,44 +64,21 @@ spec:
 
   taskRunSpecs:
     - pipelineTaskName: build-container
-#      computeResources:
-#        limits:
-#          cpu: 3
-#          memory: 4Gi
-#        requests:
-#          cpu: 3
-#          memory: 4Gi
-      stepSpecs: # v1 style
+      stepSpecs:
+        # Provision more CPU to speed up build compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
         - name: build
           computeResources:
             requests:
               cpu: 1
-#      stepOverrides: # v1beta1 style
-#        - name: build
-#          resources:
-#            requests:
-#              cpu: 1
-    # This overrides clamav scan requested resources to make the task run faster.
     - pipelineTaskName: clamav-scan
-#      computeResources:
-#        limits:
-#          cpu: 2
-#          memory: 4Gi
-#        requests:
-#          cpu: 1
-#          memory: 4Gi
-      stepSpecs: # v1 style
+      stepSpecs:
+        # Provision more CPU to speed up ClamAV scan compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
         - name: extract-and-scan-image
           computeResources:
             requests:
               cpu: 1
-              memory: 3Gi
-#      stepOverrides: # v1beta1 style
-#        - name: extract-and-scan-image
-#          resources:
-#            requests:
-#              cpu: 1
-#              memory: 3Gi
 
   pipelineSpec:
 

--- a/.tekton/scanner-db-pull-request.yaml
+++ b/.tekton/scanner-db-pull-request.yaml
@@ -62,6 +62,33 @@ spec:
       secret:
         secretName: '{{ git_auth_secret }}'
 
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs: # v1 style
+        - name: build
+          computeResources:
+            requests:
+              cpu: 1
+      stepOverrides: # v1beta1 style
+        - name: build
+          resources:
+            requests:
+              cpu: 1
+    # This overrides clamav scan requested resources to make the task run faster.
+    - pipelineTaskName: clamav-scan
+      stepSpecs: # v1 style
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              cpu: 1
+              memory: 3Gi
+      stepOverrides: # v1beta1 style
+        - name: extract-and-scan-image
+          resources:
+            requests:
+              cpu: 1
+              memory: 3Gi
+
   pipelineSpec:
 
     finally:

--- a/.tekton/scanner-db-pull-request.yaml
+++ b/.tekton/scanner-db-pull-request.yaml
@@ -85,11 +85,11 @@ spec:
     - pipelineTaskName: clamav-scan
       computeResources:
         limits:
-          cpu: 1
+          cpu: 2
           memory: 4Gi
-        requests:
-          cpu: 1
-          memory: 4Gi
+#        requests:
+#          cpu: 1
+#          memory: 4Gi
 #      stepSpecs: # v1 style
 #        - name: extract-and-scan-image
 #          computeResources:

--- a/.tekton/scanner-db-push.yaml
+++ b/.tekton/scanner-db-push.yaml
@@ -61,14 +61,6 @@ spec:
         secretName: '{{ git_auth_secret }}'
 
   taskRunSpecs:
-    - pipelineTaskName: build-container
-      stepSpecs:
-        # Provision more CPU to speed up build compared to the defaults.
-        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
-        - name: build
-          computeResources:
-            requests:
-              cpu: 1
     - pipelineTaskName: clamav-scan
       stepSpecs:
         # Provision more CPU to speed up ClamAV scan compared to the defaults.

--- a/.tekton/scanner-db-push.yaml
+++ b/.tekton/scanner-db-push.yaml
@@ -62,30 +62,21 @@ spec:
 
   taskRunSpecs:
     - pipelineTaskName: build-container
-      stepSpecs: # v1 style
+      stepSpecs:
+        # Provision more CPU to speed up build compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
         - name: build
           computeResources:
             requests:
               cpu: 1
-      stepOverrides: # v1beta1 style
-        - name: build
-          resources:
-            requests:
-              cpu: 1
-    # This overrides clamav scan requested resources to make the task run faster.
     - pipelineTaskName: clamav-scan
-      stepSpecs: # v1 style
+      stepSpecs:
+        # Provision more CPU to speed up ClamAV scan compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
         - name: extract-and-scan-image
           computeResources:
             requests:
               cpu: 1
-              memory: 3Gi
-      stepOverrides: # v1beta1 style
-        - name: extract-and-scan-image
-          resources:
-            requests:
-              cpu: 1
-              memory: 3Gi
 
   pipelineSpec:
 

--- a/.tekton/scanner-db-push.yaml
+++ b/.tekton/scanner-db-push.yaml
@@ -60,6 +60,33 @@ spec:
       secret:
         secretName: '{{ git_auth_secret }}'
 
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs: # v1 style
+        - name: build
+          computeResources:
+            requests:
+              cpu: 1
+      stepOverrides: # v1beta1 style
+        - name: build
+          resources:
+            requests:
+              cpu: 1
+    # This overrides clamav scan requested resources to make the task run faster.
+    - pipelineTaskName: clamav-scan
+      stepSpecs: # v1 style
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              cpu: 1
+              memory: 3Gi
+      stepOverrides: # v1beta1 style
+        - name: extract-and-scan-image
+          resources:
+            requests:
+              cpu: 1
+              memory: 3Gi
+
   pipelineSpec:
 
     finally:

--- a/.tekton/scanner-db-slim-pull-request.yaml
+++ b/.tekton/scanner-db-slim-pull-request.yaml
@@ -61,6 +61,16 @@ spec:
       secret:
         secretName: '{{ git_auth_secret }}'
 
+  taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        # Provision more CPU to speed up ClamAV scan compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              cpu: 1
+
   pipelineSpec:
 
     finally:

--- a/.tekton/scanner-db-slim-push.yaml
+++ b/.tekton/scanner-db-slim-push.yaml
@@ -59,6 +59,16 @@ spec:
       secret:
         secretName: '{{ git_auth_secret }}'
 
+  taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        # Provision more CPU to speed up ClamAV scan compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              cpu: 1
+
   pipelineSpec:
 
     finally:

--- a/.tekton/scanner-pull-request.yaml
+++ b/.tekton/scanner-pull-request.yaml
@@ -64,7 +64,7 @@ spec:
         - name: build
           computeResources:
             requests:
-              cpu: 1
+              cpu: 2
     - pipelineTaskName: clamav-scan
       stepSpecs:
         # Provision more CPU to speed up ClamAV scan compared to the defaults.

--- a/.tekton/scanner-pull-request.yaml
+++ b/.tekton/scanner-pull-request.yaml
@@ -56,6 +56,24 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs:
+        # Provision more CPU to speed up build compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
+        - name: build
+          computeResources:
+            requests:
+              cpu: 1
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        # Provision more CPU to speed up ClamAV scan compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              cpu: 1
+
   pipelineSpec:
 
     finally:

--- a/.tekton/scanner-push.yaml
+++ b/.tekton/scanner-push.yaml
@@ -55,6 +55,24 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs:
+        # Provision more CPU to speed up build compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
+        - name: build
+          computeResources:
+            requests:
+              cpu: 1
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        # Provision more CPU to speed up ClamAV scan compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              cpu: 1
+
   pipelineSpec:
 
     finally:

--- a/.tekton/scanner-push.yaml
+++ b/.tekton/scanner-push.yaml
@@ -63,7 +63,7 @@ spec:
         - name: build
           computeResources:
             requests:
-              cpu: 1
+              cpu: 2
     - pipelineTaskName: clamav-scan
       stepSpecs:
         # Provision more CPU to speed up ClamAV scan compared to the defaults.

--- a/.tekton/scanner-slim-pull-request.yaml
+++ b/.tekton/scanner-slim-pull-request.yaml
@@ -55,6 +55,24 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs:
+        # Provision more CPU to speed up build compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
+        - name: build
+          computeResources:
+            requests:
+              cpu: 2
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        # Provision more CPU to speed up ClamAV scan compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              cpu: 1
+
   pipelineSpec:
 
     finally:

--- a/.tekton/scanner-slim-push.yaml
+++ b/.tekton/scanner-slim-push.yaml
@@ -54,6 +54,24 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs:
+        # Provision more CPU to speed up build compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L126
+        - name: build
+          computeResources:
+            requests:
+              cpu: 2
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        # Provision more CPU to speed up ClamAV scan compared to the defaults.
+        # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              cpu: 1
+
   pipelineSpec:
 
     finally:


### PR DESCRIPTION
The overrides are possible after https://issues.redhat.com/browse/PLNSRVCE-1625 got addressed.

I did not go over OOTB limits, rather made requests high enough so that CPU is actually reserved for intensive steps when Konflux cluster is oversubscribed. However, we can redefine limits too if needed.

I did not override cpu for scanner-db* builds because there's no lengthy Go compilation. I hope the default 250m should be enough, or we'll see.

My idea for this PR is to have the feature enabled to assess its stability and usefulness for us should we observe the need to tweak requests.

This reinstates <https://github.com/stackrox/scanner/pull/1394>.

The commit history (at the time of publishing) is messy. It only makes sense to review the final state (i.e. not per commit).