### PR TITLE
fix: remove directory name duplication in vulnerability data image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -535,7 +535,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: offline-dump
-          path: scanner-vuln-updates.zip
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Description

If you pull `quay.io/stackrox-io/vulnerabilities:latest` right now and check for the vulnerability data, you'll notice the zip file is located at `/srv/scanner-vuln-updates.zip/scanner-vuln-updates.zip`. These changes remove the `scanner-vuln-updates.zip` directory, so the location should be `/srv/scanner-vuln-updates.zip`.