### PR TITLE
chore: remove github.com/golang/protobuf direct dep

### DIFF
--- a/e2etests/components_test.go
+++ b/e2etests/components_test.go
@@ -10,17 +10,17 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/golang/protobuf/jsonpb"
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func loadExpectedComponentResponse(filePath string, t *testing.T) map[string]*v1.LanguageLevelComponents {
-	f, err := os.Open(filePath)
+	f, err := os.ReadFile(filePath)
 	require.NoError(t, err)
 	var resp v1.GetLanguageLevelComponentsResponse
-	require.NoError(t, jsonpb.Unmarshal(f, &resp))
+	require.NoError(t, protojson.Unmarshal(f, &resp))
 	return resp.GetLayerToComponents()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.12.0
-	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20210315223345-82c243799c99
@@ -95,6 +94,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/certificate-transparency-go v1.2.1 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect


### PR DESCRIPTION
This repository is deprecated, so this PR replaces its last remaining use with `google.golang.org/protobuf`.