### PR TITLE
fix(deps): switch to github.com/anchore/archiver/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -188,6 +188,19 @@ replace (
 
 	github.com/heroku/docker-registry-client => github.com/stackrox/docker-registry-client v0.1.0
 
+	// The current latest version of github.com/mholt/archiver/v3 (v3.5.1) suffers from CVE-2024-0406.
+	// There is currently a PR in place to resolve it (https://github.com/mholt/archiver/pull/396),
+	// but it has not had much attention recently.
+	// Just replace our usage of github.com/mholt/archiver/v3 with github.com/anchore/archiver/v3 (v3.5.2)
+	// so static vulnerability scanners will be happy.
+	// This version (probably) fixes CVE-2024-0406, but we are also unaffected by that vulnerability anyway,
+	// as we do not use [(*archiver.Tar).Unarchive()], so it doesn't really matter.
+	// What is important, though, is the code changes between github.com/mholt/archiver/v3 v3.5.1
+	// and github.com/anchore/archiver/v3 v3.5.2 only touch the [(*archiver.Tar).Unarchive()] path,
+	// and nothing we use. See https://github.com/mholt/archiver/compare/v3.5.1...anchore:archiver:v3.5.2
+	// for more details of the exact difference.
+	github.com/mholt/archiver/v3 => github.com/anchore/archiver/v3 v3.5.2
+
 	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.12-0.20230825152000-1361e2f7db46
 	github.com/stackrox/rox => github.com/stackrox/stackrox v0.0.0-20240402171531-15fa6d254174
 

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/anchore/archiver/v3 v3.5.2 h1:Bjemm2NzuRhmHy3m0lRe5tNoClB9A4zYyDV58PaB6aA=
+github.com/anchore/archiver/v3 v3.5.2/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
@@ -469,8 +471,6 @@ github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Clwo=
-github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=


### PR DESCRIPTION
github.com/mholt/archiver/v3 v3.51.1 is affected by CVE-2024-0406. There is a [PR in-progress](https://github.com/mholt/archiver/pull/396) to resolve this, but it has been rather inactive lately.

We are not affected by this vulnerability, as it affects a codepath which we do not use.

I previously decided to remove the https://github.com/stackrox/scanner/pull/1472 dependency by copying functions over to this repository. However, I ran into issues with CI I have not really been wanting to resolve in that PR, and I believe this approach is safer.

In this approach, we replace github.com/mholt/archiver/v3 v3.51.1 with github.com/anchore/archiver/v3 v3.51.2. See https://github.com/mholt/archiver/compare/v3.5.1...anchore:archiver:v3.5.2 for the exact details. It is clear the only difference is the contents of the previously mentioned PR, which does not affect our codepath.

Note 1: This uses the `replace` directive instead of actually completely replacing the dependency due to annoying circular dependency things with the `stackrox/stackrox` repo.

Note 2: This will not resolve the vulnerability match in the `stackrox/stackrox` repo, as `replace` is only used when the `go.mod` in this repo is the main module. So, we will have to `replace` in the `stackrox/stackrox` repo, too