### PR TITLE
fix(ci): handle release builds in GHA CI workflow

### DIFF
--- a/.github/actions/handle-tagged-build/action.yaml
+++ b/.github/actions/handle-tagged-build/action.yaml
@@ -1,0 +1,10 @@
+name: Handle tagged build
+description: Handle tagged build
+runs:
+  using: composite
+  steps:
+    - name: Handle tagged build
+      run: |
+        source ./scripts/ci/lib.sh
+        handle_gha_tagged_build
+      shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,8 @@ jobs:
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 
+      - uses: ./.github/actions/handle-tagged-build
+
       - name: Build updater (amd64)
         run: make build-updater
 
@@ -82,6 +84,8 @@ jobs:
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
+
+      - uses: ./.github/actions/handle-tagged-build
 
       - name: Build Scanner
         run: make GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} scanner-build-nodeps
@@ -370,6 +374,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: ./.github/actions/job-preamble
+
+      - uses: ./.github/actions/handle-tagged-build
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -705,6 +705,21 @@ handle_release_runs() {
     fi
 }
 
+handle_gha_tagged_build() {
+  if [[ -z "${GITHUB_REF:-}" ]]; then
+        echo "No GITHUB_REF in env"
+        exit 0
+    fi
+    echo "GITHUB_REF: ${GITHUB_REF}"
+    if [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then
+        tag="${GITHUB_REF#refs/tags/*}"
+        echo "This is a tagged build: $tag"
+        echo "RELEASE_TAG=$tag" >> "$GITHUB_ENV"
+    else
+        echo "This is not a tagged build"
+    fi
+}
+
 store_test_results() {
     if [[ "$#" -ne 2 ]]; then
         die "missing args. usage: store_test_results <from> <to>"


### PR DESCRIPTION
## Description

Our `tag` make target relies on the `RELEASE_TAG` environment variable being set to the tag name when we perform a release build. Many of our scripts and processes rely on `make tag` outputting the current string (like the release version). We used to set this environment variable properly in OSCI due to:
https://github.com/stackrox/scanner/blob/372710a6a5dcbd786af68572d2c97b76262cd7f8/scripts/ci/lib.sh#L622
https://github.com/stackrox/scanner/blob/372710a6a5dcbd786af68572d2c97b76262cd7f8/scripts/ci/lib.sh#L696-L706
For these changes, I copied the `stackrox/stackrox` pattern for handling tagged builds in our GitHub Action workflow, which was added in this PR: https://github.com/stackrox/stackrox/pull/4239

Note: This needs to be cherry-picked into the `release-2.34` branch.