### PR TITLE
build: Add "appstudio" to the PR branch name filter for Konflux CI

### DIFF
--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs


### PR DESCRIPTION
This should enable Konflux CI on renovate PRs that update task bundles like this one <https://github.com/stackrox/scanner/pull/1575>. Notice its branch name does not mention `konflux` or `rhtap`.

Context: https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1721753985769919

Testing: none, I hope it should just work.