### PR TITLE
ROX-24081: use make tag result in image names on Konflux

### DIFF
--- a/.tekton/determine-image-tag-task.yaml
+++ b/.tekton/determine-image-tag-task.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: determine-image-tag
+  namespace: rh-acs-tenant
+# TODO(ROX-23812): Refactor to a task bundle
+spec:
+  description: Determines the tag for the output image using the StackRox convention from 'make tag' output.
+  params:
+  results:
+  - name: image-tag
+    description: Image Tag determined by custom logic.
+  steps:
+  - name: determine-image-tag
+    image: registry.access.redhat.com/ubi8:latest
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      dnf -y upgrade --nobest
+      dnf -y install git make
+      cd "$(workspaces.source.path)/source"
+      scripts/konflux/fail-build-if-git-is-dirty.sh
+      echo -n "$(make --quiet --no-print-directory tag)-fast" | tee "$(results.image-tag.path)"
+  workspaces:
+    - name: source
+      description: The workspace where source code is included.

--- a/.tekton/scanner-db-pull-request.yaml
+++ b/.tekton/scanner-db-pull-request.yaml
@@ -276,7 +276,7 @@ spec:
 
       - name: fetch-sql-definitions
         runAfter:
-          - clone-repository
+          - determine-image-tag
         taskSpec:
           steps:
             - name: fetch-sql-definitions

--- a/.tekton/scanner-db-pull-request.yaml
+++ b/.tekton/scanner-db-pull-request.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: rh-acs-tenant
 
 spec:
-
   params:
     - name: dockerfile
       value: image/db/rhel/konflux.Dockerfile
@@ -27,8 +26,8 @@ spec:
       value: '{{source_url}}'
     - name: image-expires-after
       value: '13w'
-    - name: output-image
-      value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-db:on-pr-{{revision}}
+    - name: output-image-repo
+      value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-db
     - name: path-context
       value: .
     - name: revision
@@ -45,6 +44,10 @@ spec:
       value: 'true'
     - name: build-target-stage
       value: scanner-db
+    - name: clone-depth
+      value: '0'
+    - name: clone-fetch-tags
+      value: 'true'
 
   workspaces:
     - name: workspace
@@ -95,7 +98,7 @@ spec:
           - name: git-url
             value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
           - name: image-url
-            value: $(params.output-image)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: build-task-status
             value: $(tasks.build-container.status)
         workspaces:
@@ -119,8 +122,8 @@ spec:
         description: Revision of the Source Repository
         name: revision
         type: string
-      - description: Fully Qualified Output Image
-        name: output-image
+      - description: Output Image Repository
+        name: output-image-repo
         type: string
       - default: .
         description: Path to the source code of an application's component from where
@@ -192,7 +195,11 @@ spec:
       - name: init
         params:
           - name: image-url
-            value: $(params.output-image)
+            # We can't provide a real tag because it is not known at this time.
+            # We still provide a fake tag to the task to comply with the expected input.
+            # Because 'rebuild' is set to true, this has no effect.
+            # TODO(ROX-24116): Apply both Konflux-style and StackRox-style tags to containers
+            value: $(params.output-image-repo):fake-tag
           - name: rebuild
             value: $(params.rebuild)
           - name: skip-checks
@@ -213,11 +220,10 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: $(params.revision)
-          # A shallow repo clone is sufficient for scanner-db build.
           - name: depth
-            value: "1"
+            value: "$(params.clone-depth)"
           - name: fetchTags
-            value: "false"
+            value: "$(params.clone-fetch-tags)"
         runAfter:
           - init
         taskRef:
@@ -239,12 +245,22 @@ spec:
           - name: basic-auth
             workspace: git-auth
 
+      - name: determine-image-tag
+        runAfter:
+        # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
+        - clone-repository
+        taskRef:
+          name: determine-image-tag
+        workspaces:
+        - name: source
+          workspace: workspace
+
       - name: prefetch-dependencies
         params:
           - name: input
             value: $(params.prefetch-input)
         runAfter:
-          - clone-repository
+          - determine-image-tag
         taskRef:
           params:
             - name: name
@@ -277,7 +293,7 @@ spec:
       - name: build-container
         params:
           - name: IMAGE
-            value: $(params.output-image)
+            value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
           - name: DOCKERFILE
             value: $(params.dockerfile)
           - name: CONTEXT
