### PR TITLE
fix: add tag resolution for jobs missing it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -541,6 +541,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - uses: ./.github/actions/handle-tagged-build
+
       - uses: actions/download-artifact@v4
         with:
           name: offline-dump
@@ -638,6 +640,8 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/job-preamble
+
+      - uses: ./.github/actions/handle-tagged-build
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -541,8 +541,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: ./.github/actions/handle-tagged-build
-
       - uses: actions/download-artifact@v4
         with:
           name: offline-dump

--- a/scripts/ci/jobs/upload-dumps-for-downstream.sh
+++ b/scripts/ci/jobs/upload-dumps-for-downstream.sh
@@ -37,6 +37,8 @@ upload_dumps_for_downstream() {
         die "Unsupported"
     fi
 
+    info "Using scanner_version: $scanner_version"
+
     destination="gs://definitions.stackrox.io/scanner-data/${scanner_version}/"
 
     info "Uploading dumps"


### PR DESCRIPTION
The `upload-dumps-for-downstream` job did not upload bundles with the appropriate tag - breaking downstream builds.