### PR TITLE
ROX-24276: Add release GOTAGS flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ GOPATH_WD_OVERRIDES := -w /src -e GOPATH=/go
 IMAGE_BUILD_FLAGS   := -e CGO_ENABLED=$(CGO_ENABLED) -e GOOS=linux -e GOARCH=$(GOARCH)
 IMAGE_BUILD_ARGS     = --build-arg LABEL_VERSION=$(TAG) --build-arg LABEL_RELEASE=$(TAG) --build-arg QUAY_TAG_EXPIRATION=$(QUAY_TAG_EXPIRATION)
 BUILD_FLAGS         := CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH)
-BUILD_CMD           := go build -trimpath -ldflags="-X github.com/stackrox/scanner/pkg/version.Version=$(TAG)" -o image/scanner/bin/scanner ./cmd/clair
+BUILD_CMD           := go build -trimpath -ldflags="-X github.com/stackrox/scanner/pkg/version.Version=$(TAG)" -tags=$(GOTAGS) -o image/scanner/bin/scanner ./cmd/clair
 NODESCAN_BUILD_CMD  := go build -trimpath -o tools/bin/local-nodescanner ./tools/local-nodescanner
 
 #####################################################################

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -11,6 +11,7 @@ RUN if [[ "$SCANNER_TAG" == "" ]]; then >&2 echo "error: required SCANNER_TAG ar
 ENV RELEASE_TAG="${SCANNER_TAG}"
 
 ENV GOFLAGS=""
+ENV GOTAGS=release
 ENV CI=1
 
 COPY . /src


### PR DESCRIPTION
~Context: https://issues.redhat.com/browse/ROX-24276~

Validation:

Look for:

```
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-X github.com/stackrox/scanner/pkg/version.Version=2.35.x-10-g6e82c7a6f1-fast" -tags=release -o image/scanner/bin/scanner ./cmd/clair
```

* https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/scanner-on-push-vg9qc/logs?task=build-container-amd64
* https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/scanner-slim-on-push-5kvbb/logs?task=build-container-amd64

