### PR TITLE
fix(vulns): change legacy loader to omit rejected

### DIFF
--- a/pkg/vulnloader/nvdloader/loader_legacy.go
+++ b/pkg/vulnloader/nvdloader/loader_legacy.go
@@ -110,13 +110,16 @@ func (l *legacyLoader) downloadFeedForYear(enrichmentMap map[string]*FileFormatW
 }
 
 func (l *legacyLoader) rejected(item *schema.NVDCVEFeedJSON10DefCVEItem) bool {
-	if item.CVE.Description != nil {
-		for _, desc := range item.CVE.Description.DescriptionData {
-			if strings.HasPrefix(strings.ToLower(desc.Value), rejectedReason) {
-				return true
-			}
+	if item.CVE.Description == nil {
+		return false
+	}
+
+	for _, desc := range item.CVE.Description.DescriptionData {
+		if strings.HasPrefix(strings.ToLower(desc.Value), rejectedReason) {
+			return true
 		}
 	}
+
 	return false
 }
 

--- a/pkg/vulnloader/nvdloader/loader_legacy_test.go
+++ b/pkg/vulnloader/nvdloader/loader_legacy_test.go
@@ -18,8 +18,6 @@ func TestRejected(t *testing.T) {
 		want bool
 		cve  *schema.CVEJSON40
 	}{
-		//{ "nil", nil, false, }, // is assumed that item.CVE exists per current logic
-		//{"no desc", false, &c{CVE: nil}}, // is assumed that item.CVE exists per current logic
 		{"nil desc", false, &c{
 			Description: nil,
 		}},

--- a/pkg/vulnloader/nvdloader/loader_legacy_test.go
+++ b/pkg/vulnloader/nvdloader/loader_legacy_test.go
@@ -1,0 +1,66 @@
+package nvdloader
+
+import (
+	"testing"
+
+	"github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+// shorthand to make code cleaner
+type c = schema.CVEJSON40
+
+func TestRejected(t *testing.T) {
+	l := new(legacyLoader)
+
+	tcs := []struct {
+		desc string
+		want bool
+		cve  *schema.CVEJSON40
+	}{
+		//{ "nil", nil, false, }, // is assumed that item.CVE exists per current logic
+		//{"no desc", false, &c{CVE: nil}}, // is assumed that item.CVE exists per current logic
+		{"nil desc", false, &c{
+			Description: nil,
+		}},
+		{"nil desc data", false, &c{
+			Description: &schema.CVEJSON40Description{
+				DescriptionData: nil,
+			},
+		}},
+		{"empty desc data", false, &c{
+			Description: &schema.CVEJSON40Description{
+				DescriptionData: []*schema.CVEJSON40LangString{},
+			},
+		}},
+		{"not rejected desc", false, &c{
+			Description: &schema.CVEJSON40Description{
+				DescriptionData: []*schema.CVEJSON40LangString{
+					{Value: "very bad"},
+				},
+			},
+		}},
+		{"rejected desc", true, &c{
+			Description: &schema.CVEJSON40Description{
+				DescriptionData: []*schema.CVEJSON40LangString{
+					{Value: rejectedReason + "blah blah"},
+				},
+			},
+		}},
+		{"rejected on second desc", true, &c{
+			Description: &schema.CVEJSON40Description{
+				DescriptionData: []*schema.CVEJSON40LangString{
+					{Value: "blah blah"},
+					{Value: rejectedReason + "blah blah"},
+				},
+			},
+		}},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			item := &schema.NVDCVEFeedJSON10DefCVEItem{CVE: tc.cve}
+			assert.Equal(t, l.rejected(item), tc.want)
+		})
+	}
+
+}


### PR DESCRIPTION
Changes the legacy loader to omit vulns that are 'rejected' based on the vuln desc.

- [ ] Is there a better way to determine this vs. using vuln description?

```

======= genesis-dump-legacy/nvd     <-- BEFORE CHANGE
  total: 256,106
 unique: 255,798 (251,421 for 2002+)
 yearly:
   1999:  1,579
   2000:  1,242
   2001:  1,556
   2002:  2,392
   2003:  1,553
   2004:  2,707
   2005:  4,766
   2006:  7,142
   2007:  6,580
   2008:  7,176
   2009:  5,040
   2010:  5,217
   2011:  4,861
   2012:  5,892
   2013:  6,780
   2014:  8,982
   2015:  8,747
   2016: 10,549
   2017: 16,981
   2018: 17,352
   2019: 16,984
   2020: 20,486
   2021: 22,875
   2022: 24,856
   2023: 28,331
   2024: 15,172

======= genesis-dump-legacy-rejected/nvd      <-- AFTER CHANGE
  total: 242,058
 unique: 241,750 (237,437 for 2002+)
 yearly:
   1999:  1,540
   2000:  1,236
   2001:  1,537
   2002:  2,356
   2003:  1,503
   2004:  2,644
   2005:  4,625
   2006:  6,993
   2007:  6,458
   2008:  7,004
   2009:  4,908
   2010:  5,047
   2011:  4,609
   2012:  5,441
   2013:  6,175
   2014:  8,408
   2015:  8,079
   2016:  9,271
   2017: 14,648
   2018: 15,738
   2019: 15,516
   2020: 18,861
   2021: 22,083
   2022: 24,033
   2023: 27,888
   2024: 15,149


======= genesis-dump-2.0/nvd       <-- NVD 2.0 API OUTPUT (goal for numbers to be close)
  total: 237,173
 unique: 237,019 (237,019 for 2002+)
 yearly:
   2002:  2,356
   2003:  1,503
   2004:  2,644
   2005:  4,625
   2006:  6,993
   2007:  6,458
   2008:  7,004
   2009:  4,908
   2010:  5,047
   2011:  4,609
   2012:  5,441
   2013:  6,175
   2014:  8,408
   2015:  8,079
   2016:  9,271
   2017: 14,648
   2018: 15,738
   2019: 15,516
   2020: 18,861
   2021: 22,084
   2022: 24,030
   2023: 27,851
   2024: 14,770
```