### PR TITLE
Bump docker/docker targeting ACS 4.4.3 (scanner 2.33.5)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/containers/ocicrypt v1.1.9 // indirect
 	github.com/containers/storage v1.51.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
-	github.com/docker/docker v24.0.7+incompatible // indirect
+	github.com/docker/docker v24.0.9+incompatible // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v24.0.7+incompatible h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM=
-github.com/docker/docker v24.0.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.9+incompatible h1:HPGzNmwfLZWdxHqK9/II92pyi1EpYKsAqcl4G0Of9v0=
+github.com/docker/docker v24.0.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU5CAUmr9zpesgbU6SWc8/B4mflAE4=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 h1:iFaUwBSo5Svw6L7HYpRu/0lE3e0BaElwnNO1qkNQxBY=


### PR DESCRIPTION
Bumps docker/docker to address:
```
+--------------------------------+----------------------+----------------+-----------+---------------------+----------------------------------------------------------------------------+
|           COMPONENT            |       VERSION        |      CVE       | SEVERITY  |    FIXED VERSION    |                                    LINK                                    |
+--------------------------------+----------------------+----------------+-----------+---------------------+----------------------------------------------------------------------------+
|    github.com/docker/docker    | v24.0.6+incompatible | CVE-2024-24557 | MODERATE  |       24.0.9        |    https://github.com/moby/moby/security/advisories/GHSA-xw73-rw38-6vjc    |
+--------------------------------+----------------------+----------------+-----------+---------------------+----------------------------------------------------------------------------+
```

Attn reviewers, this is a transitive dep:

```
$ go mod why -m github.com/docker/docker
# github.com/docker/docker
github.com/stackrox/scanner/pkg/scan
github.com/containers/image/v5/manifest
github.com/docker/docker/api/types/versions
```

An alternative is to bump `github.com/container/images/v5` to `v5.30.1+`.