@@ -315,7 +331,7 @@ spec:
       - name: build-source-image
         params:
           - name: BINARY_IMAGE
-            value: $(params.output-image)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: BASE_IMAGES
             value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
         runAfter:

--- a/.tekton/scanner-db-push.yaml
+++ b/.tekton/scanner-db-push.yaml
@@ -17,7 +17,6 @@ metadata:
   namespace: rh-acs-tenant
 
 spec:
-
   params:
     - name: dockerfile
       value: image/db/rhel/konflux.Dockerfile
@@ -25,8 +24,8 @@ spec:
       value: '{{source_url}}'
     - name: image-expires-after
       value: '13w'
-    - name: output-image
-      value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-db:{{revision}}
+    - name: output-image-repo
+      value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-db
     - name: path-context
       value: .
     - name: revision
@@ -43,6 +42,10 @@ spec:
       value: 'true'
     - name: build-target-stage
       value: scanner-db
+    - name: clone-depth
+      value: '0'
+    - name: clone-fetch-tags
+      value: 'true'
 
   workspaces:
     - name: workspace
@@ -93,7 +96,7 @@ spec:
           - name: git-url
             value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
           - name: image-url
-            value: $(params.output-image)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: build-task-status
             value: $(tasks.build-container.status)
         workspaces:
@@ -117,8 +120,8 @@ spec:
         description: Revision of the Source Repository
         name: revision
         type: string
-      - description: Fully Qualified Output Image
-        name: output-image
+      - description: Output Image Repository
+        name: output-image-repo
         type: string
       - default: .
         description: Path to the source code of an application's component from where
@@ -190,7 +193,11 @@ spec:
       - name: init
         params:
           - name: image-url
-            value: $(params.output-image)
+            # We can't provide a real tag because it is not known at this time.
+            # We still provide a fake tag to the task to comply with the expected input.
+            # Because 'rebuild' is set to true, this has no effect.
+            # TODO(ROX-24116): Apply both Konflux-style and StackRox-style tags to containers
+            value: $(params.output-image-repo):fake-tag
           - name: rebuild
             value: $(params.rebuild)
           - name: skip-checks
@@ -211,11 +218,10 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: $(params.revision)
-          # A shallow repo clone is sufficient for scanner-db build.
           - name: depth
-            value: "1"
+            value: "$(params.clone-depth)"
           - name: fetchTags
-            value: "false"
+            value: "$(params.clone-fetch-tags)"
         runAfter:
           - init
         taskRef:
@@ -237,12 +243,22 @@ spec:
           - name: basic-auth
             workspace: git-auth
 
+      - name: determine-image-tag
+        runAfter:
+        # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
+        - clone-repository
+        taskRef:
+          name: determine-image-tag
+        workspaces:
+        - name: source
+          workspace: workspace
+
       - name: prefetch-dependencies
         params:
           - name: input
             value: $(params.prefetch-input)
         runAfter:
-          - clone-repository
+          - determine-image-tag
         taskRef:
           params:
             - name: name
@@ -275,7 +291,7 @@ spec:
       - name: build-container
         params:
           - name: IMAGE
-            value: $(params.output-image)
+            value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
           - name: DOCKERFILE
             value: $(params.dockerfile)
           - name: CONTEXT
@@ -313,7 +329,7 @@ spec:
       - name: build-source-image
         params:
           - name: BINARY_IMAGE
-            value: $(params.output-image)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: BASE_IMAGES
             value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
         runAfter:

--- a/.tekton/scanner-db-push.yaml
+++ b/.tekton/scanner-db-push.yaml
@@ -274,7 +274,7 @@ spec:
 
       - name: fetch-sql-definitions
         runAfter:
-          - clone-repository
+          - determine-image-tag
         taskSpec:
           steps:
             - name: fetch-sql-definitions

--- a/.tekton/scanner-db-slim-pull-request.yaml
+++ b/.tekton/scanner-db-slim-pull-request.yaml
@@ -18,7 +18,6 @@ metadata:
   namespace: rh-acs-tenant
 
 spec:
-
   params:
     - name: dockerfile
       value: image/db/rhel/konflux.Dockerfile
@@ -26,8 +25,8 @@ spec:
       value: '{{source_url}}'
     - name: image-expires-after
       value: '13w'
-    - name: output-image
-      value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-db-slim:on-pr-{{revision}}
+    - name: output-image-repo
+      value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-db-slim
     - name: path-context
       value: .
     - name: revision
