### PR TITLE
build: Drop clamav-scan resource requests

### DIFF
--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -69,14 +69,6 @@ spec:
       computeResources:
         requests:
           cpu: 2
-  - pipelineTaskName: clamav-scan
-    stepSpecs:
-    # Provision more CPU to speed up ClamAV scan compared to the defaults.
-    # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
-    - name: extract-and-scan-image
-      computeResources:
-        requests:
-          cpu: 1
 
   # Multiarch builds sometimes make the pipeline timeout after 1h.
   timeouts:

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -59,16 +59,6 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
-  taskRunSpecs:
-  - pipelineTaskName: clamav-scan
-    stepSpecs:
-    # Provision more CPU to speed up ClamAV scan compared to the defaults.
-    # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
-    - name: extract-and-scan-image
-      computeResources:
-        requests:
-          cpu: 1
-
   timeouts:
     tasks: 1h
     finally: 10m

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -59,16 +59,6 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
-  taskRunSpecs:
-  - pipelineTaskName: clamav-scan
-    stepSpecs:
-    # Provision more CPU to speed up ClamAV scan compared to the defaults.
-    # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
-    - name: extract-and-scan-image
-      computeResources:
-        requests:
-          cpu: 1
-
   timeouts:
     tasks: 1h
     finally: 10m

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -69,14 +69,6 @@ spec:
       computeResources:
         requests:
           cpu: 2
-  - pipelineTaskName: clamav-scan
-    stepSpecs:
-    # Provision more CPU to speed up ClamAV scan compared to the defaults.
-    # https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L48
-    - name: extract-and-scan-image
-      computeResources:
-        requests:
-          cpu: 1
 
   # Multiarch builds sometimes make the pipeline timeout after 1h.
   timeouts:


### PR DESCRIPTION
Let the Konflux team manage these resources as they seem to be on track of doing that
https://github.com/konflux-ci/build-definitions/pull/1247