### PR TITLE
fix: Add additional deps to the notification job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -684,6 +684,10 @@ jobs:
   send-notification:
     needs:
       - diff-dumps
+      - upload-db-dump
+      - upload-dumps-for-downstream
+      - upload-dumps-for-embedding
+      - push-manifests
     runs-on: ubuntu-latest
     if: failure()
     steps:


### PR DESCRIPTION
Add some leaf jobs in the dependency tree that were missing in the notification job dependencies, so that if these path fail, we see notifications.

![image](https://github.com/user-attachments/assets/bf234030-d7cf-4586-a626-39f5625557dc)