@@ -44,6 +43,10 @@ spec:
       value: 'true'
     - name: build-target-stage
       value: scanner-db-slim
+    - name: clone-depth
+      value: '0'
+    - name: clone-fetch-tags
+      value: 'true'
 
   workspaces:
     - name: workspace
@@ -94,7 +97,7 @@ spec:
           - name: git-url
             value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
           - name: image-url
-            value: $(params.output-image)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: build-task-status
             value: $(tasks.build-container.status)
         workspaces:
@@ -118,8 +121,8 @@ spec:
         description: Revision of the Source Repository
         name: revision
         type: string
-      - description: Fully Qualified Output Image
-        name: output-image
+      - description: Output Image Repository
+        name: output-image-repo
         type: string
       - default: .
         description: Path to the source code of an application's component from where
@@ -191,7 +194,11 @@ spec:
       - name: init
         params:
           - name: image-url
-            value: $(params.output-image)
+            # We can't provide a real tag because it is not known at this time.
+            # We still provide a fake tag to the task to comply with the expected input.
+            # Because 'rebuild' is set to true, this has no effect.
+            # TODO(ROX-24116): Apply both Konflux-style and StackRox-style tags to containers
+            value: $(params.output-image-repo):fake-tag
           - name: rebuild
             value: $(params.rebuild)
           - name: skip-checks
@@ -212,11 +219,10 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: $(params.revision)
-          # A shallow repo clone is sufficient for scanner-db-slim build.
           - name: depth
-            value: "1"
+            value: "$(params.clone-depth)"
           - name: fetchTags
-            value: "false"
+            value: "$(params.clone-fetch-tags)"
         runAfter:
           - init
         taskRef:
@@ -238,12 +244,22 @@ spec:
           - name: basic-auth
             workspace: git-auth
 
+      - name: determine-image-tag
+        runAfter:
+        # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
+        - clone-repository
+        taskRef:
+          name: determine-image-tag
+        workspaces:
+        - name: source
+          workspace: workspace
+
       - name: prefetch-dependencies
         params:
           - name: input
             value: $(params.prefetch-input)
         runAfter:
-          - clone-repository
+          - determine-image-tag
         taskRef:
           params:
             - name: name
@@ -260,7 +276,7 @@ spec:
       - name: build-container
         params:
           - name: IMAGE
-            value: $(params.output-image)
+            value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
           - name: DOCKERFILE
             value: $(params.dockerfile)
           - name: CONTEXT
@@ -297,7 +313,7 @@ spec:
       - name: build-source-image
         params:
           - name: BINARY_IMAGE
-            value: $(params.output-image)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: BASE_IMAGES
             value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
         runAfter:

--- a/.tekton/scanner-db-slim-push.yaml
+++ b/.tekton/scanner-db-slim-push.yaml
@@ -16,7 +16,6 @@ metadata:
   namespace: rh-acs-tenant
 
 spec:
-
   params:
     - name: dockerfile
       value: image/db/rhel/konflux.Dockerfile
@@ -24,8 +23,8 @@ spec:
       value: '{{source_url}}'
     - name: image-expires-after
       value: '13w'
-    - name: output-image
-      value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-db-slim:{{revision}}
+    - name: output-image-repo
+      value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-db-slim
     - name: path-context
       value: .
     - name: revision
@@ -42,6 +41,10 @@ spec:
       value: 'true'
     - name: build-target-stage
       value: scanner-db-slim
+    - name: clone-depth
+      value: '0'
+    - name: clone-fetch-tags
+      value: 'true'
 
   workspaces:
     - name: workspace
@@ -92,7 +95,7 @@ spec:
           - name: git-url
             value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
           - name: image-url
-            value: $(params.output-image)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: build-task-status
             value: $(tasks.build-container.status)
         workspaces:
@@ -116,8 +119,8 @@ spec:
         description: Revision of the Source Repository
         name: revision
         type: string
-      - description: Fully Qualified Output Image
-        name: output-image
+      - description: Output Image Repository
+        name: output-image-repo
         type: string
       - default: .
         description: Path to the source code of an application's component from where
@@ -189,7 +192,11 @@ spec:
       - name: init
         params:
           - name: image-url
