### PR TITLE
ROX-26784: Configure tekton pipelines for release branch

### DIFF
--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -8,13 +8,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "release-2.35" && event in ["push", "pull_request"]
   labels:
-    appstudio.openshift.io/application: acs
-    appstudio.openshift.io/component: scanner
+    appstudio.openshift.io/application: acs-4-6
+    appstudio.openshift.io/component: scanner-4-6
     pipelines.appstudio.openshift.io/type: build
   name: scanner-build
   namespace: rh-acs-tenant

--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -8,7 +8,13 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" || (
+        event == "push" && (
+          target_branch == "release-2.35" ||
+          target_branch.matches("^refs/tags/.?")
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-4-6

--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: (target_branch == "release-2.35" || target_branch.matches("^2\\.35\\..?")) && event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: event in ["push", "pull_request"]
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-4-6

--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "release-2.35" && event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: (target_branch == "release-2.35" || target_branch.matches("^2\\.35\\..?")) && event in ["push", "pull_request"]
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-4-6

--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -11,8 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" || (
         event == "push" && (
-          target_branch == "release-2.35" ||
-          target_branch.matches("^refs/tags/.?")
+          source_branch.startsWith("release-") ||
+          target_branch.startsWith("refs/tags/")
         )
       )
   labels:

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "release-2.35" && event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: (target_branch == "release-2.35" || target_branch.matches("^2\\.35\\..?")) && event in ["push", "pull_request"]
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-db-4-6

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -8,13 +8,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "release-2.35" && event in ["push", "pull_request"]
   labels:
-    appstudio.openshift.io/application: acs
-    appstudio.openshift.io/component: scanner-db
+    appstudio.openshift.io/application: acs-4-6
+    appstudio.openshift.io/component: scanner-db-4-6
     pipelines.appstudio.openshift.io/type: build
   name: scanner-db-build
   namespace: rh-acs-tenant

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -11,8 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" || (
         event == "push" && (
-          target_branch == "release-2.35" ||
-          target_branch.matches("^refs/tags/.?")
+          source_branch.startsWith("release-") ||
+          target_branch.startsWith("refs/tags/")
         )
       )
   labels:

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: (target_branch == "release-2.35" || target_branch.matches("^2\\.35\\..?")) && event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: event in ["push", "pull_request"]
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-db-4-6

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -8,7 +8,13 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" || (
+        event == "push" && (
+          target_branch == "release-2.35" ||
+          target_branch.matches("^refs/tags/.?")
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-db-4-6

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: (target_branch == "release-2.35" || target_branch.matches("^2\\.35\\..?")) && event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: event in ["push", "pull_request"]
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-db-slim-4-6

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -8,7 +8,13 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" || (
+        event == "push" && (
+          target_branch == "release-2.35" ||
+          target_branch.matches("^refs/tags/.?")
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-db-slim-4-6

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "release-2.35" && event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: (target_branch == "release-2.35" || target_branch.matches("^2\\.35\\..?")) && event in ["push", "pull_request"]
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-db-slim-4-6

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -8,13 +8,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "release-2.35" && event in ["push", "pull_request"]
   labels:
-    appstudio.openshift.io/application: acs
-    appstudio.openshift.io/component: scanner-db-slim
+    appstudio.openshift.io/application: acs-4-6
+    appstudio.openshift.io/component: scanner-db-slim-4-6
     pipelines.appstudio.openshift.io/type: build
   name: scanner-db-slim-build
   namespace: rh-acs-tenant

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -11,8 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" || (
         event == "push" && (
-          target_branch == "release-2.35" ||
-          target_branch.matches("^refs/tags/.?")
+          source_branch.startsWith("release-") ||
+          target_branch.startsWith("refs/tags/")
         )
       )
   labels:

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: (target_branch == "release-2.35" || target_branch.matches("^2\\.35\\..?")) && event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: event in ["push", "pull_request"]
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-slim-4-6

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -8,7 +8,13 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" || (
+        event == "push" && (
+          target_branch == "release-2.35" ||
+          target_branch.matches("^refs/tags/.?")
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-slim-4-6

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "release-2.35" && event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: (target_branch == "release-2.35" || target_branch.matches("^2\\.35\\..?")) && event in ["push", "pull_request"]
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: scanner-slim-4-6

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -8,13 +8,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "release-2.35" && event in ["push", "pull_request"]
   labels:
-    appstudio.openshift.io/application: acs
-    appstudio.openshift.io/component: scanner-slim
+    appstudio.openshift.io/application: acs-4-6
+    appstudio.openshift.io/component: scanner-slim-4-6
     pipelines.appstudio.openshift.io/type: build
   name: scanner-slim-build
   namespace: rh-acs-tenant

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -11,8 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" || (
         event == "push" && (
-          target_branch == "release-2.35" ||
-          target_branch.matches("^refs/tags/.?")
+          target_branch.startsWith("release-") ||
+          target_branch.startsWith("refs/tags/")
         )
       )
   labels:


### PR DESCRIPTION
There are a couple of changes to the PipelineRun files:

* Update application and component names to match the ACS 4.6 release versions
* Update the CEL expression to only run ACS 4.6 pipelines on Scanner 2.35 PRs and pushes. All PRs to the release-2.35 branch will trigger Konflux builds.