### PR TITLE
chore: Add `^release-` branches for on-push Konflux builds

### DIFF
--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && (target_branch == "master" || target_branch.startsWith("release-"))) || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("^(master|release-.*)$")) || (event == "pull_request" && source_branch.matches("(konflux|appstudio|rhtap)"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && (target_branch == "master" || target_branch.startsWith("release-"))) || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && (target_branch == "master" || target_branch.startsWith("release-"))) || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("^(master|release-.*)$")) || (event == "pull_request" && source_branch.matches("(konflux|appstudio|rhtap)"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && (target_branch == "master" || target_branch.startsWith("release-"))) || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && (target_branch == "master" || target_branch.startsWith("release-"))) || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("^(master|release-.*)$")) || (event == "pull_request" && source_branch.matches("(konflux|appstudio|rhtap)"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && (target_branch == "master" || target_branch.startsWith("release-"))) || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && (target_branch == "master" || target_branch.startsWith("release-"))) || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("^(master|release-.*)$")) || (event == "pull_request" && source_branch.matches("(konflux|appstudio|rhtap)"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && (target_branch == "master" || target_branch.startsWith("release-"))) || (event == "pull_request" && (source_branch.contains("konflux") || source_branch.contains("appstudio") || source_branch.contains("rhtap")))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs


### PR DESCRIPTION
This should enable Konflux builds from release branches for the case when [SCANNER_VERSION](https://github.com/stackrox/stackrox/blob/master/SCANNER_VERSION) points to a tag/commit that was on a release branch, not on `master`.

See also: https://redhat-internal.slack.com/archives/C079XCJEZK6/p1721729454430659?thread_ts=1721678052.993799&cid=C079XCJEZK6

Prerequisite for <https://issues.redhat.com/browse/ROX-24468>.

Available CEL functions are here <https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions>.