### PR TITLE
ROX-26784: Don't trigger Konflux builds against release branches

### DIFF
--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -10,12 +10,10 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      target_branch == "master" && (
-        event == "push" || (
-          event == "pull_request" && (
-            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
-            body.pull_request.labels.exists(l, l.name == "konflux-build")
-          )
+      event == "push" || (
+        event == "pull_request" && (
+          source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+          body.pull_request.labels.exists(l, l.name == "konflux-build")
         )
       )
   labels:

--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -9,8 +9,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" || (
+    pipelinesascode.tekton.dev/on-cel-expression: (
+        event == "push" && (
+          source_branch == "master" ||
+          target_branch.startsWith("refs/tags/")
+        )
+      ) || (
         event == "pull_request" && (
           source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
           body.pull_request.labels.exists(l, l.name == "konflux-build")

--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -10,12 +10,10 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      target_branch == "master" && (
-        event == "push" || (
-          event == "pull_request" && (
-            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
-            body.pull_request.labels.exists(l, l.name == "konflux-build")
-          )
+      event == "push" || (
+        event == "pull_request" && (
+          source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+          body.pull_request.labels.exists(l, l.name == "konflux-build")
         )
       )
   labels:

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -9,8 +9,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" || (
+    pipelinesascode.tekton.dev/on-cel-expression: (
+        event == "push" && (
+          source_branch == "master" ||
+          target_branch.startsWith("refs/tags/")
+        )
+      ) || (
         event == "pull_request" && (
           source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
           body.pull_request.labels.exists(l, l.name == "konflux-build")

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-db

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -10,12 +10,10 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      target_branch == "master" && (
-        event == "push" || (
-          event == "pull_request" && (
-            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
-            body.pull_request.labels.exists(l, l.name == "konflux-build")
-          )
+      event == "push" || (
+        event == "pull_request" && (
+          source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+          body.pull_request.labels.exists(l, l.name == "konflux-build")
         )
       )
   labels:

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -9,8 +9,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" || (
+    pipelinesascode.tekton.dev/on-cel-expression: (
+        event == "push" && (
+          source_branch == "master" ||
+          target_branch.startsWith("refs/tags/")
+        )
+      ) || (
         event == "pull_request" && (
           source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
           body.pull_request.labels.exists(l, l.name == "konflux-build")

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-db-slim

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -10,12 +10,10 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      target_branch == "master" && (
-        event == "push" || (
-          event == "pull_request" && (
-            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
-            body.pull_request.labels.exists(l, l.name == "konflux-build")
-          )
+      event == "push" || (
+        event == "pull_request" && (
+          source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+          body.pull_request.labels.exists(l, l.name == "konflux-build")
         )
       )
   labels:

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -9,8 +9,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" || (
+    pipelinesascode.tekton.dev/on-cel-expression: (
+        event == "push" && (
+          source_branch == "master" ||
+          target_branch.startsWith("refs/tags/")
+        )
+      ) || (
         event == "pull_request" && (
           source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
           body.pull_request.labels.exists(l, l.name == "konflux-build")

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -10,8 +10,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|renovate|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      target_branch == "master" && (
+        event == "push" || (
+          event == "pull_request" && (
+            source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+            body.pull_request.labels.exists(l, l.name == "konflux-build")
+          )
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: scanner-slim


### PR DESCRIPTION
This is primarily intended to stop triggering builds in Konflux for "master" components when there are PRs or pushes on release branches.

This retains the branch naming and label conventions to reduce load on Konflux.