### PR TITLE
ROX-26026: Make `determine-image-tag` recognize git tags

### DIFF
--- a/.tekton/determine-image-tag-task.yaml
+++ b/.tekton/determine-image-tag-task.yaml
@@ -41,4 +41,15 @@ spec:
       dnf -y install git make
 
       scripts/konflux/fail-build-if-git-is-dirty.sh
-      echo -n "$(make --quiet --no-print-directory tag)$(params.TAG_SUFFIX)" | tee "$(results.IMAGE_TAG.path)"
+
+      # First, try take git tag if it's a tagged commit.
+      tag="$(git tag --points-at)"
+      if [[ -z "$tag" ]]; then
+        # If not, use make target's output.
+        tag="$(make --quiet --no-print-directory tag)"
+      elif [[ "$(wc -l <<< "$tag")" -gt 1 ]]; then
+        >&2 echo -e "Error: the HEAD commit has multiple tags, don't know which one to choose:\n$tag"
+        exit 5
+      fi
+
+      echo -n "${tag}$(params.TAG_SUFFIX)" | tee "$(results.IMAGE_TAG.path)"


### PR DESCRIPTION
Same as https://github.com/stackrox/collector/pull/1920. I hope it just works for Scanner.