### PR TITLE
fix: increase image poll timeout

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -41,7 +41,8 @@ class PreSystemTests:
     PreSystemTests - System tests need images.
     """
 
-    POLL_TIMEOUT = 60 * 60
+    # Poll for 2 hours.
+    POLL_TIMEOUT = 120 * 60
 
     def run(self):
         self.poll_for_images()


### PR DESCRIPTION
Previous releases done completely via OpenShift CI take... forever. Increase the image poll time so tests can more reliably pass. This will be backported into `release-2.34` and `release-2.33` once merged.