### PR TITLE
chore(go): go1.21.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
   pre-build-updater:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
   pre-build-scanner:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
     needs:
       - pre-build-scanner
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -119,7 +119,7 @@ jobs:
     needs:
       - pre-build-scanner
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -153,7 +153,7 @@ jobs:
     needs:
       - pre-build-updater
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -194,7 +194,7 @@ jobs:
     needs:
       - generate-genesis-dump
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -236,7 +236,7 @@ jobs:
       always() &&
       (needs.generate-genesis-dump.result == 'success' || needs.generate-genesis-dump.result == 'skipped')
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -289,7 +289,7 @@ jobs:
       always() &&
       (needs.generate-db-dump.result == 'success' || needs.generate-db-dump.result == 'skipped')
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -334,7 +334,7 @@ jobs:
       - generate-scanner-db-bundle
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -400,7 +400,7 @@ jobs:
     needs:
       - generate-genesis-dump
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -436,7 +436,7 @@ jobs:
     needs:
       - generate-db-dump
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -463,7 +463,7 @@ jobs:
     needs:
       - generate-db-dump
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -495,7 +495,7 @@ jobs:
     needs:
       - generate-db-dump
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sanity-check-vuln-updates.yaml
+++ b/.github/workflows/sanity-check-vuln-updates.yaml
@@ -10,7 +10,7 @@ jobs:
       SLACK_WEBHOOK_ONCALL: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.61
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -10,4 +10,4 @@
 # - `make update` and commit the results
 # - run `/test pj-rehearse-max` on the openshift/release PR to validate the change
 
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66

--- a/.openshift-ci/build/Dockerfile.build-bundle
+++ b/.openshift-ci/build/Dockerfile.build-bundle
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/.openshift-ci/build/Dockerfile.build-db-bundle
+++ b/.openshift-ci/build/Dockerfile.build-db-bundle
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/.openshift-ci/build/Dockerfile.generate-db-dump
+++ b/.openshift-ci/build/Dockerfile.generate-db-dump
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/.openshift-ci/build/Dockerfile.generate-genesis-dump
+++ b/.openshift-ci/build/Dockerfile.generate-genesis-dump
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.65
+FROM quay.io/stackrox-io/apollo-ci:scanner-test-0.3.66
 
 COPY . /go/src/github.com/stackrox/scanner
 WORKDIR /go/src/github.com/stackrox/scanner

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-scanner-build-0.3.65
+scanner-build-0.3.66


### PR DESCRIPTION
Build images with Go 1.21.8. Note: we don't bother bumping the `go.mod` version, as there is nothing in 1.21 which we require