### PR TITLE
chore: update get_pr_details with the stackrox version

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -337,6 +337,7 @@ pr_has_label() {
 
 # get_pr_details() from GitHub and display the result. Exits 1 if not run in CI in a PR context.
 _PR_DETAILS=""
+_PR_DETAILS_CACHE_FILE="/tmp/PR_DETAILS_CACHE.json"
 get_pr_details() {
     local pull_request
     local org
@@ -344,10 +345,16 @@ get_pr_details() {
 
     if [[ -n "${_PR_DETAILS}" ]]; then
         echo "${_PR_DETAILS}"
-        return
+        return 0
+    fi
+    if [[ -e "${_PR_DETAILS_CACHE_FILE}" ]]; then
+        _PR_DETAILS="$(cat "${_PR_DETAILS_CACHE_FILE}")"
+        echo "${_PR_DETAILS}"
+        return 0
     fi
 
     _not_a_PR() {
+        echo "This does not appear to be a PR context" >&2
         echo '{ "msg": "this is not a PR" }'
         exit 1
     }
@@ -362,14 +369,21 @@ get_pr_details() {
             org=$(jq -r <<<"$CLONEREFS_OPTIONS" '.refs[0].org')
             repo=$(jq -r <<<"$CLONEREFS_OPTIONS" '.refs[0].repo')
         else
-            echo "Expect a JOB_SPEC or CLONEREFS_OPTIONS"
+            echo "Expect a JOB_SPEC or CLONEREFS_OPTIONS" >&2
             exit 2
         fi
         [[ "${pull_request}" == "null" ]] && _not_a_PR
+    elif is_GITHUB_ACTIONS; then
+        pull_request="$(jq -r .pull_request.number "${GITHUB_EVENT_PATH}")" || _not_a_PR
+        [[ "${pull_request}" == "null" ]] && _not_a_PR
+        org="${GITHUB_REPOSITORY_OWNER}"
+        repo="${GITHUB_REPOSITORY#*/}"
     else
-        echo "Expect OpenShift CI"
+        echo "Unsupported CI" >&2
         exit 2
     fi
+
+    local headers url pr_details
 
     headers=()
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then
@@ -377,14 +391,19 @@ get_pr_details() {
     fi
 
     url="https://api.github.com/repos/${org}/${repo}/pulls/${pull_request}"
-    pr_details=$(curl --retry 5 -sS "${headers[@]}" "${url}")
+
+    if ! pr_details=$(curl --retry 5 -sS "${headers[@]}" "${url}"); then
+        echo "Github API error: $pr_details, exit code: $?" >&2
+        exit 2
+    fi
+
     if [[ "$(jq .id <<<"$pr_details")" == "null" ]]; then
         # A valid PR response is expected at this point
-        echo "Invalid response from GitHub: $pr_details"
+        echo "Invalid response from GitHub: $pr_details" >&2
         exit 2
     fi
     _PR_DETAILS="$pr_details"
-    echo "$pr_details"
+    echo "$pr_details" | tee "${_PR_DETAILS_CACHE_FILE}"
 }
 
 GATE_JOBS_CONFIG="$SCRIPTS_ROOT/scripts/ci/gate-jobs-config.json"


### PR DESCRIPTION
## Description

We have a bash function that is most, if not only, used in CI to get the PR details. This function wasn't updated when we moved the OSCI jobs to GitHub Actions, which is causing PRs not to get the labels properly. The newer version found in [stackrox/stackrox](https://github.com/stackrox/stackrox) also has better logging.

These changes update `get_pr_details()` with the current version in [stackrox/stackrox](https://github.com/stackrox/stackrox).