### PR TITLE
chore: Swap `TAG_SUFFIX` for `SCANNER_TAG`

### DIFF
--- a/.tekton/scanner-component-pipeline.yaml
+++ b/.tekton/scanner-component-pipeline.yaml
@@ -252,7 +252,7 @@ spec:
       value: $(params.build-target-stage)
     - name: BUILD_ARGS
       value:
-      - TAG_SUFFIX=$(params.output-tag-suffix)
+      - SCANNER_TAG=$(tasks.determine-image-tag.results.image-tag)
     runAfter:
     - prefetch-dependencies
     - fetch-scanner-data

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 endif
 
 ifeq ($(TAG),)
-TAG=$(shell git describe --tags --abbrev=10 --dirty --long)$(TAG_SUFFIX)
+TAG=$(shell git describe --tags --abbrev=10 --dirty --long)
 endif
 
 # Set expiration on Quay.io for non-release tags.

--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.redhat.io/rhel8/postgresql-15:latest AS scanner-db-common
 
+ARG SCANNER_TAG
+
 LABEL \
     com.redhat.license_terms="https://www.redhat.com/agreements" \
     description="Scanner Database Image for Red Hat Advanced Cluster Security for Kubernetes" \
@@ -9,9 +11,7 @@ LABEL \
     source-location="https://github.com/stackrox/scanner" \
     summary="Scanner DB for Red Hat Advanced Cluster Security for Kubernetes" \
     url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
-    # We must set version label to prevent inheriting value set in the base stage.
-    # TODO(ROX-20236): configure injection of dynamic version value when it becomes possible.
-    version="0.0.1-todo"
+    version="$SCANNER_TAG"
 
 USER root
 

--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -11,7 +11,7 @@ LABEL \
     source-location="https://github.com/stackrox/scanner" \
     summary="Scanner DB for Red Hat Advanced Cluster Security for Kubernetes" \
     url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
-    version="$SCANNER_TAG"
+    version="${SCANNER_TAG}"
 
 USER root
 

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_TAG=latest
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 AS builder
 
 ARG SCANNER_TAG
-ENV RELEASE_TAG="$SCANNER_TAG"
+ENV RELEASE_TAG="${SCANNER_TAG}"
 
 ENV GOFLAGS=""
 ENV CI=1
@@ -42,7 +42,7 @@ LABEL \
     source-location="https://github.com/stackrox/scanner" \
     summary="The image scanner for Red Hat Advanced Cluster Security for Kubernetes" \
     url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
-    version="$SCANNER_TAG"
+    version="${SCANNER_TAG}"
 
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -5,8 +5,8 @@ ARG BASE_TAG=latest
 # Compiling scanner binaries and staging repo2cpe and genesis manifests
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 AS builder
 
-ARG TAG_SUFFIX
-ENV TAG_SUFFIX="$TAG_SUFFIX"
+ARG SCANNER_TAG
+ENV RELEASE_TAG="$SCANNER_TAG"
 
 ENV GOFLAGS=""
 ENV CI=1
@@ -31,6 +31,8 @@ COPY ./blob-genesis_manifests.json image/scanner/dump/genesis_manifests.json
 # Common base for scanner slim and full
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS scanner-common
 
+ARG SCANNER_TAG
+
 LABEL \
     com.redhat.license_terms="https://www.redhat.com/agreements" \
     description="This image supports image scanning for Red Hat Advanced Cluster Security for Kubernetes" \
@@ -40,9 +42,7 @@ LABEL \
     source-location="https://github.com/stackrox/scanner" \
     summary="The image scanner for Red Hat Advanced Cluster Security for Kubernetes" \
     url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
-    # We must set version label to prevent inheriting value set in the base stage.
-    # TODO(ROX-20236): configure injection of dynamic version value when it becomes possible.
-    version="0.0.1-todo"
+    version="$SCANNER_TAG"
 
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
When looking at collector (<https://github.com/stackrox/collector/pull/1694>), I realized I did a bit of mess in my earlier <https://github.com/stackrox/scanner/pull/1527>.

Here I get rid of `TAG_SUFFIX` variable and inject the full tag via `RELEASE_TAG` environment variable. See
https://github.com/stackrox/scanner/blob/631dea9898c3c69f18ea3c45dd66e733cd616905/Makefile#L13-L21

I also inject a value into the `version` label in all four built containers. Similar to <https://github.com/stackrox/collector/pull/1694>, if/when we'll need to re-tag, we will take care of the label then. Mentioned that in ROX-24468.

Testing:
- [x] 4 Konflux-built images still have `-fast` in the tag.
- [x] 4 Konflux-built images have `-fast` in `version` label.
- [x] GHA-built images don't have `-fast` in tag or `label`.
- [x] Konflux-built scanner and slim-scanner have `-fast` version in `github.com/stackrox/scanner/pkg/version.Version`.

For the last item, smoke-tested build, seeing proper thing in logs:
```
{"Event":"Running Scanner version: 2.33.x-80-gc60f8fc954-fast","Level":"info","Location":"main.go:293","Time":"2024-06-05 17:39:50.747575"}
```
and
```
{"Event":"Running Scanner version 2.33.x-80-gc60f8fc954-fast in Node Inventory mode","Level":"info","Location":"main.go:280","Time":"2024-06-05 17:43:45.267545"}
```
Both image and node scanning seem to work.