### PR TITLE
chore: revive legacy NVD feed and make toggleable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,6 +158,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'generate-dumps-on-pr')
     env:
       NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+      ROX_LEGACY_NVD_LOADER: true
     runs-on: ubuntu-latest
     needs:
       - pre-build-updater

--- a/pkg/env/list.go
+++ b/pkg/env/list.go
@@ -40,4 +40,8 @@ var (
 
 	// MaxGrpcConcurrentStreams configures the maximum number of HTTP/2 streams to use with gRPC
 	MaxGrpcConcurrentStreams = RegisterIntegerSetting("ROX_GRPC_MAX_CONCURRENT_STREAMS", DefaultMaxGrpcConcurrentStreams)
+
+	// LegacyNVDLoader when true will cause the loader to pull NVD data using
+	// the NVD Legacy Data Feeds, if false will pull from the NVD 2.0 API.
+	LegacyNVDLoader = RegisterBooleanSetting("ROX_LEGACY_NVD_LOADER", false)
 )

--- a/pkg/vulnloader/nvdloader/loader_legacy.go
+++ b/pkg/vulnloader/nvdloader/loader_legacy.go
@@ -1,0 +1,130 @@
+package nvdloader
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+	"github.com/facebookincubator/nvdtools/wfn"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/scanner/pkg/vulndump"
+	"github.com/stackrox/scanner/pkg/vulnloader"
+)
+
+var _ vulnloader.Loader = (*legacyLoader)(nil)
+
+type legacyLoader struct{}
+
+// DownloadFeedsToPath downloads the NVD feeds to the given path.
+// If this function is successful, it will fill the directory with
+// one json file for each year of NVD data.
+func (l *legacyLoader) DownloadFeedsToPath(outputDir string) error {
+	log.Info("Downloading NVD data using Legacy Data Feed")
+
+	// Fetch NVD enrichment data from curated repos
+	enrichmentMap, err := Fetch()
+	if err != nil {
+		return errors.Wrap(err, "could not fetch NVD enrichment sources")
+	}
+
+	nvdDir := filepath.Join(outputDir, vulndump.NVDDirName)
+	if err := os.MkdirAll(nvdDir, 0755); err != nil {
+		return errors.Wrapf(err, "creating subdir for %s", vulndump.NVDDirName)
+	}
+	endYear := time.Now().Year()
+	for year := 2002; year <= endYear; year++ {
+		if err := l.downloadFeedForYear(enrichmentMap, nvdDir, year); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *legacyLoader) removeInvalidCPEs(item *schema.NVDCVEFeedJSON10DefNode) {
+	cpeMatches := item.CPEMatch[:0]
+	for _, cpeMatch := range item.CPEMatch {
+		if cpeMatch.Cpe23Uri == "" {
+			cpeMatches = append(cpeMatches, cpeMatch)
+			continue
+		}
+		attr, err := wfn.UnbindFmtString(cpeMatch.Cpe23Uri)
+		if err != nil {
+			log.Errorf("error parsing %+v", item)
+			continue
+		}
+		if attr.Product == wfn.Any {
+			log.Warnf("Filtering out CPE: %+v", attr)
+			continue
+		}
+		cpeMatches = append(cpeMatches, cpeMatch)
+	}
+	item.CPEMatch = cpeMatches
+	for _, child := range item.Children {
+		l.removeInvalidCPEs(child)
+	}
+}
+
+func (l *legacyLoader) downloadFeedForYear(enrichmentMap map[string]*FileFormatWrapper, outputDir string, year int) error {
+	url := l.jsonFeedURLForYear(year)
+	resp, err := client.Get(url)
+	if err != nil {
+		return errors.Wrapf(err, "failed to download feed for year %d", year)
+	}
+	defer utils.IgnoreError(resp.Body.Close)
+	// Un-gzip it.
+	gr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't read resp body for year %d", year)
+	}
+
+	// Strip out tabs and newlines for size savings
+	dump, err := LoadJSONFileFromReader(gr)
+	if err != nil {
+		return errors.Wrapf(err, "could not decode json for year %d", year)
+	}
+
+	cveItems := dump.CVEItems[:0]
+	for _, item := range dump.CVEItems {
+		if _, ok := manuallyEnrichedVulns[item.CVE.CVEDataMeta.ID]; ok {
+			log.Warnf("Skipping vuln %s because it is being manually enriched", item.CVE.CVEDataMeta.ID)
+			continue
+		}
+		for _, node := range item.Configurations.Nodes {
+			l.removeInvalidCPEs(node)
+		}
+		if enrichedEntry, ok := enrichmentMap[item.CVE.CVEDataMeta.ID]; ok {
+			// Add the CPE matches instead of removing for backwards compatibility purposes
+			item.Configurations.Nodes = append(item.Configurations.Nodes, &schema.NVDCVEFeedJSON10DefNode{
+				CPEMatch: enrichedEntry.AffectedPackages,
+				Operator: "OR",
+			})
+			item.LastModifiedDate = enrichedEntry.LastUpdated
+		}
+		cveItems = append(cveItems, item)
+	}
+	for _, item := range manuallyEnrichedVulns {
+		cveItems = append(cveItems, item)
+	}
+	dump.CVEItems = cveItems
+
+	outF, err := os.Create(filepath.Join(outputDir, fmt.Sprintf("%d.json", year)))
+	if err != nil {
+		return errors.Wrap(err, "failed to create file")
+	}
+	defer utils.IgnoreError(outF.Close)
+
+	if err := json.NewEncoder(outF).Encode(&dump); err != nil {
+		return errors.Wrapf(err, "could not encode json map for year %d", year)
+	}
+	return nil
+}
+
+func (l *legacyLoader) jsonFeedURLForYear(year int) string {
+	return fmt.Sprintf("https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz", year)
+}


