### PR TITLE
chore(deps): bump docker-registry-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -188,7 +188,7 @@ replace (
 	// - trailing comments propagation to generated code
 	github.com/gogo/protobuf => github.com/stackrox/protobuf v1.2.2-0.20240207122816-e936d453291c
 
-	github.com/heroku/docker-registry-client => github.com/stackrox/docker-registry-client v0.0.0-20231011162931-bac16127162d
+	github.com/heroku/docker-registry-client => github.com/stackrox/docker-registry-client v0.1.0
 
 	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.12-0.20230825152000-1361e2f7db46
 	github.com/stackrox/rox => github.com/stackrox/stackrox v0.0.0-20240402171531-15fa6d254174

--- a/go.sum
+++ b/go.sum
@@ -591,8 +591,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace h1:9PNP1jnUjRhfmGMlkXHjYPishpcw4jpSt/V/xYY3FMA=
 github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.10.0/go.mod h1:SoyBPwAtKDzypXNDFKN5kzH7ppppbGZtls1UpIy5AsM=
-github.com/stackrox/docker-registry-client v0.0.0-20231011162931-bac16127162d h1:ZkQYQqH6EcgvFGJyX3dFVZPIg/YaEv9NqxeuBNEXo4w=
-github.com/stackrox/docker-registry-client v0.0.0-20231011162931-bac16127162d/go.mod h1:4pA1hEzlc3r9j0EXFuHLgRs9ryO8X7TWsvCnpX/Y/04=
+github.com/stackrox/docker-registry-client v0.1.0 h1:TbNgSP3dhNbLAqlwyTIYNXbNvl9TDTAbh+cfzVyJ6II=
+github.com/stackrox/docker-registry-client v0.1.0/go.mod h1:4TU+pA11iczIvhtL0own2OJcJXc1o26tBHDivaXhlZU=
 github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd h1:vEjp7Q66zd4W72//Uk3uyVN50Mh/nFLbN9pb7CVK7mE=
 github.com/stackrox/dotnet-scraper v0.0.0-20201023051640-72ef543323dd/go.mod h1:HILeV3i/EyJz844GcrC3+oU7oZONhjfujaIYBMJ/bZE=
 github.com/stackrox/istio-cves v0.0.0-20221007013142-0bde9b541ec8 h1:rUIvoAHokPcd92aJT2gJwVeyE8tMuaqS5l5s3cEgXFY=


### PR DESCRIPTION
Fixed a potential panic and created the first release of this: v0.1.0

https://github.com/stackrox/docker-registry-client/pull/19

I also tried to remove the `replace`, but the circular dependency with the stackrox/stackrox repo made this super annoying. Would rather just deal with this, since we don't expect this to update much, and we plan on removing this repo as a dependency for stackrox/stackrox in the future, anyway