### PR TITLE
ROX-24283: enable strictfipsruntime in the Konflux build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,7 @@ GOPATH_WD_OVERRIDES := -w /src -e GOPATH=/go
 IMAGE_BUILD_FLAGS   := -e CGO_ENABLED=$(CGO_ENABLED) -e GOOS=linux -e GOARCH=$(GOARCH)
 IMAGE_BUILD_ARGS     = --build-arg LABEL_VERSION=$(TAG) --build-arg LABEL_RELEASE=$(TAG) --build-arg QUAY_TAG_EXPIRATION=$(QUAY_TAG_EXPIRATION)
 BUILD_FLAGS         := CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH)
-GOTAGS              ?=
-BUILD_CMD           := go build -trimpath -ldflags="-X github.com/stackrox/scanner/pkg/version.Version=$(TAG)" $(if $(GOTAGS),-tags=$(GOTAGS)) -o image/scanner/bin/scanner ./cmd/clair
+BUILD_CMD           := go build -trimpath -ldflags="-X github.com/stackrox/scanner/pkg/version.Version=$(TAG)" -tags=$(GOTAGS) -o image/scanner/bin/scanner ./cmd/clair
 NODESCAN_BUILD_CMD  := go build -trimpath -o tools/bin/local-nodescanner ./tools/local-nodescanner
 
 #####################################################################

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ GOPATH_WD_OVERRIDES := -w /src -e GOPATH=/go
 IMAGE_BUILD_FLAGS   := -e CGO_ENABLED=$(CGO_ENABLED) -e GOOS=linux -e GOARCH=$(GOARCH)
 IMAGE_BUILD_ARGS     = --build-arg LABEL_VERSION=$(TAG) --build-arg LABEL_RELEASE=$(TAG) --build-arg QUAY_TAG_EXPIRATION=$(QUAY_TAG_EXPIRATION)
 BUILD_FLAGS         := CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH)
-BUILD_CMD           := go build -trimpath -ldflags="-X github.com/stackrox/scanner/pkg/version.Version=$(TAG)" -o image/scanner/bin/scanner ./cmd/clair
+GOTAGS              ?=
+BUILD_CMD           := go build -trimpath -ldflags="-X github.com/stackrox/scanner/pkg/version.Version=$(TAG)" $(if $(GOTAGS),-tags=$(GOTAGS)) -o image/scanner/bin/scanner ./cmd/clair
 NODESCAN_BUILD_CMD  := go build -trimpath -o tools/bin/local-nodescanner ./tools/local-nodescanner
 
 #####################################################################

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ GOPATH_WD_OVERRIDES := -w /src -e GOPATH=/go
 IMAGE_BUILD_FLAGS   := -e CGO_ENABLED=$(CGO_ENABLED) -e GOOS=linux -e GOARCH=$(GOARCH)
 IMAGE_BUILD_ARGS     = --build-arg LABEL_VERSION=$(TAG) --build-arg LABEL_RELEASE=$(TAG) --build-arg QUAY_TAG_EXPIRATION=$(QUAY_TAG_EXPIRATION)
 BUILD_FLAGS         := CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH)
-BUILD_CMD           := go build -trimpath -ldflags="-X github.com/stackrox/scanner/pkg/version.Version=$(TAG)" -tags=$(GOTAGS) -o image/scanner/bin/scanner ./cmd/clair
+BUILD_CMD           := go build -trimpath -ldflags="-X github.com/stackrox/scanner/pkg/version.Version=$(TAG)" -tags="$(GOTAGS)" -o image/scanner/bin/scanner ./cmd/clair
 NODESCAN_BUILD_CMD  := go build -trimpath -o tools/bin/local-nodescanner ./tools/local-nodescanner
 
 #####################################################################

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -10,6 +10,8 @@ ARG SCANNER_TAG
 RUN if [[ "$SCANNER_TAG" == "" ]]; then >&2 echo "error: required SCANNER_TAG arg is unset"; exit 6; fi
 ENV RELEASE_TAG="${SCANNER_TAG}"
 
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOTAGS=strictfipsruntime
 ENV GOFLAGS=""
 ENV CI=1
 

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -10,6 +10,7 @@ ARG SCANNER_TAG
 RUN if [[ "$SCANNER_TAG" == "" ]]; then >&2 echo "error: required SCANNER_TAG arg is unset"; exit 6; fi
 ENV RELEASE_TAG="${SCANNER_TAG}"
 
+# TODO(ROX-27054): Remove the redundant strictfipsruntime option if one is found to be so
 ENV GOEXPERIMENT=strictfipsruntime
 ENV GOTAGS=strictfipsruntime
 ENV GOFLAGS=""


### PR DESCRIPTION
## Description

Enables the strictfipsruntime build flag for the Konflux build.

For more info about the strictfipsruntime flag, see [this doc](https://docs.google.com/document/d/1CTpSwITQfOgoOTlPITZNJZy0ltYz60hxkmWsLemCqw0/edit?tab=t.0) (there might be a better resource but this is the one David and I found), and for our general research regarding the linked ticket, see [this doc](https://docs.google.com/document/d/1KcjlevcMF4DLi-KROru7tuUUIb4wSk5e6bnXpU8HZxA/edit?tab=t.0).

Related stackrox PR: https://github.com/stackrox/stackrox/pull/12909

Verified the build works via Konflux CI and verified the `check-payload` results of the following images:
- [x] ` quay.io/rhacs-eng/scanner:2.35.x-13-g2c519017f0-fast`
- [x] ` quay.io/rhacs-eng/scanner-slim:2.35.x-13-g2c519017f0-fast`