### PR TITLE
Generate v4 versioned offline vuln

### DIFF
--- a/scripts/ci/jobs/diff-dumps.sh
+++ b/scripts/ci/jobs/diff-dumps.sh
@@ -123,8 +123,8 @@ upload_v4_versioned_vuln() {
     while IFS= read -r version; do
         echo "$version"
         curl --silent --show-error --max-time 60 --retry 3 -o "scanner-v4-defs-${version}.zip" "https://storage.googleapis.com/scanner-v4-test/offline-bundles/scanner-v4-defs-${version}.zip"
-        zip scanner-vuln-${version}.zip scanner-defs.zip k8s-istio.zip scanner-v4-defs-${version}.zip
-        "${cmd[@]}" gsutil cp scanner-vuln-${version}.zip gs://scanner-support-public/offline/v1/${version}/scanner-vuln-${version}.zip
+        zip scanner-vulns-${version}.zip scanner-defs.zip k8s-istio.zip scanner-v4-defs-${version}.zip
+        "${cmd[@]}" gsutil cp scanner-vulns-${version}.zip gs://scanner-support-public/offline/v1/${version}/scanner-vulns-${version}.zip
     done <<< "$versions"
 }
 

--- a/scripts/ci/jobs/diff-dumps.sh
+++ b/scripts/ci/jobs/diff-dumps.sh
@@ -112,6 +112,11 @@ upload_offline_dump() {
 }
 
 upload_v4_versioned_vuln() {
+    info "Uploading offline dump"
+    cmd=()
+    if is_in_PR_context; then
+        cmd+=(echo "Would do")
+    fi
     cd /tmp/offline-dump
     version_file="out/RELEASE_VERSION.txt"
     versions=$(grep -oE '^[0-9]+\.[0-9]+' "$version_file" | sort -V)
@@ -121,7 +126,6 @@ upload_v4_versioned_vuln() {
         zip scanner-vuln-${version}.zip scanner-defs.zip k8s-istio.zip scanner-v4-defs-${version}.zip
         "${cmd[@]}" gsutil cp scanner-vuln-${version}.zip gs://scanner-support-public/offline/v1/${version}/scanner-vuln-${version}.zip
     done <<< "$versions"
-
 }
 
 diff_dumps() {

--- a/scripts/ci/jobs/diff-dumps.sh
+++ b/scripts/ci/jobs/diff-dumps.sh
@@ -122,9 +122,12 @@ upload_v4_versioned_vuln() {
     versions=$(grep -oE '^[0-9]+\.[0-9]+' "$version_file" | sort -V)
     while IFS= read -r version; do
         echo "$version"
-        curl --silent --show-error --max-time 60 --retry 3 -o "scanner-v4-defs-${version}.zip" "https://storage.googleapis.com/scanner-v4-test/offline-bundles/scanner-v4-defs-${version}.zip"
-        zip scanner-vulns-${version}.zip scanner-defs.zip k8s-istio.zip scanner-v4-defs-${version}.zip
-        "${cmd[@]}" gsutil cp scanner-vulns-${version}.zip gs://scanner-support-public/offline/v1/${version}/scanner-vulns-${version}.zip
+        if curl --silent --show-error --max-time 60 --retry 3 -o "scanner-v4-defs-${version}.zip" "https://storage.googleapis.com/scanner-v4-test/offline-bundles/scanner-v4-defs-${version}.zip"; then
+            zip scanner-vulns-${version}.zip scanner-defs.zip k8s-istio.zip scanner-v4-defs-${version}.zip
+            "${cmd[@]}" gsutil cp scanner-vulns-${version}.zip gs://scanner-support-public/offline/v1/${version}/scanner-vulns-${version}.zip
+        else
+            echo "Failed to download scanner-v4-defs-${version}.zip, skipping..."
+        fi
     done <<< "$versions"
 }
 


### PR DESCRIPTION
Generate scanner-vulns-{version}.zip for scanner v4 offline mode

Due to time constraints and my limited understanding of decoupling ci.yaml and diff-dump (just for testing), I directly modified the diff-dump.sh script.