### PR TITLE
chore: update status of Debian 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,18 @@ simple add the `generate-dumps-on-pr` label to your PR.
 DB integration tests also run in CI upon every commit.
 However, to test these locally, be sure to [install PostgreSQL 12](https://postgresapp.com/downloads.html)
 and run it prior to running the tests.
+
+## Updating the StackRox feed
+
+Currently, the StackRox GCS bucket contains vulnerabilities for old Debian releases.
+To add to this:
+
+* Find the latest genesis dump which contains vulnerabilities for the Debian version in question.
+  * For example: https://github.com/stackrox/scanner/actions/runs/9730826138
+* Download the `genesis-dump`
+* Unzip it then run the following (change the version, as needed):
+  * `cat os_vulns.json | jq '[ .[] | select(.Namespace != null) | select(.Namespace.Name == "debian:10") ]' > debian10.json`
+* Sanity check the number of vulns via (change the version, as needed):
+  * `cat debian10.json | jq length`
+  * This should be a single, large number (tens of thousands)
+* Upload to the `stackrox-scanner-feed` bucket

--- a/pkg/wellknownnamespaces/set.go
+++ b/pkg/wellknownnamespaces/set.go
@@ -7,6 +7,7 @@ var (
 	KnownStaleNamespaces = set.NewFrozenStringSet(
 		"debian:8",
 		"debian:9",
+		"debian:10",
 		"ubuntu:12.04",
 		"ubuntu:12.10",
 		"ubuntu:13.04",
@@ -57,7 +58,6 @@ var (
 		"centos:6",
 		"centos:7",
 		"centos:8",
-		"debian:10",
 		"debian:11",
 		"debian:12",
 		"debian:unstable",


### PR DESCRIPTION
Debian 10 is no longer supported, so move into the stale state. Debian 10 vulns were uploaded to the StackRox GCS bucket