-            value: $(params.output-image)
+            # We can't provide a real tag because it is not known at this time.
+            # We still provide a fake tag to the task to comply with the expected input.
+            # Because 'rebuild' is set to true, this has no effect.
+            # TODO(ROX-24116): Apply both Konflux-style and StackRox-style tags to containers
+            value: $(params.output-image-repo):fake-tag
           - name: rebuild
             value: $(params.rebuild)
           - name: skip-checks
@@ -210,11 +217,10 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: $(params.revision)
-          # A shallow repo clone is sufficient for scanner-db-slim build.
           - name: depth
-            value: "1"
+            value: "$(params.clone-depth)"
           - name: fetchTags
-            value: "false"
+            value: "$(params.clone-fetch-tags)"
         runAfter:
           - init
         taskRef:
@@ -236,12 +242,22 @@ spec:
           - name: basic-auth
             workspace: git-auth
 
+      - name: determine-image-tag
+        runAfter:
+        # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
+        - clone-repository
+        taskRef:
+          name: determine-image-tag
+        workspaces:
+        - name: source
+          workspace: workspace
+
       - name: prefetch-dependencies
         params:
           - name: input
             value: $(params.prefetch-input)
         runAfter:
-          - clone-repository
+          - determine-image-tag
         taskRef:
           params:
             - name: name
@@ -258,7 +274,7 @@ spec:
       - name: build-container
         params:
           - name: IMAGE
-            value: $(params.output-image)
+            value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
           - name: DOCKERFILE
             value: $(params.dockerfile)
           - name: CONTEXT
@@ -295,7 +311,7 @@ spec:
       - name: build-source-image
         params:
           - name: BINARY_IMAGE
-            value: $(params.output-image)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: BASE_IMAGES
             value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
         runAfter:

--- a/.tekton/scanner-pull-request.yaml
+++ b/.tekton/scanner-pull-request.yaml
@@ -279,8 +279,7 @@ spec:
 
     - name: fetch-vuln-feed-data
       runAfter:
-      - init
-      - clone-repository
+      - determine-image-tag
       taskSpec:
         steps:
           - name: fetch-vuln-feed-data

--- a/.tekton/scanner-pull-request.yaml
+++ b/.tekton/scanner-pull-request.yaml
@@ -17,7 +17,6 @@ metadata:
   name: scanner-on-pull-request
   namespace: rh-acs-tenant
 spec:
-
   params:
   - name: dockerfile
     value: image/scanner/rhel/konflux.Dockerfile
@@ -25,8 +24,8 @@ spec:
     value: '{{repo_url}}'
   - name: image-expires-after
     value: '13w'
-  - name: output-image
-    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner:on-pr-{{revision}}
+  - name: output-image-repo
+    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner
   - name: path-context
     value: .
   - name: revision
@@ -39,6 +38,10 @@ spec:
     value: 'true'
   - name: build-target-stage
     value: scanner
+  - name: clone-depth
+    value: '0'
+  - name: clone-fetch-tags
+    value: 'true'
 
   workspaces:
   - name: workspace
@@ -97,7 +100,7 @@ spec:
       - name: git-url
         value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
       - name: image-url
-        value: $(params.output-image)
+        value: $(tasks.build-container.results.IMAGE_URL)
       - name: build-task-status
         value: $(tasks.build-container.status)
       workspaces:
@@ -121,8 +124,8 @@ spec:
       description: Revision of the Source Repository
       name: revision
       type: string
-    - description: Fully Qualified Output Image
-      name: output-image
+    - description: Output Image Repository
+      name: output-image-repo
       type: string
     - default: .
       description: Path to the source code of an application's component from where
@@ -194,7 +197,11 @@ spec:
     - name: init
       params:
       - name: image-url
-        value: $(params.output-image)
+        # We can't provide a real tag because it is not known at this time.
+        # We still provide a fake tag to the task to comply with the expected input.
+        # Because 'rebuild' is set to true, this has no effect.
+        # TODO(ROX-24116): Apply both Konflux-style and StackRox-style tags to containers
+        value: $(params.output-image-repo):fake-tag
       - name: rebuild
         value: $(params.rebuild)
       - name: skip-checks
@@ -216,9 +223,9 @@ spec:
       - name: revision
         value: $(params.revision)
       - name: depth
-        value: "0"
+        value: "$(params.clone-depth)"
       - name: fetchTags
-        value: "true"
+        value: "$(params.clone-fetch-tags)"
       runAfter:
       - init
       taskRef:
@@ -241,12 +248,22 @@ spec:
       - name: basic-auth
         workspace: git-auth
 
