### PR TITLE
Bump max known OCP version

### DIFF
--- a/pkg/cpeutils/utils.go
+++ b/pkg/cpeutils/utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Note: this must be updated with each new OpenShift release.
-const maxKnownOpenShift4MinorVersion = 14
+const maxKnownOpenShift4MinorVersion = 17
 
 // *** START Regex-related consts/vars. ***
 

--- a/pkg/cpeutils/utils_test.go
+++ b/pkg/cpeutils/utils_test.go
@@ -84,6 +84,9 @@ func TestGetAllOpenShift4CPEs(t *testing.T) {
 				"cpe:/a:redhat:openshift:4.12",
 				"cpe:/a:redhat:openshift:4.13",
 				"cpe:/a:redhat:openshift:4.14",
+				"cpe:/a:redhat:openshift:4.15",
+				"cpe:/a:redhat:openshift:4.16",
+				"cpe:/a:redhat:openshift:4.17",
 			},
 		},
 		{
@@ -104,6 +107,9 @@ func TestGetAllOpenShift4CPEs(t *testing.T) {
 				"cpe:/a:redhat:openshift:4.12::el8",
 				"cpe:/a:redhat:openshift:4.13::el8",
 				"cpe:/a:redhat:openshift:4.14::el8",
+				"cpe:/a:redhat:openshift:4.15::el8",
+				"cpe:/a:redhat:openshift:4.16::el8",
+				"cpe:/a:redhat:openshift:4.17::el8",
 			},
 		},
 		{
@@ -124,6 +130,9 @@ func TestGetAllOpenShift4CPEs(t *testing.T) {
 				"cpe:/a:redhat:openshift:4.12::el9",
 				"cpe:/a:redhat:openshift:4.13::el9",
 				"cpe:/a:redhat:openshift:4.14::el9",
+				"cpe:/a:redhat:openshift:4.15::el9",
+				"cpe:/a:redhat:openshift:4.16::el9",
+				"cpe:/a:redhat:openshift:4.17::el9",
 			},
 		},
 		{


### PR DESCRIPTION
To assist with vuln matching for CPEs that do not have a `Y` version