### PR TITLE
ROX-25723: add ecosystem preflight check

### DIFF
--- a/.tekton/scanner-component-pipeline.yaml
+++ b/.tekton/scanner-component-pipeline.yaml
@@ -515,6 +515,24 @@ spec:
       operator: in
       values: [ "false" ]
 
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-manifest.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: ecosystem-cert-preflight-checks
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+
   - name: sast-snyk-check
     params:
     - name: SOURCE_ARTIFACT

--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -26,6 +26,8 @@ COPY image/db/pg_hba.conf \
 COPY image/db/rhel/scripts/docker-entrypoint.sh \
      /usr/local/bin/
 
+COPY LICENSE /licenses/LICENSE
+
 RUN dnf upgrade -y --nobest && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     mkdir -p /var/lib/postgresql && \

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -59,6 +59,8 @@ COPY --from=builder /src/image/scanner/bin/scanner ./
 COPY --chown=65534:65534 --from=builder "/src/image/scanner/dump${REPO_TO_CPE_DIR}/" ".${REPO_TO_CPE_DIR}/"
 COPY --chown=65534:65534 --from=builder /src/image/scanner/dump/genesis_manifests.json ./
 
+COPY LICENSE /licenses/LICENSE
+
 RUN microdnf upgrade --nobest && \
     microdnf install xz && \
     microdnf clean all && \


### PR DESCRIPTION
Validated that new check passes (except for the known issue of missing labels on multi-arch images due to KFLUXBUGS-1495). 