### PR TITLE
ROX-20855: Reduce container user permissions over `docker-entrypoint.sh`

### DIFF
--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -73,8 +73,6 @@ RUN microdnf upgrade -y --nobest && \
     rpm -e --nodeps $(rpm -qa shadow-utils curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
-    chown postgres:postgres /usr/local/bin/docker-entrypoint.sh && \
-    chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir /docker-entrypoint-initdb.d
 
 # This is equivalent to postgres:postgres.

--- a/image/db/rhel/Dockerfile.slim
+++ b/image/db/rhel/Dockerfile.slim
@@ -73,8 +73,6 @@ RUN microdnf upgrade -y --nobest && \
     rpm -e --nodeps $(rpm -qa shadow-utils curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
-    chown postgres:postgres /usr/local/bin/docker-entrypoint.sh && \
-    chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir /docker-entrypoint-initdb.d
 
 # This is equivalent to postgres:postgres.

--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -19,8 +19,7 @@ COPY image/db/pg_hba.conf \
      image/db/postgresql.conf \
      /etc/
 
-COPY --chown=postgres:postgres \
-     image/db/rhel/scripts/docker-entrypoint.sh \
+COPY image/db/rhel/scripts/docker-entrypoint.sh \
      /usr/local/bin/
 
 RUN dnf upgrade -y --nobest && \
@@ -33,7 +32,6 @@ RUN dnf upgrade -y --nobest && \
     dnf clean all && \
     rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum && \
-    chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir /docker-entrypoint-initdb.d
 
 ENV PG_MAJOR=15 \


### PR DESCRIPTION
There's no need to own executable by `postgres` user, hence removed `chown`.

There's no need to add executable flag because `COPY` statement preserves it and the original file has it, hence removed `chmod`.