+    - name: determine-image-tag
+      runAfter:
+      # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
+      - clone-repository
+      taskRef:
+        name: determine-image-tag
+      workspaces:
+      - name: source
+        workspace: workspace
+
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       runAfter:
-      - clone-repository
+      - determine-image-tag
       taskRef:
         params:
         - name: name
@@ -283,7 +300,7 @@ spec:
     - name: build-container
       params:
       - name: IMAGE
-        value: $(params.output-image)
+        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT
@@ -322,7 +339,7 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: $(tasks.build-container.results.IMAGE_URL)
       - name: BASE_IMAGES
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:

--- a/.tekton/scanner-push.yaml
+++ b/.tekton/scanner-push.yaml
@@ -15,7 +15,6 @@ metadata:
   name: scanner-on-push
   namespace: rh-acs-tenant
 spec:
-
   params:
   - name: dockerfile
     value: image/scanner/rhel/konflux.Dockerfile
@@ -24,8 +23,8 @@ spec:
   - name: image-expires-after
     # TODO(ROX-20230): make release images not expire.
     value: '13w'
-  - name: output-image
-    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner:{{revision}}
+  - name: output-image-repo
+    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner
   - name: path-context
     value: .
   - name: revision
@@ -38,6 +37,10 @@ spec:
     value: 'true'
   - name: build-target-stage
     value: scanner
+  - name: clone-depth
+    value: '0'
+  - name: clone-fetch-tags
+    value: 'true'
 
   workspaces:
   - name: workspace
@@ -96,7 +99,7 @@ spec:
       - name: git-url
         value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
       - name: image-url
-        value: $(params.output-image)
+        value: $(tasks.build-container.results.IMAGE_URL)
       - name: build-task-status
         value: $(tasks.build-container.status)
       workspaces:
@@ -120,8 +123,8 @@ spec:
       description: Revision of the Source Repository
       name: revision
       type: string
-    - description: Fully Qualified Output Image
-      name: output-image
+    - description: Output Image Repository
+      name: output-image-repo
       type: string
     - default: .
       description: Path to the source code of an application's component from where
@@ -193,7 +196,11 @@ spec:
     - name: init
       params:
       - name: image-url
-        value: $(params.output-image)
+        # We can't provide a real tag because it is not known at this time.
+        # We still provide a fake tag to the task to comply with the expected input.
+        # Because 'rebuild' is set to true, this has no effect.
+        # TODO(ROX-24116): Apply both Konflux-style and StackRox-style tags to containers
+        value: $(params.output-image-repo):fake-tag
       - name: rebuild
         value: $(params.rebuild)
       - name: skip-checks
@@ -215,9 +222,9 @@ spec:
       - name: revision
         value: $(params.revision)
       - name: depth
-        value: "0"
+        value: "$(params.clone-depth)"
       - name: fetchTags
-        value: "true"
+        value: "$(params.clone-fetch-tags)"
       runAfter:
       - init
       taskRef:
@@ -240,12 +247,22 @@ spec:
       - name: basic-auth
         workspace: git-auth
 
+    - name: determine-image-tag
+      runAfter:
+      # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
+      - clone-repository
+      taskRef:
+        name: determine-image-tag
+      workspaces:
+      - name: source
+        workspace: workspace
+
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       runAfter:
-      - clone-repository
+      - determine-image-tag
       taskRef:
         params:
         - name: name
@@ -282,7 +299,7 @@ spec:
     - name: build-container
       params:
       - name: IMAGE
-        value: $(params.output-image)
+        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT
@@ -321,7 +338,7 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: $(tasks.build-container.results.IMAGE_URL)
       - name: BASE_IMAGES
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:

--- a/.tekton/scanner-push.yaml
+++ b/.tekton/scanner-push.yaml
@@ -278,8 +278,7 @@ spec:
 
     - name: fetch-vuln-feed-data
       runAfter:
-      - init
-      - clone-repository
+      - determine-image-tag
       taskSpec:
         steps:
           - name: fetch-vuln-feed-data

--- a/.tekton/scanner-slim-pull-request.yaml
+++ b/.tekton/scanner-slim-pull-request.yaml
@@ -275,8 +275,7 @@ spec:
 
     - name: fetch-vuln-feed-data
       runAfter:
-      - init
-      - clone-repository
+      - determine-image-tag
       taskSpec:
         steps:
           - name: fetch-vuln-feed-data

