### PR TITLE
fix(ci): one more place needs release build tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -453,6 +453,8 @@ jobs:
 
       - uses: ./.github/actions/job-preamble
 
+      - uses: ./.github/actions/handle-tagged-build
+
       - name: Push Scanner and ScannerDB image manifests
         # Skip for external contributions.
         if: |


### PR DESCRIPTION
The `push-manifests` job needs this as well, example using wrong tag: https://github.com/stackrox/scanner/actions/runs/9844546307/job/27180906936