### PR TITLE
build: Switch `git-url` from `repo_url` to `source_url`

### DIFF
--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -25,7 +25,7 @@ spec:
   - name: dockerfile
     value: image/scanner/rhel/konflux.Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   - name: image-expires-after
     # TODO(ROX-24530): return expiration for non-released images to 13w
     value: '52w'

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -25,7 +25,7 @@ spec:
   - name: dockerfile
     value: image/scanner/rhel/konflux.Dockerfile
   - name: git-url
-    value: '{{repo_url}}'
+    value: '{{source_url}}'
   - name: image-expires-after
     # TODO(ROX-24530): return expiration for non-released images to 13w
     value: '52w'


### PR DESCRIPTION
See https://github.com/stackrox/stackrox/pull/13101 for details.
Interestingly, scanner-db-s were already on `source_url`.