--- a/.tekton/scanner-slim-pull-request.yaml
+++ b/.tekton/scanner-slim-pull-request.yaml
@@ -214,6 +214,7 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+
     - name: clone-repository
       params:
       - name: url
@@ -245,6 +246,7 @@ spec:
         workspace: workspace
       - name: basic-auth
         workspace: git-auth
+
     - name: determine-image-tag
       runAfter:
       # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
@@ -330,6 +332,7 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
@@ -359,6 +362,7 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+
     - name: deprecated-base-image-check
       params:
         - name: BASE_IMAGES_DIGESTS
@@ -383,6 +387,7 @@ spec:
         operator: in
         values:
         - "false"
+
     - name: clair-scan
       params:
       - name: image-digest
@@ -405,6 +410,7 @@ spec:
         operator: in
         values:
         - "false"
+
     - name: sast-snyk-check
       runAfter:
       - clone-repository
@@ -425,6 +431,7 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+
     - name: clamav-scan
       params:
       - name: image-digest
@@ -447,6 +454,7 @@ spec:
         operator: in
         values:
         - "false"
+
     - name: sbom-json-check
       params:
       - name: IMAGE_URL

--- a/.tekton/scanner-slim-pull-request.yaml
+++ b/.tekton/scanner-slim-pull-request.yaml
@@ -24,8 +24,8 @@ spec:
     value: '{{repo_url}}'
   - name: image-expires-after
     value: '13w'
-  - name: output-image
-    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-slim:on-pr-{{revision}}
+  - name: output-image-repo
+    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-slim
   - name: path-context
     value: .
   - name: revision
@@ -38,6 +38,10 @@ spec:
     value: 'true'
   - name: build-target-stage
     value: scanner-slim
+  - name: clone-depth
+    value: '0'
+  - name: clone-fetch-tags
+    value: 'true'
 
   workspaces:
   - name: workspace
@@ -96,7 +100,7 @@ spec:
       - name: git-url
         value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
       - name: image-url
-        value: $(params.output-image)
+        value: $(tasks.build-container.results.IMAGE_URL)
       - name: build-task-status
         value: $(tasks.build-container.status)
       workspaces:
@@ -120,8 +124,8 @@ spec:
       description: Revision of the Source Repository
       name: revision
       type: string
-    - description: Fully Qualified Output Image
-      name: output-image
+    - description: Output Image Repository
+      name: output-image-repo
       type: string
     - default: .
       description: Path to the source code of an application's component from where
@@ -192,7 +196,11 @@ spec:
     - name: init
       params:
       - name: image-url
-        value: $(params.output-image)
+        # We can't provide a real tag because it is not known at this time.
+        # We still provide a fake tag to the task to comply with the expected input.
+        # Because 'rebuild' is set to true, this has no effect.
+        # TODO(ROX-24116): Apply both Konflux-style and StackRox-style tags to containers
+        value: $(params.output-image-repo):fake-tag
       - name: rebuild
         value: $(params.rebuild)
       - name: skip-checks
@@ -213,9 +221,9 @@ spec:
       - name: revision
         value: $(params.revision)
       - name: depth
-        value: "0"
+        value: "$(params.clone-depth)"
       - name: fetchTags
-        value: "true"
+        value: "$(params.clone-fetch-tags)"
       runAfter:
       - init
       taskRef:
@@ -237,12 +245,21 @@ spec:
         workspace: workspace
       - name: basic-auth
         workspace: git-auth
+    - name: determine-image-tag
+      runAfter:
+      # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
+      - clone-repository
+      taskRef:
+        name: determine-image-tag
+      workspaces:
+      - name: source
+        workspace: workspace
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       runAfter:
-      - clone-repository
+      - determine-image-tag
       taskRef:
         params:
         - name: name
@@ -279,7 +296,7 @@ spec:
     - name: build-container
       params:
       - name: IMAGE
-        value: $(params.output-image)
+        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT
@@ -317,7 +334,7 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: $(tasks.build-container.results.IMAGE_URL)
       - name: BASE_IMAGES
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:

--- a/.tekton/scanner-slim-push.yaml
+++ b/.tekton/scanner-slim-push.yaml
@@ -213,6 +213,7 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+
     - name: clone-repository
       params:
       - name: url
@@ -244,6 +245,7 @@ spec:
         workspace: workspace
       - name: basic-auth
         workspace: git-auth
