### PR TITLE
ROX-21744: allow sensor/scanner comms in non-ocp (2/2)

### DIFF
--- a/pkg/env/list.go
+++ b/pkg/env/list.go
@@ -21,12 +21,6 @@ var (
 	// If SkipPeerValidation or OpenshiftAPI is enabled, the ingress implications are ignored.
 	SlimMode = RegisterBooleanSetting("ROX_SLIM_MODE", false)
 
-	// OpenshiftAPI indicates Scanner is running in an OpenShift environment.
-	// When set to "true", ingress is allowed from both Central and Sensor.
-	// This is ignored if SkipPeerValidation is enabled.
-	// This variable was copied over from the stackrox repo.
-	OpenshiftAPI = RegisterBooleanSetting("ROX_OPENSHIFT_API", false)
-
 	// NodeName is used when running Scanner in Node Inventory mode. This should be set by
 	// Kubernetes in the Secured Cluster.
 	NodeName = RegisterSetting("ROX_NODE_NAME")

--- a/pkg/mtls/verifier.go
+++ b/pkg/mtls/verifier.go
@@ -14,15 +14,12 @@ const (
 )
 
 // VerifyPeerCertificate verifies the given peer certificate.
-// By default, it verifies the certificate has the Central Common Name.
-// If ROX_OPENSHIFT_API is enabled, then it verifies it has either the Central or Sensor Common Name.
-// Otherwise, if ROX_SLIM_MODE is enabled, then is verifies it has the Sensor Common Name.
+// By default, it verifies the certificate has the Central or Sensor Common Name.
+// If ROX_SLIM_MODE is enabled, then is verifies it has the Sensor Common Name.
 // The CA should have already been verified via tls.VerifyClientCertIfGiven.
 func VerifyPeerCertificate(tls *tls.ConnectionState) error {
-	verifyPeerCertificate := verifyCentralPeerCertificate
-	if env.OpenshiftAPI.Enabled() {
-		verifyPeerCertificate = verifyCentralOrSensorPeerCertificate
-	} else if env.SlimMode.Enabled() {
+	verifyPeerCertificate := verifyCentralOrSensorPeerCertificate
+	if env.SlimMode.Enabled() {
 		verifyPeerCertificate = verifySensorPeerCertificate
 	}
 

--- a/pkg/mtls/verifier_test.go
+++ b/pkg/mtls/verifier_test.go
@@ -44,23 +44,6 @@ var (
 
 func TestVerifyPeerCertificate_Default(t *testing.T) {
 	assert.NoError(t, VerifyPeerCertificate(centralTLSState))
-	assert.Error(t, VerifyPeerCertificate(sensorTLSState))
-	assert.Error(t, VerifyPeerCertificate(fooTLSState))
-}
-
-func TestVerifyPeerCertificate_ROX_OPENSHIFT_API(t *testing.T) {
-	t.Setenv(env.OpenshiftAPI.EnvVar(), "true")
-
-	assert.NoError(t, VerifyPeerCertificate(centralTLSState))
-	assert.NoError(t, VerifyPeerCertificate(sensorTLSState))
-	assert.Error(t, VerifyPeerCertificate(fooTLSState))
-}
-
-func TestVerifyPeerCertificate_ROX_OPENSHIFT_API_AND_ROX_SLIM_MODE(t *testing.T) {
-	t.Setenv(env.OpenshiftAPI.EnvVar(), "true")
-	t.Setenv(env.SlimMode.EnvVar(), "true")
-
-	assert.NoError(t, VerifyPeerCertificate(centralTLSState))
 	assert.NoError(t, VerifyPeerCertificate(sensorTLSState))
 	assert.Error(t, VerifyPeerCertificate(fooTLSState))
 }


### PR DESCRIPTION
Adjusts the Scanner mTLS configuration to allow requests from Sensor irregardless of the k8s flavor.

This is necessary to support delegated scanning in non-OCP environments where Central/Sensor exist in same namespace.

Also removes references to `ROX_OPENSHIFT_API` that are no longer used.

This is a two part change, also refer to: https://github.com/stackrox/stackrox/pull/10759

## Testing Performed

Created a gke infra cluster, installed ACS into a single namespace (with the net policy changes referenced in the [other PR](https://github.com/stackrox/stackrox/pull/10759)), and delegated scans.

Before this change:

```
$ rctl image scan --image=nginx:1.13.0 --cluster=remote
ERROR:	Scanning image failed: could not scan image: "nginx:1.13.0": rpc error: code = Internal desc = error delegating scan to cluster "f5175adf-7f49-491c-a6b5-e6c47d778cbf" for "docker.io/library/nginx:1.13.0": image enrichment error: scanning image "registry:\"docker.io\" remote:\"library/nginx\" tag:\"1.13.0\" full_name:\"docker.io/library/nginx:1.13.0\" " locally: getting image components from scanner: rpc error: code = InvalidArgument desc = peer certificate common name "SENSOR_SERVICE: 00000000-0000-0000-0000-000000000000" does not match any expected common name prefix. Retrying after 3 seconds...
```

And after:

```
$ rctl image scan --image=nginx:1.13.0 --cluster=remote
{
  "id": "sha256:12d30ce421ad530494d588f87b2328ddc3cae666e77ea1ae5ac3a6661e52cde6",
  "name": {
    "registry": "docker.io",
    "remote": "library/nginx",
    "tag": "1.13.0",
    "fullName": "docker.io/library/nginx:1.13.0"
  },
...
```
