### PR TITLE
ROX-26784: Only trigger Konflux builds against master

### DIFF
--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-db

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-db-slim

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-slim


### PR DESCRIPTION
This is primarily intended to stop triggering builds in Konflux for "master" components when there are PRs or pushes on release branches.

This retains the branch naming and label conventions to reduce load on Konflux.

One side effect of this change is that PRs against branches other than master or release branches will not have Konflux builds ever run against them.