### PR TITLE
chore: update genesis dump targeting scanner 2.34 (acs 4.5.0)

### DIFF
--- a/image/scanner/dump/genesis_manifests.json
+++ b/image/scanner/dump/genesis_manifests.json
@@ -456,6 +456,11 @@
       "dumpLocationInGS": "gs://stackrox-scanner-ci-vuln-dump/genesis-20240424180825.zip",
       "timestamp": "2024-04-24T18:08:25.500332002Z",
       "uuid": "3460152f-270b-4699-b668-688822016735"
+    },
+    {
+      "dumpLocationInGS": "gs://stackrox-scanner-ci-vuln-dump/genesis-20240701210710.zip",
+      "timestamp": "2024-07-01T21:07:10.04154886Z",
+      "uuid": "fb5a20c3-7c89-42da-a7ef-4678261a096f"
     }
   ]
 }

--- a/image/scanner/dump/genesis_manifests.json
+++ b/image/scanner/dump/genesis_manifests.json
@@ -458,8 +458,8 @@
       "uuid": "3460152f-270b-4699-b668-688822016735"
     },
     {
-      "dumpLocationInGS": "gs://stackrox-scanner-ci-vuln-dump/genesis-20240701210710.zip",
-      "timestamp": "2024-07-01T21:07:10.04154886Z",
+      "dumpLocationInGS": "gs://stackrox-scanner-ci-vuln-dump/genesis-20240705155444.zip",
+      "timestamp": "2024-07-05T15:54:44.983462899Z",
       "uuid": "fb5a20c3-7c89-42da-a7ef-4678261a096f"
     }
   ]


### PR DESCRIPTION
Based of the dump from this run: https://github.com/stackrox/scanner/actions/runs/9810783119