### PR TITLE
chore(e2e): fix Ubuntu openssl test

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3842,7 +3842,7 @@ Applications using RegexRequestMatcher with '.' in the regular expression are po
 						FixedBy: "3.0.2-0ubuntu1.7",
 					},
 				},
-				FixedBy: "3.0.2-0ubuntu1.14",
+				FixedBy: "3.0.2-0ubuntu1.16",
 				// This image installs the openssl pacakge in the second layer;
 				// however, the first layer already installed libssl3 whose source package is openssl.
 				// Therefore, we claim openssl was installed in the first layer.


### PR DESCRIPTION
## Description

Fixes the `TestGRPCGetImageVulnerabilities/quay.io/rhacs-eng/qa:ubuntu-22.04-openssl/openssl/3.0.2-0ubuntu1.6` E2E test.