### PR TITLE
chore: track cups vulns

### DIFF
--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -4371,13 +4371,13 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 				VersionFormat: "rpm",
 				Version:       "1.20.0-34.el8.x86_64",
 				AddedBy:       "sha256:7a6d2526dba4ead4120381a83ce344db5959e947aab63fa3d1a3fae4f7986d62",
-				FixedBy:       "",
+				FixedBy:       "0:1.20.0-35.el8_10",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
-						Name:          "CVE-2024-47076",
+						Name:          "RHSA-2024:7463",
 						NamespaceName: "rhel:8",
-						Description:   "DOCUMENTATION: A flaw was found in OpenPrinting CUPS. In certain conditions, a remote attacker can add a malicious printer or directly hijack an existing printer by replacing the valid IPP URL with a malicious one. Also, it is possible that due to a lack of validation of IPP attributes returned by the server, this issue allows attacker-controlled data to be used on the rest of the CUPS system. \n            \n            MITIGATION: See the security bulletin for a detailed mitigation procedure.",
-						Link:          "https://access.redhat.com/security/cve/CVE-2024-47076",
+						Description:   "The cups-filters package contains back ends, filters, and other software that was once part of the core Common UNIX Printing System (CUPS) distribution but is now maintained independently. \n\nSecurity Fix(es):\n\n* cups-browsed: cups-browsed binds on UDP INADDR_ANY:631 trusting any packet from any source ()\n\n* cups-filters: libcupsfilters: `cfGetPrinterAttributes` API does not perform sanitization on returned IPP attributes (CVE-2024-47076)\n\n* cups: libppd: remote command injection via attacker controlled data in PPD file ()\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+						Link:          "https://access.redhat.com/errata/RHSA-2024:7463",
 						Severity:      "Important",
 						FixedBy:       "",
 						Metadata: map[string]interface{}{
@@ -4393,54 +4393,6 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 									"ImpactScore":         4.2,
 									"Score":               8.2,
 									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N",
-								},
-							},
-						},
-					},
-					{
-						Name:          "CVE-2024-47175",
-						NamespaceName: "rhel:8",
-						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nThe ppdCreatePPDFromIPP2 function in libppd doesn't properly check or clean IPP attributes before writing them to a temporary PPD file. This means that a remote attacker, who has control of or has hijacked an exposed printer (through UPD or mDNS), could send a harmful IPP attribute and potentially insert malicious commands into the PPD file. \n            STATEMENT: RHCOS and RHEL include libs-cups as a build-time dependency. However, the vulnerability is not exploitable with just the client libraries unless a print server based on OpenPrinting is actively running.\n\nRHEL and RHCOS does not have cups-browsed enabled by default so the impact for those are set to 'Low'\n            MITIGATION: See the security bulletin for a detailed mitigation procedure.",
-						Link:          "https://access.redhat.com/security/cve/CVE-2024-47175",
-						Severity:      "Important",
-						FixedBy:       "",
-						Metadata: map[string]interface{}{
-							"Red Hat": map[string]interface{}{
-								"CVSSv2": map[string]interface{}{
-									"ExploitabilityScore": 0.0,
-									"ImpactScore":         0.0,
-									"Score":               0.0,
-									"Vectors":             "",
-								},
-								"CVSSv3": map[string]interface{}{
-									"ExploitabilityScore": 2.2,
-									"ImpactScore":         5.5,
-									"Score":               7.7,
-									"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L",
-								},
-							},
-						},
-					},
-					{
-						Name:          "CVE-2024-47176",
-						NamespaceName: "rhel:8",
-						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nA security issue was discovered in OpenPrinting CUPS. The `cups-browsed` component is responsible for discovering printers on a network and adding them to the system. In order to do so, the service uses two distinct protocols. For the first one, the service binds on all interfaces on UDP port 631 and accepts a custom packet from any untrusted source. This is exploitable from outside the LAN if the computer is exposed on the public internet. The service also listens for DNS-SD / mDNS advertisements trough AVAHI. In both cases, when a printer is discovered by either the UDP packet or mDNS, its IPP or IPPS url is automatically contacted by cups-browsed and a `Get-Printer-Attributes` request is sent to it which can leak potentially sensitive system information to an attacker via the User-Agent header. \n            STATEMENT: The cups-browsed service is disabled by default on all versions of RHEL.\n            MITIGATION: See the security bulletin for a detailed mitigation procedure.",
-						Link:          "https://access.redhat.com/security/cve/CVE-2024-47176",
-						Severity:      "Important",
-						FixedBy:       "",
-						Metadata: map[string]interface{}{
-							"Red Hat": map[string]interface{}{
-								"CVSSv2": map[string]interface{}{
-									"ExploitabilityScore": 0.0,
-									"ImpactScore":         0.0,
-									"Score":               0.0,
-									"Vectors":             "",
-								},
-								"CVSSv3": map[string]interface{}{
-									"ExploitabilityScore": 3.9,
-									"ImpactScore":         3.6,
-									"Score":               7.5,
-									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
 								},
 							},
 						},
@@ -4484,7 +4436,10 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 						NamespaceName: "rhel:8",
 						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nThe ppdCreatePPDFromIPP2 function in libppd doesn't properly check or clean IPP attributes before writing them to a temporary PPD file. This means that a remote attacker, who has control of or has hijacked an exposed printer (through UPD or mDNS), could send a harmful IPP attribute and potentially insert malicious commands into the PPD file. \n            STATEMENT: RHCOS and RHEL include libs-cups as a build-time dependency. However, the vulnerability is not exploitable with just the client libraries unless a print server based on OpenPrinting is actively running.\n\nRHEL and RHCOS does not have cups-browsed enabled by default so the impact for those are set to 'Low'\n            MITIGATION: See the security bulletin for a detailed mitigation procedure.",
 						Link:          "https://access.redhat.com/security/cve/CVE-2024-47175",
-						Severity:      "Low",
+						// Note: This SHOULD be Low; however, OVAL data does not say that, at this time.
+						// The CVE page and VEX do, though...
+						// See https://issues.redhat.com/browse/SECDATA-739.
+						Severity:      "Important",
 						FixedBy:       "",
 						Metadata: map[string]interface{}{
 							"Red Hat": map[string]interface{}{

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -4371,7 +4371,7 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 				VersionFormat: "rpm",
 				Version:       "1.20.0-34.el8.x86_64",
 				AddedBy:       "sha256:7a6d2526dba4ead4120381a83ce344db5959e947aab63fa3d1a3fae4f7986d62",
-				FixedBy:       "0:1.20.0-35.el8_10",
+				FixedBy:       "1.20.0-35.el8_10",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "RHSA-2024:7463",
@@ -4379,7 +4379,7 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 						Description:   "The cups-filters package contains back ends, filters, and other software that was once part of the core Common UNIX Printing System (CUPS) distribution but is now maintained independently. \n\nSecurity Fix(es):\n\n* cups-browsed: cups-browsed binds on UDP INADDR_ANY:631 trusting any packet from any source ()\n\n* cups-filters: libcupsfilters: `cfGetPrinterAttributes` API does not perform sanitization on returned IPP attributes (CVE-2024-47076)\n\n* cups: libppd: remote command injection via attacker controlled data in PPD file ()\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
 						Link:          "https://access.redhat.com/errata/RHSA-2024:7463",
 						Severity:      "Important",
-						FixedBy:       "",
+						FixedBy:       "0:1.20.0-35.el8_10",
 						Metadata: map[string]interface{}{
 							"Red Hat": map[string]interface{}{
 								"CVSSv2": map[string]interface{}{
@@ -4589,6 +4589,115 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 									"ImpactScore":         4.0,
 									"Score":               8.6,
 									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		image:                   "quay.io/rhacs-eng/qa:ubuntu18.04-cups-vulns",
+		registry:                "https://quay.io",
+		source:                  "NVD",
+		username:                os.Getenv("QUAY_RHACS_ENG_RO_USERNAME"),
+		password:                os.Getenv("QUAY_RHACS_ENG_RO_PASSWORD"),
+		onlyCheckSpecifiedVulns: true,
+		namespace:               "ubuntu:18.04",
+		expectedFeatures: []apiV1.Feature{
+			{
+				Name:          "cups",
+				NamespaceName: "ubuntu:18.04",
+				VersionFormat: "dpkg",
+				Version:       "2.2.7-1ubuntu2.10",
+				AddedBy:       "sha256:deb4f515230cd51956c71ab9bb67732b471bbe5905e96b9a76b934d4d2cceeb3",
+				FixedBy:       "2.2.7-1ubuntu2.10+esm6",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:          "CVE-2024-47175",
+						NamespaceName: "ubuntu:18.04",
+						Description:   "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
+						Link:          "https://ubuntu.com/security/CVE-2024-47175",
+						Severity:      "Moderate",
+						FixedBy:       "2.2.7-1ubuntu2.10+esm6",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"PublishedDateTime":    "2024-09-26T16:00Z",
+								"LastModifiedDateTime": "2024-10-02T16:00Z",
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 3.9,
+									"ImpactScore":         4.0,
+									"Score":               8.6,
+									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:          "cups-filters",
+				NamespaceName: "ubuntu:18.04",
+				VersionFormat: "dpkg",
+				Version:       "1.20.2-0ubuntu3.3",
+				AddedBy:       "sha256:deb4f515230cd51956c71ab9bb67732b471bbe5905e96b9a76b934d4d2cceeb3",
+				FixedBy:       "1.20.2-0ubuntu3.3+esm1",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:          "CVE-2024-47176",
+						NamespaceName: "ubuntu:18.04",
+						Description:   "Multiple bugs leading to info leak and remote code execution",
+						Link:          "https://ubuntu.com/security/CVE-2024-47176",
+						Severity:      "Moderate",
+						FixedBy:       "1.20.2-0ubuntu3.3+esm1",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"PublishedDateTime":    "2024-09-26T16:00Z",
+								"LastModifiedDateTime": "2024-09-27T16:00Z",
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 1.6,
+									"ImpactScore":         6.0,
+									"Score":               8.3,
+									"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H",
+								},
+							},
+						},
+					},
+					{
+						Name:          "CVE-2024-47177",
+						NamespaceName: "ubuntu:18.04",
+						Description:   "Command injection via FoomaticRIPCommandLine",
+						Link:          "https://ubuntu.com/security/CVE-2024-47177",
+						Severity:      "Moderate",
+						FixedBy:       "",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"PublishedDateTime":    "2024-09-26T16:00Z",
+								"LastModifiedDateTime": "2024-09-27T16:00Z",
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 2.2,
+									"ImpactScore":         6.0,
+									"Score":               9.0,
+									"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
 								},
 							},
 						},

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -4522,7 +4522,7 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 				VersionFormat: "dpkg",
 				Version:       "1.28.17-3",
 				AddedBy:       "sha256:8144b98fa7b4e7cfd356b0be733a31c453f04de4369fd76237d839db8215ed1c",
-				FixedBy:       "",
+				FixedBy:       "1.28.17-3+deb12u1",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "CVE-2024-47076",
@@ -4530,7 +4530,7 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 						Description:   "CUPS is a standards-based, open-source printing system, and `libcupsfilters` contains the code of the filters of the former `cups-filters` package as library functions to be used for the data format conversion tasks needed in Printer Applications. The `cfGetPrinterAttributes5` function in `libcupsfilters` does not sanitize IPP attributes returned from an IPP server. When these IPP attributes are used, for instance, to generate a PPD file, this can lead to attacker controlled data to be provided to the rest of the CUPS system.",
 						Link:          "https://security-tracker.debian.org/tracker/CVE-2024-47076",
 						Severity:      "Important",
-						FixedBy:       "",
+						FixedBy:       "1.28.17-3+deb12u1",
 						Metadata: map[string]interface{}{
 							"NVD": map[string]interface{}{
 								"PublishedDateTime":    "2024-09-26T16:00Z",
@@ -4556,7 +4556,7 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 						Description:   "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL.  Due to the service binding to `*:631 ( INADDR_ANY )`, multiple bugs in `cups-browsed` can be exploited in sequence to introduce a malicious printer to the system. This chain of exploits ultimately enables an attacker to execute arbitrary commands remotely on the target machine without authentication when a print job is started. This poses a significant security risk over the network. Notably, this vulnerability is particularly concerning as it can be exploited from the public internet, potentially exposing a vast number of systems to remote attacks if their CUPS services are enabled.",
 						Link:          "https://security-tracker.debian.org/tracker/CVE-2024-47176",
 						Severity:      "Important",
-						FixedBy:       "",
+						FixedBy:       "1.28.17-3+deb12u1",
 						Metadata: map[string]interface{}{
 							"NVD": map[string]interface{}{
 								"PublishedDateTime":    "2024-09-26T16:00Z",
@@ -4610,7 +4610,7 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 				VersionFormat: "dpkg",
 				Version:       "2.4.2-3+deb12u7",
 				AddedBy:       "sha256:8144b98fa7b4e7cfd356b0be733a31c453f04de4369fd76237d839db8215ed1c",
-				FixedBy:       "",
+				FixedBy:       "2.4.2-3+deb12u8",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{
 						Name:          "CVE-2024-47175",
@@ -4618,7 +4618,7 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 						Description:   "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
 						Link:          "https://security-tracker.debian.org/tracker/CVE-2024-47175",
 						Severity:      "Important",
-						FixedBy:       "",
+						FixedBy:       "2.4.2-3+deb12u8",
 						Metadata: map[string]interface{}{
 							"NVD": map[string]interface{}{
 								"PublishedDateTime":    "2024-09-26T16:00Z",

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -4356,4 +4356,290 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 			},
 		},
 	},
+	{
+		image:                   "quay.io/rhacs-eng/qa:ubi8-cups-vulns",
+		registry:                "https://quay.io",
+		source:                  "NVD",
+		username:                os.Getenv("QUAY_RHACS_ENG_RO_USERNAME"),
+		password:                os.Getenv("QUAY_RHACS_ENG_RO_PASSWORD"),
+		onlyCheckSpecifiedVulns: true,
+		namespace:               "rhel:8",
+		expectedFeatures: []apiV1.Feature{
+			{
+				Name:          "cups-filters",
+				NamespaceName: "rhel:8",
+				VersionFormat: "rpm",
+				Version:       "1.20.0-34.el8.x86_64",
+				AddedBy:       "sha256:7a6d2526dba4ead4120381a83ce344db5959e947aab63fa3d1a3fae4f7986d62",
+				FixedBy:       "",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:          "CVE-2024-47076",
+						NamespaceName: "rhel:8",
+						Description:   `DOCUMENTATION: A flaw was found in OpenPrinting CUPS. In certain conditions, a remote attacker can add a malicious printer or directly hijack an existing printer by replacing the valid IPP URL with a malicious one. Also, it is possible that due to a lack of validation of IPP attributes returned by the server, this issue allows attacker-controlled data to be used on the rest of the CUPS system.`,
+						Link:          "https://access.redhat.com/security/cve/CVE-2024-47076",
+						Severity:      "Important",
+						FixedBy:       "",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 3.9,
+									"ImpactScore":         4.2,
+									"Score":               8.2,
+									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N",
+								},
+							},
+						},
+					},
+					{
+						Name:          "CVE-2024-47175",
+						NamespaceName: "rhel:8",
+						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nThe ppdCreatePPDFromIPP2 function in libppd doesn't properly check or clean IPP attributes before writing them to a temporary PPD file. This means that a remote attacker, who has control of or has hijacked an exposed printer (through UPD or mDNS), could send a harmful IPP attribute and potentially insert malicious commands into the PPD file. \n            STATEMENT: RHCOS and RHEL include libs-cups as a build-time dependency. However, the vulnerability is not exploitable with just the client libraries unless a print server based on OpenPrinting is actively running.\n\nRHEL and RHCOS does not have cups-browsed enabled by default so the impact for those are set to 'Low'",
+						Link:          "https://access.redhat.com/security/cve/CVE-2024-47175",
+						Severity:      "Important",
+						FixedBy:       "",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 2.2,
+									"ImpactScore":         5.5,
+									"Score":               7.7,
+									"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L",
+								},
+							},
+						},
+					},
+					{
+						Name:          "CVE-2024-47176",
+						NamespaceName: "rhel:8",
+						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nA security issue was discovered in OpenPrinting CUPS. The `cups-browsed` component is responsible for discovering printers on a network and adding them to the system. In order to do so, the service uses two distinct protocols. For the first one, the service binds on all interfaces on UDP port 631 and accepts a custom packet from any untrusted source. This is exploitable from outside the LAN if the computer is exposed on the public internet. The service also listens for DNS-SD / mDNS advertisements trough AVAHI. In both cases, when a printer is discovered by either the UDP packet or mDNS, its IPP or IPPS url is automatically contacted by cups-browsed and a `Get-Printer-Attributes` request is sent to it which can leak potentially sensitive system information to an attacker via the User-Agent header. \n            STATEMENT: The cups-browsed service is disabled by default on all versions of RHEL.\n            MITIGATION: The cups-browsed service can be disabled without any impact to printer functionality provided by cups.",
+						Link:          "https://access.redhat.com/security/cve/CVE-2024-47176",
+						Severity:      "Important",
+						FixedBy:       "",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 3.9,
+									"ImpactScore":         3.6,
+									"Score":               7.5,
+									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+								},
+							},
+						},
+					},
+					{
+						Name:          "CVE-2024-47177",
+						NamespaceName: "rhel:8",
+						Description:   "DOCUMENTATION: A security flaw was found in OpenPrinting CUPS. A remote attacker may be able to exploit cups-filters via the `FoomaticRIPCommandLine` entry in the PPD file, which would trigger the CUPS system to execute any arbitrary commands injected into that file when a print job is sent to the affected device.",
+						Link:          "https://access.redhat.com/security/cve/CVE-2024-47177",
+						Severity:      "Important",
+						FixedBy:       "",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 1.3,
+									"ImpactScore":         4.7,
+									"Score":               6.1,
+									"Vectors":             "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:L/I:H/A:L",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:          "cups",
+				NamespaceName: "rhel:8",
+				VersionFormat: "rpm",
+				Version:       "1:2.2.6-60.el8_10.x86_64",
+				AddedBy:       "sha256:7a6d2526dba4ead4120381a83ce344db5959e947aab63fa3d1a3fae4f7986d62",
+				FixedBy:       "",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:          "CVE-2024-47175",
+						NamespaceName: "rhel:8",
+						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nThe ppdCreatePPDFromIPP2 function in libppd doesn't properly check or clean IPP attributes before writing them to a temporary PPD file. This means that a remote attacker, who has control of or has hijacked an exposed printer (through UPD or mDNS), could send a harmful IPP attribute and potentially insert malicious commands into the PPD file. \n            STATEMENT: RHCOS and RHEL include libs-cups as a build-time dependency. However, the vulnerability is not exploitable with just the client libraries unless a print server based on OpenPrinting is actively running.\n\nRHEL and RHCOS does not have cups-browsed enabled by default so the impact for those are set to 'Low'",
+						Link:          "https://access.redhat.com/security/cve/CVE-2024-47175",
+						Severity:      "Low",
+						FixedBy:       "",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 2.2,
+									"ImpactScore":         5.5,
+									"Score":               7.7,
+									"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		image:                   "quay.io/rhacs-eng/qa:debian12-cups-vulns",
+		registry:                "https://quay.io",
+		source:                  "NVD",
+		username:                os.Getenv("QUAY_RHACS_ENG_RO_USERNAME"),
+		password:                os.Getenv("QUAY_RHACS_ENG_RO_PASSWORD"),
+		onlyCheckSpecifiedVulns: true,
+		namespace:               "debian:12",
+		expectedFeatures: []apiV1.Feature{
+			{
+				Name:          "cups-filters",
+				NamespaceName: "debian:12",
+				VersionFormat: "dpkg",
+				Version:       "1.28.17-3",
+				AddedBy:       "sha256:8144b98fa7b4e7cfd356b0be733a31c453f04de4369fd76237d839db8215ed1c",
+				FixedBy:       "",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:          "CVE-2024-47076",
+						NamespaceName: "debian:12",
+						Description:   "CUPS is a standards-based, open-source printing system, and `libcupsfilters` contains the code of the filters of the former `cups-filters` package as library functions to be used for the data format conversion tasks needed in Printer Applications. The `cfGetPrinterAttributes5` function in `libcupsfilters` does not sanitize IPP attributes returned from an IPP server. When these IPP attributes are used, for instance, to generate a PPD file, this can lead to attacker controlled data to be provided to the rest of the CUPS system.",
+						Link:          "https://security-tracker.debian.org/tracker/CVE-2024-47076",
+						Severity:      "Important",
+						FixedBy:       "",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"PublishedDateTime":    "2024-09-26T16:00Z",
+								"LastModifiedDateTime": "2024-09-27T16:00Z",
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 3.9,
+									"ImpactScore":         4.0,
+									"Score":               8.6,
+									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+								},
+							},
+						},
+					},
+					{
+						Name:          "CVE-2024-47176",
+						NamespaceName: "debian:12",
+						Description:   "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL.  Due to the service binding to `*:631 ( INADDR_ANY )`, multiple bugs in `cups-browsed` can be exploited in sequence to introduce a malicious printer to the system. This chain of exploits ultimately enables an attacker to execute arbitrary commands remotely on the target machine without authentication when a print job is started. This poses a significant security risk over the network. Notably, this vulnerability is particularly concerning as it can be exploited from the public internet, potentially exposing a vast number of systems to remote attacks if their CUPS services are enabled.",
+						Link:          "https://security-tracker.debian.org/tracker/CVE-2024-47176",
+						Severity:      "Important",
+						FixedBy:       "",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"PublishedDateTime":    "2024-09-26T16:00Z",
+								"LastModifiedDateTime": "2024-09-27T16:00Z",
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 1.6,
+									"ImpactScore":         6.0,
+									"Score":               8.3,
+									"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H",
+								},
+							},
+						},
+					},
+					{
+						Name:          "CVE-2024-47177",
+						NamespaceName: "debian:12",
+						Description:   "CUPS is a standards-based, open-source printing system, and cups-filters provides backends, filters, and other software for CUPS 2.x to use on non-Mac OS systems. Any value passed to `FoomaticRIPCommandLine` via a PPD file will be executed as a user controlled command. When combined with other logic bugs as described in CVE_2024-47176, this can lead to remote command execution.",
+						Link:          "https://security-tracker.debian.org/tracker/CVE-2024-47177",
+						Severity:      "Important",
+						FixedBy:       "",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"PublishedDateTime":    "2024-09-26T16:00Z",
+								"LastModifiedDateTime": "2024-09-27T16:00Z",
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 2.2,
+									"ImpactScore":         6.0,
+									"Score":               9.0,
+									"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:          "cups",
+				NamespaceName: "debian:12",
+				VersionFormat: "dpkg",
+				Version:       "2.4.2-3+deb12u7",
+				AddedBy:       "sha256:8144b98fa7b4e7cfd356b0be733a31c453f04de4369fd76237d839db8215ed1c",
+				FixedBy:       "",
+				Vulnerabilities: []apiV1.Vulnerability{
+					{
+						Name:          "CVE-2024-47175",
+						NamespaceName: "debian:12",
+						Description:   "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
+						Link:          "https://security-tracker.debian.org/tracker/CVE-2024-47175",
+						Severity:      "Important",
+						FixedBy:       "",
+						Metadata: map[string]interface{}{
+							"NVD": map[string]interface{}{
+								"PublishedDateTime":    "2024-09-26T16:00Z",
+								"LastModifiedDateTime": "2024-09-27T16:00Z",
+								"CVSSv2": map[string]interface{}{
+									"ExploitabilityScore": 0.0,
+									"ImpactScore":         0.0,
+									"Score":               0.0,
+									"Vectors":             "",
+								},
+								"CVSSv3": map[string]interface{}{
+									"ExploitabilityScore": 3.9,
+									"ImpactScore":         4.0,
+									"Score":               8.6,
+									"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 }

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -4359,7 +4359,7 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 	{
 		image:                   "quay.io/rhacs-eng/qa:ubi8-cups-vulns",
 		registry:                "https://quay.io",
-		source:                  "NVD",
+		source:                  "Red Hat",
 		username:                os.Getenv("QUAY_RHACS_ENG_RO_USERNAME"),
 		password:                os.Getenv("QUAY_RHACS_ENG_RO_PASSWORD"),
 		onlyCheckSpecifiedVulns: true,
@@ -4376,12 +4376,12 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 					{
 						Name:          "CVE-2024-47076",
 						NamespaceName: "rhel:8",
-						Description:   `DOCUMENTATION: A flaw was found in OpenPrinting CUPS. In certain conditions, a remote attacker can add a malicious printer or directly hijack an existing printer by replacing the valid IPP URL with a malicious one. Also, it is possible that due to a lack of validation of IPP attributes returned by the server, this issue allows attacker-controlled data to be used on the rest of the CUPS system.`,
+						Description:   "DOCUMENTATION: A flaw was found in OpenPrinting CUPS. In certain conditions, a remote attacker can add a malicious printer or directly hijack an existing printer by replacing the valid IPP URL with a malicious one. Also, it is possible that due to a lack of validation of IPP attributes returned by the server, this issue allows attacker-controlled data to be used on the rest of the CUPS system. \n            \n            MITIGATION: See the security bulletin for a detailed mitigation procedure.",
 						Link:          "https://access.redhat.com/security/cve/CVE-2024-47076",
 						Severity:      "Important",
 						FixedBy:       "",
 						Metadata: map[string]interface{}{
-							"NVD": map[string]interface{}{
+							"Red Hat": map[string]interface{}{
 								"CVSSv2": map[string]interface{}{
 									"ExploitabilityScore": 0.0,
 									"ImpactScore":         0.0,
@@ -4400,12 +4400,12 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 					{
 						Name:          "CVE-2024-47175",
 						NamespaceName: "rhel:8",
-						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nThe ppdCreatePPDFromIPP2 function in libppd doesn't properly check or clean IPP attributes before writing them to a temporary PPD file. This means that a remote attacker, who has control of or has hijacked an exposed printer (through UPD or mDNS), could send a harmful IPP attribute and potentially insert malicious commands into the PPD file. \n            STATEMENT: RHCOS and RHEL include libs-cups as a build-time dependency. However, the vulnerability is not exploitable with just the client libraries unless a print server based on OpenPrinting is actively running.\n\nRHEL and RHCOS does not have cups-browsed enabled by default so the impact for those are set to 'Low'",
+						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nThe ppdCreatePPDFromIPP2 function in libppd doesn't properly check or clean IPP attributes before writing them to a temporary PPD file. This means that a remote attacker, who has control of or has hijacked an exposed printer (through UPD or mDNS), could send a harmful IPP attribute and potentially insert malicious commands into the PPD file. \n            STATEMENT: RHCOS and RHEL include libs-cups as a build-time dependency. However, the vulnerability is not exploitable with just the client libraries unless a print server based on OpenPrinting is actively running.\n\nRHEL and RHCOS does not have cups-browsed enabled by default so the impact for those are set to 'Low'\n            MITIGATION: See the security bulletin for a detailed mitigation procedure.",
 						Link:          "https://access.redhat.com/security/cve/CVE-2024-47175",
 						Severity:      "Important",
 						FixedBy:       "",
 						Metadata: map[string]interface{}{
-							"NVD": map[string]interface{}{
+							"Red Hat": map[string]interface{}{
 								"CVSSv2": map[string]interface{}{
 									"ExploitabilityScore": 0.0,
 									"ImpactScore":         0.0,
@@ -4424,12 +4424,12 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 					{
 						Name:          "CVE-2024-47176",
 						NamespaceName: "rhel:8",
-						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nA security issue was discovered in OpenPrinting CUPS. The `cups-browsed` component is responsible for discovering printers on a network and adding them to the system. In order to do so, the service uses two distinct protocols. For the first one, the service binds on all interfaces on UDP port 631 and accepts a custom packet from any untrusted source. This is exploitable from outside the LAN if the computer is exposed on the public internet. The service also listens for DNS-SD / mDNS advertisements trough AVAHI. In both cases, when a printer is discovered by either the UDP packet or mDNS, its IPP or IPPS url is automatically contacted by cups-browsed and a `Get-Printer-Attributes` request is sent to it which can leak potentially sensitive system information to an attacker via the User-Agent header. \n            STATEMENT: The cups-browsed service is disabled by default on all versions of RHEL.\n            MITIGATION: The cups-browsed service can be disabled without any impact to printer functionality provided by cups.",
+						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nA security issue was discovered in OpenPrinting CUPS. The `cups-browsed` component is responsible for discovering printers on a network and adding them to the system. In order to do so, the service uses two distinct protocols. For the first one, the service binds on all interfaces on UDP port 631 and accepts a custom packet from any untrusted source. This is exploitable from outside the LAN if the computer is exposed on the public internet. The service also listens for DNS-SD / mDNS advertisements trough AVAHI. In both cases, when a printer is discovered by either the UDP packet or mDNS, its IPP or IPPS url is automatically contacted by cups-browsed and a `Get-Printer-Attributes` request is sent to it which can leak potentially sensitive system information to an attacker via the User-Agent header. \n            STATEMENT: The cups-browsed service is disabled by default on all versions of RHEL.\n            MITIGATION: See the security bulletin for a detailed mitigation procedure.",
 						Link:          "https://access.redhat.com/security/cve/CVE-2024-47176",
 						Severity:      "Important",
 						FixedBy:       "",
 						Metadata: map[string]interface{}{
-							"NVD": map[string]interface{}{
+							"Red Hat": map[string]interface{}{
 								"CVSSv2": map[string]interface{}{
 									"ExploitabilityScore": 0.0,
 									"ImpactScore":         0.0,
@@ -4448,12 +4448,12 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 					{
 						Name:          "CVE-2024-47177",
 						NamespaceName: "rhel:8",
-						Description:   "DOCUMENTATION: A security flaw was found in OpenPrinting CUPS. A remote attacker may be able to exploit cups-filters via the `FoomaticRIPCommandLine` entry in the PPD file, which would trigger the CUPS system to execute any arbitrary commands injected into that file when a print job is sent to the affected device.",
+						Description:   "DOCUMENTATION: A security flaw was found in OpenPrinting CUPS. A remote attacker may be able to exploit cups-filters via the `FoomaticRIPCommandLine` entry in the PPD file, which would trigger the CUPS system to execute any arbitrary commands injected into that file when a print job is sent to the affected device. \n            \n            MITIGATION: See the security bulletin for a detailed mitigation procedure.",
 						Link:          "https://access.redhat.com/security/cve/CVE-2024-47177",
 						Severity:      "Important",
 						FixedBy:       "",
 						Metadata: map[string]interface{}{
-							"NVD": map[string]interface{}{
+							"Red Hat": map[string]interface{}{
 								"CVSSv2": map[string]interface{}{
 									"ExploitabilityScore": 0.0,
 									"ImpactScore":         0.0,
@@ -4482,12 +4482,12 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 					{
 						Name:          "CVE-2024-47175",
 						NamespaceName: "rhel:8",
-						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nThe ppdCreatePPDFromIPP2 function in libppd doesn't properly check or clean IPP attributes before writing them to a temporary PPD file. This means that a remote attacker, who has control of or has hijacked an exposed printer (through UPD or mDNS), could send a harmful IPP attribute and potentially insert malicious commands into the PPD file. \n            STATEMENT: RHCOS and RHEL include libs-cups as a build-time dependency. However, the vulnerability is not exploitable with just the client libraries unless a print server based on OpenPrinting is actively running.\n\nRHEL and RHCOS does not have cups-browsed enabled by default so the impact for those are set to 'Low'",
+						Description:   "DOCUMENTATION: A security issue was found in OpenPrinting CUPS.\n\nThe function ppdCreatePPDFromIPP2 in the libppd library is responsible for generating a PostScript Printer Description (PPD) file based on attributes retrieved from an Internet Printing Protocol (IPP) response. Essentially, it takes printer information, usually obtained via IPP, and creates a corresponding PPD file that describes the printer's capabilities (such as supported media sizes, resolutions, color modes, etc.).\n\nPPD files are used by printing systems like CUPS (Common Unix Printing System) to communicate with and configure printers. They provide a standardized format that allows different printers to work with the printing system in a consistent way.\n\nThe ppdCreatePPDFromIPP2 function in libppd doesn't properly check or clean IPP attributes before writing them to a temporary PPD file. This means that a remote attacker, who has control of or has hijacked an exposed printer (through UPD or mDNS), could send a harmful IPP attribute and potentially insert malicious commands into the PPD file. \n            STATEMENT: RHCOS and RHEL include libs-cups as a build-time dependency. However, the vulnerability is not exploitable with just the client libraries unless a print server based on OpenPrinting is actively running.\n\nRHEL and RHCOS does not have cups-browsed enabled by default so the impact for those are set to 'Low'\n            MITIGATION: See the security bulletin for a detailed mitigation procedure.",
 						Link:          "https://access.redhat.com/security/cve/CVE-2024-47175",
 						Severity:      "Low",
 						FixedBy:       "",
 						Metadata: map[string]interface{}{
-							"NVD": map[string]interface{}{
+							"Red Hat": map[string]interface{}{
 								"CVSSv2": map[string]interface{}{
 									"ExploitabilityScore": 0.0,
 									"ImpactScore":         0.0,

--- a/ext/vulnsrc/manual/manual.go
+++ b/ext/vulnsrc/manual/manual.go
@@ -42,7 +42,7 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "1.28.7-1+deb11u3",
 			},
 		},
 		Metadata: map[string]interface{}{
@@ -83,7 +83,7 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "1.28.17-3+deb12u1",
 			},
 		},
 		Metadata: map[string]interface{}{
@@ -124,7 +124,7 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "1.28.17-5",
 			},
 			{
 				Feature: database.Feature{
@@ -134,7 +134,7 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "2.0.0-3",
 			},
 		},
 		Metadata: map[string]interface{}{
@@ -428,7 +428,7 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "2.3.3op2-3+deb11u9",
 			},
 			{
 				Feature: database.Feature{
@@ -438,7 +438,8 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				// Unaffected.
+				Version: versionfmt.MinVersion,
 			},
 		},
 		Metadata: map[string]interface{}{
@@ -479,7 +480,7 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "2.4.2-3+deb12u8",
 			},
 			{
 				Feature: database.Feature{
@@ -489,7 +490,8 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				// Unaffected.
+				Version: versionfmt.MinVersion,
 			},
 		},
 		Metadata: map[string]interface{}{
@@ -530,7 +532,7 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "2.4.10-2",
 			},
 		},
 		Metadata: map[string]interface{}{
@@ -835,7 +837,7 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "1.28.7-1+deb11u3",
 			},
 		},
 		Metadata: map[string]interface{}{
@@ -876,7 +878,7 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "1.28.17-3+deb12u1",
 			},
 		},
 		Metadata: map[string]interface{}{
@@ -917,7 +919,7 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "1.28.17-5",
 			},
 		},
 		Metadata: map[string]interface{}{

--- a/ext/vulnsrc/manual/manual.go
+++ b/ext/vulnsrc/manual/manual.go
@@ -3,6 +3,10 @@ package manual
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/ext/versionfmt"
+	"github.com/stackrox/scanner/ext/versionfmt/apk"
+	"github.com/stackrox/scanner/ext/versionfmt/dpkg"
+	"github.com/stackrox/scanner/ext/versionfmt/rpm"
 	"github.com/stackrox/scanner/ext/vulnsrc"
 )
 
@@ -12,7 +16,1472 @@ type updater struct {
 }
 
 // Vulnerabilities lists vulnerabilities which may not already exist in the feeds for other distros.
-var Vulnerabilities = []database.Vulnerability{}
+var Vulnerabilities = []database.Vulnerability{
+	/********** CVE-2024-47076 **********/
+
+	// Alpine has not made it clear it is affected
+
+	// Amazon claims to be unaffected in versions we support: https://explore.alas.aws.amazon.com/CVE-2024-47076.html
+
+	// Debian 11
+	{
+		Name: "CVE-2024-47076",
+		Namespace: database.Namespace{
+			Name:          "debian:11",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `libcupsfilters` contains the code of the filters of the former `cups-filters` package as library functions to be used for the data format conversion tasks needed in Printer Applications. The `cfGetPrinterAttributes5` function in `libcupsfilters` does not sanitize IPP attributes returned from an IPP server. When these IPP attributes are used, for instance, to generate a PPD file, this can lead to attacker controlled data to be provided to the rest of the CUPS system.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47076",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "debian:11",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Debian 12
+	{
+		Name: "CVE-2024-47076",
+		Namespace: database.Namespace{
+			Name:          "debian:12",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `libcupsfilters` contains the code of the filters of the former `cups-filters` package as library functions to be used for the data format conversion tasks needed in Printer Applications. The `cfGetPrinterAttributes5` function in `libcupsfilters` does not sanitize IPP attributes returned from an IPP server. When these IPP attributes are used, for instance, to generate a PPD file, this can lead to attacker controlled data to be provided to the rest of the CUPS system.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47076",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "debian:12",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Debian unstable
+	{
+		Name: "CVE-2024-47076",
+		Namespace: database.Namespace{
+			Name:          "debian:unstable",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `libcupsfilters` contains the code of the filters of the former `cups-filters` package as library functions to be used for the data format conversion tasks needed in Printer Applications. The `cfGetPrinterAttributes5` function in `libcupsfilters` does not sanitize IPP attributes returned from an IPP server. When these IPP attributes are used, for instance, to generate a PPD file, this can lead to attacker controlled data to be provided to the rest of the CUPS system.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47076",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "debian:unstable",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+			{
+				Feature: database.Feature{
+					Name: "libcupsfilters",
+					Namespace: database.Namespace{
+						Name:          "debian:unstable",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+
+	// Ubuntu 20.04
+	{
+		Name: "CVE-2024-47076",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:20.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "cfGetPrinterAttributes5 does not validate IPP attributes returned from an IPP server",
+		Link:        "https://ubuntu.com/security/CVE-2024-47076",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:20.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: "1.27.4-1ubuntu0.3",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Ubuntu 22.04
+	{
+		Name: "CVE-2024-47076",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:22.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "cfGetPrinterAttributes5 does not validate IPP attributes returned from an IPP server",
+		Link:        "https://ubuntu.com/security/CVE-2024-47076",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:22.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: "1.28.15-0ubuntu1.3",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Ubuntu 24.04
+	{
+		Name: "CVE-2024-47076",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:24.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "cfGetPrinterAttributes5 does not validate IPP attributes returned from an IPP server",
+		Link:        "https://ubuntu.com/security/CVE-2024-47076",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "libcupsfilters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:24.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: "2.0.0-0ubuntu7.1",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+
+	/********** CVE-2024-47175 **********/
+
+	// Alpine 3.19
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "alpine:v3.19",
+			VersionFormat: apk.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
+		Link:        "https://www.cve.org/CVERecord?id=CVE-2024-47175",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "alpine:v3.19",
+						VersionFormat: apk.ParserName,
+					},
+				},
+				Version: "2.4.9-r1",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Alpine 3.20
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "alpine:v3.20",
+			VersionFormat: apk.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
+		Link:        "https://www.cve.org/CVERecord?id=CVE-2024-47175",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "alpine:v3.20",
+						VersionFormat: apk.ParserName,
+					},
+				},
+				Version: "2.4.9-r1",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Alpine edge
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "alpine:edge",
+			VersionFormat: apk.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
+		Link:        "https://www.cve.org/CVERecord?id=CVE-2024-47175",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "alpine:edge",
+						VersionFormat: apk.ParserName,
+					},
+				},
+				Version: "2.4.10-r1",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+
+	// Amazon claims to be unaffected in versions we support: https://explore.alas.aws.amazon.com/CVE-2024-47175.html
+
+	// Debian 11
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "debian:11",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47175",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "debian:11",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+			{
+				Feature: database.Feature{
+					Name: "libppd",
+					Namespace: database.Namespace{
+						Name:          "debian:11",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Debian 12
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "debian:12",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47175",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "debian:12",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+			{
+				Feature: database.Feature{
+					Name: "libppd",
+					Namespace: database.Namespace{
+						Name:          "debian:12",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Debian unstable
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "debian:unstable",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47175",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "debian:unstable",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+
+	// Ubuntu 16.04
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:16.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
+		Link:        "https://ubuntu.com/security/CVE-2024-47175",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:16.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Ubuntu 18.04
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:18.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
+		Link:        "https://ubuntu.com/security/CVE-2024-47175",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:18.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Ubuntu 20.04
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:20.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
+		Link:        "https://ubuntu.com/security/CVE-2024-47175",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:20.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: "2.3.1-9ubuntu1.9",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Ubuntu 22.04
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:22.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
+		Link:        "https://ubuntu.com/security/CVE-2024-47175",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:22.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: "2.4.1op1-1ubuntu4.11",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+	// Ubuntu 24.04
+	{
+		Name: "CVE-2024-47175",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:24.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
+		Link:        "https://ubuntu.com/security/CVE-2024-47175",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:24.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: "2.4.7-1.2ubuntu7.3",
+			},
+			{
+				Feature: database.Feature{
+					Name: "libppd",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:24.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: "2:2.0.0-0ubuntu4.1",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 3.9,
+					"ImpactScore":         4.0,
+					"Score":               8.6,
+					"Vectors":             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N",
+				},
+			},
+		},
+	},
+
+	/********** CVE-2024-47176 **********/
+
+	// Alpine has not made it clear it is affected
+
+	// Amazon Linux 2
+	{
+		Name: "CVE-2024-47176",
+		Namespace: database.Namespace{
+			Name:          "amzn:2",
+			VersionFormat: rpm.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL.",
+		// Amazon currently does not have an ALAS link, so just the source of this data.
+		Link:     "https://explore.alas.aws.amazon.com/CVE-2024-47176.html",
+		Severity: database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "amzn:2",
+						VersionFormat: rpm.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 2.8,
+					"ImpactScore":         3.6,
+					"Score":               6.5,
+					"Vectors":             "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+				},
+			},
+		},
+	},
+
+	// Debian 11
+	{
+		Name: "CVE-2024-47176",
+		Namespace: database.Namespace{
+			Name:          "debian:11",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL.  Due to the service binding to `*:631 ( INADDR_ANY )`, multiple bugs in `cups-browsed` can be exploited in sequence to introduce a malicious printer to the system. This chain of exploits ultimately enables an attacker to execute arbitrary commands remotely on the target machine without authentication when a print job is started. This poses a significant security risk over the network. Notably, this vulnerability is particularly concerning as it can be exploited from the public internet, potentially exposing a vast number of systems to remote attacks if their CUPS services are enabled.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47176",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "debian:11",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 1.6,
+					"ImpactScore":         6.0,
+					"Score":               8.3,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Debian 12
+	{
+		Name: "CVE-2024-47176",
+		Namespace: database.Namespace{
+			Name:          "debian:12",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL.  Due to the service binding to `*:631 ( INADDR_ANY )`, multiple bugs in `cups-browsed` can be exploited in sequence to introduce a malicious printer to the system. This chain of exploits ultimately enables an attacker to execute arbitrary commands remotely on the target machine without authentication when a print job is started. This poses a significant security risk over the network. Notably, this vulnerability is particularly concerning as it can be exploited from the public internet, potentially exposing a vast number of systems to remote attacks if their CUPS services are enabled.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47176",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "debian:12",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 1.6,
+					"ImpactScore":         6.0,
+					"Score":               8.3,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Debian unstable
+	{
+		Name: "CVE-2024-47176",
+		Namespace: database.Namespace{
+			Name:          "debian:unstable",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL.  Due to the service binding to `*:631 ( INADDR_ANY )`, multiple bugs in `cups-browsed` can be exploited in sequence to introduce a malicious printer to the system. This chain of exploits ultimately enables an attacker to execute arbitrary commands remotely on the target machine without authentication when a print job is started. This poses a significant security risk over the network. Notably, this vulnerability is particularly concerning as it can be exploited from the public internet, potentially exposing a vast number of systems to remote attacks if their CUPS services are enabled.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47176",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "debian:unstable",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 1.6,
+					"ImpactScore":         6.0,
+					"Score":               8.3,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+
+	// Ubuntu 16.04
+	{
+		Name: "CVE-2024-47176",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:16.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "Multiple bugs leading to info leak and remote code execution",
+		Link:        "https://ubuntu.com/security/CVE-2024-47176",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:16.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 1.6,
+					"ImpactScore":         6.0,
+					"Score":               8.3,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Ubuntu 18.04
+	{
+		Name: "CVE-2024-47176",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:18.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "Multiple bugs leading to info leak and remote code execution",
+		Link:        "https://ubuntu.com/security/CVE-2024-47176",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:18.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 1.6,
+					"ImpactScore":         6.0,
+					"Score":               8.3,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Ubuntu 20.04
+	{
+		Name: "CVE-2024-47176",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:20.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "Multiple bugs leading to info leak and remote code execution",
+		Link:        "https://ubuntu.com/security/CVE-2024-47176",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:20.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: "1.27.4-1ubuntu0.3",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 1.6,
+					"ImpactScore":         6.0,
+					"Score":               8.3,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Ubuntu 22.04
+	{
+		Name: "CVE-2024-47176",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:22.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "Multiple bugs leading to info leak and remote code execution",
+		Link:        "https://ubuntu.com/security/CVE-2024-47176",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:22.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: "1.28.15-0ubuntu1.3",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 1.6,
+					"ImpactScore":         6.0,
+					"Score":               8.3,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Ubuntu 24.04
+	{
+		Name: "CVE-2024-47176",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:24.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "Multiple bugs leading to info leak and remote code execution",
+		Link:        "https://ubuntu.com/security/CVE-2024-47176",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-browsed",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:24.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: "2.0.0-0ubuntu10.1",
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 1.6,
+					"ImpactScore":         6.0,
+					"Score":               8.3,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+
+	/********** CVE-2024-47177 **********/
+
+	// Alpine has not made it clear it is affected
+
+	// Amazon claims to be unaffected in versions we support: https://explore.alas.aws.amazon.com/CVE-2024-47177.html
+
+	// Debian 11
+	{
+		Name: "CVE-2024-47177",
+		Namespace: database.Namespace{
+			Name:          "debian:11",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and cups-filters provides backends, filters, and other software for CUPS 2.x to use on non-Mac OS systems. Any value passed to `FoomaticRIPCommandLine` via a PPD file will be executed as a user controlled command. When combined with other logic bugs as described in CVE_2024-47176, this can lead to remote command execution.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47177",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "debian:11",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 2.2,
+					"ImpactScore":         6.0,
+					"Score":               9.0,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Debian 12
+	{
+		Name: "CVE-2024-47177",
+		Namespace: database.Namespace{
+			Name:          "debian:12",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and cups-filters provides backends, filters, and other software for CUPS 2.x to use on non-Mac OS systems. Any value passed to `FoomaticRIPCommandLine` via a PPD file will be executed as a user controlled command. When combined with other logic bugs as described in CVE_2024-47176, this can lead to remote command execution.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47177",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "debian:12",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 2.2,
+					"ImpactScore":         6.0,
+					"Score":               9.0,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Debian unstable
+	{
+		Name: "CVE-2024-47177",
+		Namespace: database.Namespace{
+			Name:          "debian:unstable",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "CUPS is a standards-based, open-source printing system, and cups-filters provides backends, filters, and other software for CUPS 2.x to use on non-Mac OS systems. Any value passed to `FoomaticRIPCommandLine` via a PPD file will be executed as a user controlled command. When combined with other logic bugs as described in CVE_2024-47176, this can lead to remote command execution.",
+		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47177",
+		Severity:    database.HighSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "debian:unstable",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 2.2,
+					"ImpactScore":         6.0,
+					"Score":               9.0,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+
+	// Ubuntu 16.04
+	{
+		Name: "CVE-2024-47177",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:16.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "Command injection via FoomaticRIPCommandLine",
+		Link:        "https://ubuntu.com/security/CVE-2024-47177",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:16.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 2.2,
+					"ImpactScore":         6.0,
+					"Score":               9.0,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Ubuntu 18.04
+	{
+		Name: "CVE-2024-47177",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:18.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "Command injection via FoomaticRIPCommandLine",
+		Link:        "https://ubuntu.com/security/CVE-2024-47177",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:18.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 2.2,
+					"ImpactScore":         6.0,
+					"Score":               9.0,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Ubuntu 20.04
+	{
+		Name: "CVE-2024-47177",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:20.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "Command injection via FoomaticRIPCommandLine",
+		Link:        "https://ubuntu.com/security/CVE-2024-47177",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:20.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 2.2,
+					"ImpactScore":         6.0,
+					"Score":               9.0,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Ubuntu 22.04
+	{
+		Name: "CVE-2024-47177",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:22.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "Command injection via FoomaticRIPCommandLine",
+		Link:        "https://ubuntu.com/security/CVE-2024-47177",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:22.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 2.2,
+					"ImpactScore":         6.0,
+					"Score":               9.0,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+	// Ubuntu 24.04
+	{
+		Name: "CVE-2024-47177",
+		Namespace: database.Namespace{
+			Name:          "ubuntu:24.04",
+			VersionFormat: dpkg.ParserName,
+		},
+		Description: "Command injection via FoomaticRIPCommandLine",
+		Link:        "https://ubuntu.com/security/CVE-2024-47177",
+		Severity:    database.MediumSeverity,
+		FixedIn: []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Name: "cups-filters",
+					Namespace: database.Namespace{
+						Name:          "ubuntu:24.04",
+						VersionFormat: dpkg.ParserName,
+					},
+				},
+				Version: versionfmt.MaxVersion,
+			},
+		},
+		Metadata: map[string]interface{}{
+			"NVD": map[string]interface{}{
+				"PublishedDateTime":    "2024-09-26T16:00Z",
+				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"CVSSv2": map[string]interface{}{
+					"ExploitabilityScore": 0.0,
+					"ImpactScore":         0.0,
+					"Score":               0.0,
+					"Vectors":             "",
+				},
+				"CVSSv3": map[string]interface{}{
+					"ExploitabilityScore": 2.2,
+					"ImpactScore":         6.0,
+					"Score":               9.0,
+					"Vectors":             "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+				},
+			},
+		},
+	},
+}
 
 func (u updater) Update(_ vulnsrc.DataStore) (resp vulnsrc.UpdateResponse, _ error) {
 	log.WithField("package", "Manual Entries").Info("Start fetching vulnerabilities")

--- a/ext/vulnsrc/manual/manual.go
+++ b/ext/vulnsrc/manual/manual.go
@@ -49,7 +49,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -91,7 +91,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -143,7 +143,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -452,7 +452,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -505,7 +505,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -547,7 +547,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -859,7 +859,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -901,7 +901,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -943,7 +943,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -1203,7 +1203,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -1245,7 +1245,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -1287,7 +1287,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-09-30T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,

--- a/ext/vulnsrc/manual/manual.go
+++ b/ext/vulnsrc/manual/manual.go
@@ -626,13 +626,13 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "2.2.7-1ubuntu2.10+esm6",
 			},
 		},
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-10-02T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,
@@ -1022,13 +1022,13 @@ var Vulnerabilities = []database.Vulnerability{
 						VersionFormat: dpkg.ParserName,
 					},
 				},
-				Version: versionfmt.MaxVersion,
+				Version: "1.20.2-0ubuntu3.3+esm1",
 			},
 		},
 		Metadata: map[string]interface{}{
 			"NVD": map[string]interface{}{
 				"PublishedDateTime":    "2024-09-26T16:00Z",
-				"LastModifiedDateTime": "2024-09-27T16:00Z",
+				"LastModifiedDateTime": "2024-10-02T16:00Z",
 				"CVSSv2": map[string]interface{}{
 					"ExploitabilityScore": 0.0,
 					"ImpactScore":         0.0,

--- a/ext/vulnsrc/manual/manual.go
+++ b/ext/vulnsrc/manual/manual.go
@@ -32,7 +32,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and `libcupsfilters` contains the code of the filters of the former `cups-filters` package as library functions to be used for the data format conversion tasks needed in Printer Applications. The `cfGetPrinterAttributes5` function in `libcupsfilters` does not sanitize IPP attributes returned from an IPP server. When these IPP attributes are used, for instance, to generate a PPD file, this can lead to attacker controlled data to be provided to the rest of the CUPS system.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47076",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -73,7 +74,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and `libcupsfilters` contains the code of the filters of the former `cups-filters` package as library functions to be used for the data format conversion tasks needed in Printer Applications. The `cfGetPrinterAttributes5` function in `libcupsfilters` does not sanitize IPP attributes returned from an IPP server. When these IPP attributes are used, for instance, to generate a PPD file, this can lead to attacker controlled data to be provided to the rest of the CUPS system.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47076",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -114,7 +116,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and `libcupsfilters` contains the code of the filters of the former `cups-filters` package as library functions to be used for the data format conversion tasks needed in Printer Applications. The `cfGetPrinterAttributes5` function in `libcupsfilters` does not sanitize IPP attributes returned from an IPP server. When these IPP attributes are used, for instance, to generate a PPD file, this can lead to attacker controlled data to be provided to the rest of the CUPS system.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47076",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -166,7 +169,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "cfGetPrinterAttributes5 does not validate IPP attributes returned from an IPP server",
 		Link:        "https://ubuntu.com/security/CVE-2024-47076",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -207,7 +211,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "cfGetPrinterAttributes5 does not validate IPP attributes returned from an IPP server",
 		Link:        "https://ubuntu.com/security/CVE-2024-47076",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -248,7 +253,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "cfGetPrinterAttributes5 does not validate IPP attributes returned from an IPP server",
 		Link:        "https://ubuntu.com/security/CVE-2024-47076",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -418,7 +424,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47175",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -470,7 +477,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47175",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -522,7 +530,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and `libppd` can be used for legacy PPD file support. The `libppd` function `ppdCreatePPDFromIPP2` does not sanitize IPP attributes when creating the PPD buffer. When used in combination with other functions such as `cfGetPrinterAttributes5`, can result in user controlled input and ultimately code execution via Foomatic. This vulnerability can be part of an exploit chain leading to remote code execution (RCE), as described in CVE-2024-47176.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47175",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -564,7 +573,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
 		Link:        "https://ubuntu.com/security/CVE-2024-47175",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -605,7 +615,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
 		Link:        "https://ubuntu.com/security/CVE-2024-47175",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -646,7 +657,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
 		Link:        "https://ubuntu.com/security/CVE-2024-47175",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -687,7 +699,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
 		Link:        "https://ubuntu.com/security/CVE-2024-47175",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -728,7 +741,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "ppdCreatePPDFromIPP2 does not sanitize IPP attributes when creating the PPD buffer",
 		Link:        "https://ubuntu.com/security/CVE-2024-47175",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -785,7 +799,7 @@ var Vulnerabilities = []database.Vulnerability{
 		Description: "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL.",
 		// Amazon currently does not have an ALAS link, so just the source of this data.
 		Link:     "https://explore.alas.aws.amazon.com/CVE-2024-47176.html",
-		Severity: database.HighSeverity,
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -808,6 +822,7 @@ var Vulnerabilities = []database.Vulnerability{
 					"Score":               0.0,
 					"Vectors":             "",
 				},
+				// Amazon used Red Hat's lower score.
 				"CVSSv3": map[string]interface{}{
 					"ExploitabilityScore": 2.8,
 					"ImpactScore":         3.6,
@@ -827,7 +842,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL.  Due to the service binding to `*:631 ( INADDR_ANY )`, multiple bugs in `cups-browsed` can be exploited in sequence to introduce a malicious printer to the system. This chain of exploits ultimately enables an attacker to execute arbitrary commands remotely on the target machine without authentication when a print job is started. This poses a significant security risk over the network. Notably, this vulnerability is particularly concerning as it can be exploited from the public internet, potentially exposing a vast number of systems to remote attacks if their CUPS services are enabled.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47176",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -868,7 +884,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL.  Due to the service binding to `*:631 ( INADDR_ANY )`, multiple bugs in `cups-browsed` can be exploited in sequence to introduce a malicious printer to the system. This chain of exploits ultimately enables an attacker to execute arbitrary commands remotely on the target machine without authentication when a print job is started. This poses a significant security risk over the network. Notably, this vulnerability is particularly concerning as it can be exploited from the public internet, potentially exposing a vast number of systems to remote attacks if their CUPS services are enabled.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47176",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -909,7 +926,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL.  Due to the service binding to `*:631 ( INADDR_ANY )`, multiple bugs in `cups-browsed` can be exploited in sequence to introduce a malicious printer to the system. This chain of exploits ultimately enables an attacker to execute arbitrary commands remotely on the target machine without authentication when a print job is started. This poses a significant security risk over the network. Notably, this vulnerability is particularly concerning as it can be exploited from the public internet, potentially exposing a vast number of systems to remote attacks if their CUPS services are enabled.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47176",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -951,7 +969,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "Multiple bugs leading to info leak and remote code execution",
 		Link:        "https://ubuntu.com/security/CVE-2024-47176",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -992,7 +1011,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "Multiple bugs leading to info leak and remote code execution",
 		Link:        "https://ubuntu.com/security/CVE-2024-47176",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1033,7 +1053,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "Multiple bugs leading to info leak and remote code execution",
 		Link:        "https://ubuntu.com/security/CVE-2024-47176",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1074,7 +1095,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "Multiple bugs leading to info leak and remote code execution",
 		Link:        "https://ubuntu.com/security/CVE-2024-47176",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1115,7 +1137,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "Multiple bugs leading to info leak and remote code execution",
 		Link:        "https://ubuntu.com/security/CVE-2024-47176",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1163,7 +1186,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and cups-filters provides backends, filters, and other software for CUPS 2.x to use on non-Mac OS systems. Any value passed to `FoomaticRIPCommandLine` via a PPD file will be executed as a user controlled command. When combined with other logic bugs as described in CVE_2024-47176, this can lead to remote command execution.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47177",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1204,7 +1228,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and cups-filters provides backends, filters, and other software for CUPS 2.x to use on non-Mac OS systems. Any value passed to `FoomaticRIPCommandLine` via a PPD file will be executed as a user controlled command. When combined with other logic bugs as described in CVE_2024-47176, this can lead to remote command execution.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47177",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1245,7 +1270,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "CUPS is a standards-based, open-source printing system, and cups-filters provides backends, filters, and other software for CUPS 2.x to use on non-Mac OS systems. Any value passed to `FoomaticRIPCommandLine` via a PPD file will be executed as a user controlled command. When combined with other logic bugs as described in CVE_2024-47176, this can lead to remote command execution.",
 		Link:        "https://security-tracker.debian.org/tracker/CVE-2024-47177",
-		Severity:    database.HighSeverity,
+		// Debian did not assign a severity, so basing this on the score.
+		Severity: database.HighSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1287,7 +1313,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "Command injection via FoomaticRIPCommandLine",
 		Link:        "https://ubuntu.com/security/CVE-2024-47177",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1328,7 +1355,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "Command injection via FoomaticRIPCommandLine",
 		Link:        "https://ubuntu.com/security/CVE-2024-47177",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1369,7 +1397,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "Command injection via FoomaticRIPCommandLine",
 		Link:        "https://ubuntu.com/security/CVE-2024-47177",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1410,7 +1439,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "Command injection via FoomaticRIPCommandLine",
 		Link:        "https://ubuntu.com/security/CVE-2024-47177",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
@@ -1451,7 +1481,8 @@ var Vulnerabilities = []database.Vulnerability{
 		},
 		Description: "Command injection via FoomaticRIPCommandLine",
 		Link:        "https://ubuntu.com/security/CVE-2024-47177",
-		Severity:    database.MediumSeverity,
+		// Ubuntu gave this a severity lower than the severity derived from the CVSS score.
+		Severity: database.MediumSeverity,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -1,5 +1,6 @@
 e2etests/testcase_test.go
 ext/featurefmt/rpm/testdata/Packages
+ext/vulnsrc/manual/manual.go
 generated/**/*.pb.go
 go.sum
 pkg/rhelv2/ovalutil/testdata/oval.xml


### PR DESCRIPTION
Add entries for the recent CUPs vulnerabilities. The scores are from what NVD has now, which is from GitHub, except for Amazon which just uses Red Hat's scores. The main sources of this data are from the vendors, themselves, as well as NVD (kind of)