+
     - name: determine-image-tag
       runAfter:
       # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
@@ -253,6 +255,7 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+
     - name: prefetch-dependencies
       params:
       - name: input
@@ -329,6 +332,7 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
@@ -358,6 +362,7 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+
     - name: deprecated-base-image-check
       params:
         - name: BASE_IMAGES_DIGESTS
@@ -382,6 +387,7 @@ spec:
         operator: in
         values:
         - "false"
+
     - name: clair-scan
       params:
       - name: image-digest
@@ -404,6 +410,7 @@ spec:
         operator: in
         values:
         - "false"
+
     - name: sast-snyk-check
       runAfter:
       - clone-repository
@@ -424,6 +431,7 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+
     - name: clamav-scan
       params:
       - name: image-digest
@@ -446,6 +454,7 @@ spec:
         operator: in
         values:
         - "false"
+
     - name: sbom-json-check
       params:
       - name: IMAGE_URL

--- a/.tekton/scanner-slim-push.yaml
+++ b/.tekton/scanner-slim-push.yaml
@@ -23,8 +23,8 @@ spec:
   - name: image-expires-after
     # TODO(ROX-20230): make release images not expire.
     value: '13w'
-  - name: output-image
-    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-slim:{{revision}}
+  - name: output-image-repo
+    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-slim
   - name: path-context
     value: .
   - name: revision
@@ -37,6 +37,10 @@ spec:
     value: 'true'
   - name: build-target-stage
     value: scanner-slim
+  - name: clone-depth
+    value: '0'
+  - name: clone-fetch-tags
+    value: 'true'
 
   workspaces:
   - name: workspace
@@ -95,7 +99,7 @@ spec:
       - name: git-url
         value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
       - name: image-url
-        value: $(params.output-image)
+        value: $(tasks.build-container.results.IMAGE_URL)
       - name: build-task-status
         value: $(tasks.build-container.status)
       workspaces:
@@ -119,8 +123,8 @@ spec:
       description: Revision of the Source Repository
       name: revision
       type: string
-    - description: Fully Qualified Output Image
-      name: output-image
+    - description: Output Image Repository
+      name: output-image-repo
       type: string
     - default: .
       description: Path to the source code of an application's component from where
@@ -191,7 +195,11 @@ spec:
     - name: init
       params:
       - name: image-url
-        value: $(params.output-image)
+        # We can't provide a real tag because it is not known at this time.
+        # We still provide a fake tag to the task to comply with the expected input.
+        # Because 'rebuild' is set to true, this has no effect.
+        # TODO(ROX-24116): Apply both Konflux-style and StackRox-style tags to containers
+        value: $(params.output-image-repo):fake-tag
       - name: rebuild
         value: $(params.rebuild)
       - name: skip-checks
@@ -212,9 +220,9 @@ spec:
       - name: revision
         value: $(params.revision)
       - name: depth
-        value: "0"
+        value: "$(params.clone-depth)"
       - name: fetchTags
-        value: "true"
+        value: "$(params.clone-fetch-tags)"
       runAfter:
       - init
       taskRef:
@@ -236,12 +244,21 @@ spec:
         workspace: workspace
       - name: basic-auth
         workspace: git-auth
+    - name: determine-image-tag
+      runAfter:
+      # This task must run on a freshly cloned repository to prevent seeing any changes from other tasks.
+      - clone-repository
+      taskRef:
+        name: determine-image-tag
+      workspaces:
+      - name: source
+        workspace: workspace
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       runAfter:
-      - clone-repository
+      - determine-image-tag
       taskRef:
         params:
         - name: name
@@ -278,7 +295,7 @@ spec:
     - name: build-container
       params:
       - name: IMAGE
-        value: $(params.output-image)
+        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT
@@ -316,7 +333,7 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: $(tasks.build-container.results.IMAGE_URL)
       - name: BASE_IMAGES
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:

--- a/.tekton/scanner-slim-push.yaml
+++ b/.tekton/scanner-slim-push.yaml
@@ -274,8 +274,7 @@ spec:
 
     - name: fetch-vuln-feed-data
       runAfter:
-      - init
-      - clone-repository
+      - determine-image-tag
       taskSpec:
         steps:
           - name: fetch-vuln-feed-data


### PR DESCRIPTION
According to https://github.com/stackrox/stackrox/pull/10749.

Produces images like `quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner-slim:2.33.x-57-gc4ce126d08-fast`.