### PR DESCRIPTION
Revives the old NVD loader that pulls from the NVD legacy feeds, and makes it configurable.

The code was largely copied from the version just before this PR: https://github.com/stackrox/scanner/pull/1329 with the following changes:
- Moved methods into a new `legacyLoader` (instead of package level) to avoid conflicts with the NVD 2.0 API `loader`
- Added the `ROX_LEGACY_NVD_LOADER` env var that when `true` will cause the legacy loader to be used, otherwise the NVD 2.0 loader. 

## Testing:
Ran updater locally:

_output trimmed for brevity_
```
$ ./bin/updater generate-dump --out-file image/scanner/dump/dump.zip
INFO[0000] Using temp dir "/var/folders/5n/r7z59gz16v98qlf3mb_d3_gh0000gn/T/vuln-updater3499419215" for scratch space 
INFO[0000] Downloading istio...                         
INFO[0000] Downloading k8s...                           
INFO[0000] Downloading nvd...                           
INFO[0000] Downloading NVD data using Legacy Data Feed  
WARN[0006] Skipping vuln CVE-2017-5638 because it is being manually enriched 
WARN[0009] Skipping vuln CVE-2021-41411 because it is being manually enriched 
WARN[0009] Skipping vuln CVE-2021-44228 because it is being manually enriched 
WARN[0009] Skipping vuln CVE-2021-45046 because it is being manually enriched 
WARN[0009] Skipping vuln CVE-2021-45105 because it is being manually enriched 
WARN[0010] Skipping vuln CVE-2022-0811 because it is being manually enriched 
WARN[0010] Skipping vuln CVE-2022-22963 because it is being manually enriched 
WARN[0010] Skipping vuln CVE-2022-22965 because it is being manually enriched 
WARN[0010] Skipping vuln CVE-2022-22978 because it is being manually enriched 
WARN[0010] Filtering out CPE: wfn:[part="h",vendor="intel",product=ANY,version=ANY,update=ANY,edition=ANY,language=ANY] 
WARN[0011] Filtering out CPE: wfn:[part="h",vendor="amd",product=ANY,version=ANY,update=ANY,edition=ANY,language=ANY] 
WARN[0011] Skipping vuln CVE-2023-32697 because it is being manually enriched 
WARN[0011] Skipping vuln CVE-2023-38545 because it is being manually enriched 
WARN[0011] Skipping vuln CVE-2023-38546 because it is being manually enriched 
WARN[0011] Skipping vuln CVE-2023-39325 because it is being manually enriched 
WARN[0011] Skipping vuln CVE-2023-44487 because it is being manually enriched 
INFO[0011] Downloading redhat...                        
INFO[0020] Fetching RHEL OVAL v2 vulns...               
INFO[0061] Finished fetching RHEL OVAL v2 vulns (total: 90324) 
INFO[0061] Fetching OS vulns...                         
INFO[0061] fetching vulnerability updates               
INFO[0061] Start fetching vulnerabilities                package=RHEL
INFO[0061] RHEL: fetching bulk OVAL URIs                
INFO[0061] Start fetching vulnerabilities                package="Amazon Linux 2"
INFO[0061] Start fetching vulnerabilities                package=StackRox
INFO[0061] Start fetching vulnerabilities                package=Debian
INFO[0061] Start fetching vulnerabilities                package=Ubuntu
INFO[0061] Start fetching vulnerabilities                package="Amazon Linux 2018.03"
INFO[0061] Start fetching vulnerabilities                package=Alpine
INFO[0061] running git clone to /var/folders/5n/r7z59gz16v98qlf3mb_d3_gh0000gn/T/ubuntu-cve-tracker2384428766  updater=ubuntu
INFO[0062] finished fetching                             updater name=debian
INFO[0063] finished fetching                             updater name=amzn2
INFO[0063] finished fetching                             updater name=amzn1
...
INFO[0107] Finished fetching OS vulns (total: 494831)   
INFO[0107] Writing JSON file for updated OS vulns...    
INFO[0111] Writing manifest file...                     
INFO[0111] Zipping up the files...                      
INFO[0135] Done writing the zip with the entire vuln dump! 
```
Note the `INFO[0000] Downloading NVD data using Legacy Data Feed` line

