### PR TITLE
ROX-26528: add rpms-signature-scan task to Konflux pipelines

### DIFF
--- a/.tekton/scanner-component-pipeline.yaml
+++ b/.tekton/scanner-component-pipeline.yaml
@@ -573,3 +573,23 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
+
+  - name: rpms-signature-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: rpms-signature-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]


### PR DESCRIPTION
Add new mandatory task to Konflux pipelines. The check is successful, e.g. https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/scanner-db-build-52j6z/logs?task=rpms-signature-scan. 

The [GH s390x failure](https://github.com/stackrox/scanner/actions/runs/11342081719/job/31544063009?pr=1671) is reported on [Slack](https://redhat-internal.slack.com/archives/C3W3U0RGW/p1728983880858899?thread_ts=1728469303.271559&cid=C3W3U0RGW). 