### PR TITLE
fix(e2e): Bump fixed by due to RHSA-2024:6783

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -3511,7 +3511,7 @@ var testCases = []testCase{
 				NamespaceName: "rhel:9",
 				Version:       "1:3.0.1-23.el9_0.x86_64",
 				VersionFormat: "rpm",
-				FixedBy:       "1:3.0.7-27.el9",
+				FixedBy:       "1:3.0.7-28.el9_4",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "RHSA-2022:7288",
@@ -3553,7 +3553,7 @@ For more details about the security issue(s), including the impact, a CVSS score
 				NamespaceName: "rhel:9",
 				Version:       "1:3.0.1-23.el9_0.x86_64",
 				VersionFormat: "rpm",
-				FixedBy:       "1:3.0.7-27.el9",
+				FixedBy:       "1:3.0.7-28.el9_4"",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "RHSA-2022:7288",


### PR DESCRIPTION
Update e2e tests to account for [RHSA-2024:6783](https://access.redhat.com/errata/RHSA-2024:6783.html) which bumps the "fixed by" to `1:3.0.7-28.el9_4` for `openssl` and `openssl-libs`.