### PR TITLE
fix(ci): reorder gke tags and labels variable expansions

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -66,23 +66,31 @@ create_cluster() {
     if is_OPENSHIFT_CI; then
         require_environment "JOB_NAME"
         require_environment "BUILD_ID"
-        tags="${tags},stackrox-ci-${JOB_NAME:0:50}"
-        tags="${tags/%-/x}"
-        labels="${labels},stackrox-ci-job=${JOB_NAME:0:63}"
-        labels="${labels/%-/x}"
-        labels="${labels},stackrox-ci-build-id=${BUILD_ID:0:63}"
-        labels="${labels/%-/x}"
+        build_num="${BUILD_ID}"
+        job_name="${JOB_NAME}"
     else
         die "Support is missing for this CI environment"
     fi
+
+    # Refresher on bash shell parameter expansion:
+    # https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
+    # ${VAR//./-} : Replaces all "." with a "-"
+    # ${VAR/%-/}  : Deletes the last "-"
+    # ${VAR,,}    : Converts all alphabetic to their lowercase form
+    tags="${tags},stackrox-ci-${job_name:0:50}"
+    tags="${tags//./-}"
+    tags="${tags/%-/}"
+    labels="${labels},stackrox-ci-job=${job_name:0:63}"
+    labels="${labels//./-}"
+    labels="${labels/%-/}"
+    labels="${labels},stackrox-ci-build-id=${build_num:0:63}"
+    labels="${labels//./-}"
+    labels="${labels/%-/}"
 
     if is_in_PR_context; then
         labels="${labels},pr=$(get_PR_number)"
     fi
 
-    # remove . from branch names
-    tags="${tags//./-}"
-    labels="${labels//./-}"
     # lowercase
     tags="${tags,,}"
     labels="${labels,,}"


### PR DESCRIPTION
## Description

If you're really unlucky, you can get a `.` at the end of the `tags` variable, which will be substituted for `-` _after_ we replace the last `-` with `x`.  GKE doesn't allow for `-` at the end of the string, which is why we change the last `-`.

See https://github.com/openshift/release/pull/47789 for a real-world example of this problem.

These changes reorders the shell expansion so we first replace all `.` with `-`, _then_ delete the last `-`.

Cherry-picked from https://github.com/stackrox/scanner/pull/1513

## Testing Performed

Testing the variable expansions:
```sh
# Before
❯ JOB_NAME=rehearse-47789-pull-ci-stackrox-scanner-release-2.32-e2e-tests
❯ tags="stackrox-ci"
❯ tags="${tags},stackrox-ci-${JOB_NAME:0:50}"
❯ echo "${tags}"
stackrox-ci,stackrox-ci-rehearse-47789-pull-ci-stackrox-scanner-release-2.
❯ tags="${tags/%-/x}"
❯ echo "${tags}"
stackrox-ci,stackrox-ci-rehearse-47789-pull-ci-stackrox-scanner-release-2.
❯ tags="${tags//./-}"
❯ echo "${tags}"
stackrox-ci,stackrox-ci-rehearse-47789-pull-ci-stackrox-scanner-release-2-

# After
❯ JOB_NAME=rehearse-47789-pull-ci-stackrox-scanner-release-2.32-e2e-tests
❯ tags="stackrox-ci"
❯ tags="${tags},stackrox-ci-${JOB_NAME:0:50}"
❯ tags="${tags//./-}"
❯ tags="${tags/%-/}"
❯ echo "${tags}"
stackrox-ci,stackrox-ci-rehearse-47789-pull-ci-stackrox-scanner-release-2
```
