### PR TITLE
ROX-23563: Add diff-dumps to GHA artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -429,8 +429,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: diff-dumps
-          path: /tmp/diff-dumps
+          name: diff-dumps-inspect
+          path: /tmp/diff-dumps-inspect
 
   upload-db-dump:
     # Only run on master branch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -427,7 +427,7 @@ jobs:
       - name: diff-dumps
         run: ./scripts/ci/jobs/diff-dumps.sh
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: diff-dumps
           path: /tmp/diff-dumps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -427,6 +427,11 @@ jobs:
       - name: diff-dumps
         run: ./scripts/ci/jobs/diff-dumps.sh
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: diff-dumps
+          path: /tmp/diff-dumps
+
   upload-db-dump:
     # Only run on master branch
     if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Description

The diff zips generated by the `diff-dumps` job for a PR with label "generate-dumps-on-pr" are not made accessible for inspection ([example run](https://github.com/stackrox/scanner/actions/runs/8608350848/job/23591361309?pr=1464)).

These changes add `diff-dumps` to the GitHub Actions artifacts.