### PR TITLE
ROX-24468: Link source container to the index image

### DIFF
--- a/.tekton/scanner-component-pipeline.yaml
+++ b/.tekton/scanner-component-pipeline.yaml
@@ -452,7 +452,7 @@ spec:
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
-      value: $(tasks.build-container-amd64.results.IMAGE_URL)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT


### PR DESCRIPTION
After looking at <https://github.com/konflux-ci/release-service-catalog/blob/development/tasks/push-snapshot/push-snapshot.yaml>, I come to conclusion that the source container (the one with tag `sha256-<digest>.src`) is expected to have the digest of the index image, not some arch-specific image under it (in our case - amd64 one).

Likely, when we onboarded to multiarch, the use of amd64 was the only possible thing.
Now passing the index image as the argument for the source build seems to work without failures.

In fact all our containers except for `main` and scanner-v2's were set up properly.

I leave it as a bonus question why did not EC call out the source container related to an unexpected image.