<details>
<summary>Ran `print-stats` which doesn't reflect NVD data but here for comparison:</summary>

```
$ ./bin/updater print-stats ./image/scanner/dump/dump.zip 
Vuln counts by namespace:
alpine:edge	5822
alpine:v3.10	2155
alpine:v3.11	2440
alpine:v3.12	2990
alpine:v3.13	3443
alpine:v3.14	3992
alpine:v3.15	4519
alpine:v3.16	4962
alpine:v3.17	5229
alpine:v3.18	5696
alpine:v3.19	5805
alpine:v3.2	303
alpine:v3.20	5820
alpine:v3.3	431
alpine:v3.4	607
alpine:v3.5	802
alpine:v3.6	963
alpine:v3.7	1349
alpine:v3.8	1542
alpine:v3.9	1790
amzn:2	4968
amzn:2018.03	6045
centos:6	14757
centos:7	12164
centos:8	8270
debian:10	29214
debian:11	29396
debian:12	28163
debian:13	27751
debian:8	23774
debian:9	26605
debian:unstable	31800
ubuntu:12.04	10845
ubuntu:12.10	3798
ubuntu:13.04	2677
ubuntu:14.04	17272
ubuntu:14.10	2671
ubuntu:15.04	4279
ubuntu:15.10	3997
ubuntu:16.04	18150
ubuntu:16.10	5032
ubuntu:17.04	4953
ubuntu:17.10	3820
ubuntu:18.04	15404
ubuntu:18.10	5372
ubuntu:19.04	5416
ubuntu:19.10	5083
ubuntu:20.04	13714
ubuntu:20.10	6269
ubuntu:21.04	6712
ubuntu:21.10	7518
ubuntu:22.04	12549
ubuntu:22.10	8367
ubuntu:23.04	9110
ubuntu:23.10	9357
ubuntu:24.04	8899
Total vulns: 494831
```
</details>

<details>
<summary>genesis-dump record counts comparision</summary>
From `nvd` subdir in the genesis dumps

```sh
# From Legacy Data Feed genesis-dump on 2024-07-03T20:46:38.3145323Z
$ ../../count.sh 

Vulns per file:
2002.json = 6783
2003.json = 1567
2004.json = 2721
2005.json = 4780
2006.json = 7156
2007.json = 6594
2008.json = 7190
2009.json = 5054
2010.json = 5231
2011.json = 4875
2012.json = 5906
2013.json = 6794
2014.json = 8996
2015.json = 8761
2016.json = 10563
2017.json = 16994
2018.json = 17366
2019.json = 16998
2020.json = 20500
2021.json = 22885
2022.json = 24866
2023.json = 28340
2024.json = 15186
======
TOTAL: 256106

TOTAL UNIQUE: 255798

Unique vulns by year
1999 1579 
2000 1242 
2001 1556 
2002 2392 
2003 1553 
2004 2707 
2005 4766 
2006 7142 
2007 6580 
2008 7176 
2009 5040 
2010 5217 
2011 4861 
2012 5892 
2013 6780 
2014 8982 
2015 8747 
2016 10549 
2017 16981 
2018 17352 
2019 16984 
2020 20486 
2021 22875 
2022 24856 
2023 28331 
2024 15172 

# From NVD 2.0 API dump on 2024-07-01T21:04:40.7507942Z
Vulns per file:
0.json = 17711
1.json = 20009
10.json = 20009
11.json = 19346
2.json = 20012
3.json = 20012
4.json = 20013
5.json = 20014
6.json = 20014
7.json = 20013
8.json = 20006
9.json = 20014
======
TOTAL: 237173

TOTAL UNIQUE: 237019

Unique vulns by year
2002 2356 
2003 1503 
2004 2644 
2005 4625 
2006 6993 
2007 6458 
2008 7004 
2009 4908 
2010 5047 
2011 4609 
2012 5441 
2013 6175 
2014 8408 
2015 8079 
2016 9271 
2017 14648 
2018 15738 
2019 15516 
2020 18861 
2021 22084 
2022 24030 
2023 27851 
2024 14770 
```
</details>