### PR TITLE
fix(ci): backport #1561

### DIFF
--- a/.github/actions/handle-tagged-build/action.yaml
+++ b/.github/actions/handle-tagged-build/action.yaml
@@ -1,0 +1,10 @@
+name: Handle tagged build
+description: Handle tagged build
+runs:
+  using: composite
+  steps:
+    - name: Handle tagged build
+      run: |
+        source ./scripts/ci/lib.sh
+        handle_gha_tagged_build
+      shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,8 @@ jobs:
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 
+      - uses: ./.github/actions/handle-tagged-build
+
       - name: Build updater (amd64)
         run: make build-updater
 
@@ -82,6 +84,8 @@ jobs:
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
+
+      - uses: ./.github/actions/handle-tagged-build
 
       - name: Build Scanner
         run: make GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} scanner-build-nodeps
@@ -370,6 +374,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: ./.github/actions/job-preamble
+
+      - uses: ./.github/actions/handle-tagged-build
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -705,6 +705,21 @@ handle_release_runs() {
     fi
 }
 
+handle_gha_tagged_build() {
+  if [[ -z "${GITHUB_REF:-}" ]]; then
+        echo "No GITHUB_REF in env"
+        exit 0
+    fi
+    echo "GITHUB_REF: ${GITHUB_REF}"
+    if [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then
+        tag="${GITHUB_REF#refs/tags/*}"
+        echo "This is a tagged build: $tag"
+        echo "RELEASE_TAG=$tag" >> "$GITHUB_ENV"
+    else
+        echo "This is not a tagged build"
+    fi
+}
+
 store_test_results() {
     if [[ "$#" -ne 2 ]]; then
         die "missing args. usage: store_test_results <from> <to>"


### PR DESCRIPTION
Backporting #1561 to release branch to fix the 'tagging' on release builds currently affecting 4.5.0 (scanner 2.34.0)