### PR TITLE
build: Add Konflux pipeline activation through a label

### DIFF
--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -12,7 +12,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
       (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner

--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -9,7 +9,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("^(master|release-.*)$")) || (event == "pull_request" && source_branch.matches("(konflux|appstudio|rhtap)"))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
+      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
+      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
+      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-db

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -12,7 +12,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
       (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-db

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -9,7 +9,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("^(master|release-.*)$")) || (event == "pull_request" && source_branch.matches("(konflux|appstudio|rhtap)"))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
+      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -12,7 +12,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
       (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-db-slim

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -9,7 +9,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("^(master|release-.*)$")) || (event == "pull_request" && source_branch.matches("(konflux|appstudio|rhtap)"))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
+      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
+      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-db-slim

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
+      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-slim

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -9,7 +9,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("^(master|release-.*)$")) || (event == "pull_request" && source_branch.matches("(konflux|appstudio|rhtap)"))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
+      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -12,7 +12,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
       (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || "konflux-build" in body.pull_request.labels))
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-slim


### PR DESCRIPTION
Once PR is created with some branch name, it may be handy to enable Konflux builds on demand.

Inspiration from <https://pipelinesascode.com/docs/guide/authoringprs/#using-the-body-and-headers-in-a-pipelines-as-code-parameter> and <https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions>.