### PR TITLE
ROX-27905: Exclude example rpmdb from SBOMs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,6 +117,9 @@ jobs:
       - name: Run style checks (amd64)
         run: ./scripts/ci/jobs/style-checks.sh
 
+      - name: Check Konflux setup
+        run: ./scripts/ci/jobs/check-konflux-setup.sh
+
   unit-tests:
     runs-on: ubuntu-latest
     container:

--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,6 +1,6 @@
 # Konflux uses Syft to generate container SBOMs.
 # Syft config docs https://github.com/anchore/syft/wiki/configuration
 
-# Here we exclude rpmdb files checked in this repo for testing purposes from being parsed and merged into SBOM.
+# Here we exclude files checked in this repo for testing purposes from being parsed and merged into SBOM.
 # Use scripts/ci/jobs/check-konflux-setup.sh to validate or update this exclusion list.
 exclude: []

--- a/.syft.yaml
+++ b/.syft.yaml
@@ -3,4 +3,29 @@
 
 # Here we exclude files checked in this repo for testing purposes from being parsed and merged into SBOM.
 # Use scripts/ci/jobs/check-konflux-setup.sh to validate or update this exclusion list.
-exclude: []
+exclude:
+- ./api/v1/testdata/**
+- ./cmd/clair/testdata/**
+- ./cpe/nvdtoolscache/testdata/**
+- ./database/pgsql/testdata/**
+- ./e2etests/testdata/**
+- ./ext/featurefmt/apk/testdata/**
+- ./ext/featurefmt/dpkg/testdata/**
+- ./ext/featurefmt/rpm/testdata/**
+- ./ext/vulnmdsrc/nvd/testdata/**
+- ./ext/vulnmdsrc/redhat/testdata/**
+- ./ext/vulnsrc/alpine/testdata/**
+- ./ext/vulnsrc/amzn/testdata/**
+- ./ext/vulnsrc/debian/testdata/**
+- ./ext/vulnsrc/rhel/testdata/**
+- ./ext/vulnsrc/ubuntu/testdata/**
+- ./istio/cache/testdata/**
+- ./k8s/cache/testdata/**
+- ./pkg/analyzer/dotnetcoreruntime/testdata/**
+- ./pkg/elf/testdata/**
+- ./pkg/repo2cpe/testdata/**
+- ./pkg/rhel/pulp/testdata/**
+- ./pkg/rhelv2/ovalutil/testdata/**
+- ./pkg/rhelv2/rpm/testdata/**
+- ./pkg/tarutil/testdata/**
+- ./pkg/ziputil/testdata/**

--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,6 @@
+# Konflux uses Syft to generate container SBOMs.
+# Syft config docs https://github.com/anchore/syft/wiki/configuration
+
+# Here we exclude rpmdb files checked in this repo for testing purposes from being parsed and merged into SBOM.
+# Use scripts/ci/jobs/check-konflux-setup.sh to validate or update this exclusion list.
+exclude: []

--- a/scripts/ci/jobs/check-konflux-setup.sh
+++ b/scripts/ci/jobs/check-konflux-setup.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# This script is to validate our Konflux setup. It is borrowed from the StackRox repo.
+# See https://github.com/stackrox/stackrox/blob/master/scripts/ci/jobs/check-konflux-setup.sh
+
+set -euo pipefail
+
+FAIL_FLAG="$(mktemp)"
+trap 'rm -f $FAIL_FLAG' EXIT
+
+check_example_rpmdb_files_are_ignored() {
+    # At the time of this writing, Konflux uses syft to generate SBOMs for built containers.
+    # If we happen to have test rpmdb databases in the repo, syft will union their contents with RPMs that it finds
+    # installed in the container resulting in a misleading SBOM.
+    # This check is to make sure the exclusion list in Syft config enumerates all such rpmdbs.
+    # Ref https://github.com/anchore/syft/wiki/configuration
+
+    local -r syft_config=".syft.yaml"
+    local -r exclude_attribute=".exclude"
+
+    local actual_excludes
+    actual_excludes="$(yq eval "${exclude_attribute}" "${syft_config}")"
+
+    local expected_excludes
+    expected_excludes="$(git ls-files -- '**/rpmdb.sqlite' | sort | uniq | sed 's/^/- .\//')"
+
+    echo
+    echo "➤ ${syft_config} // checking ${exclude_attribute}: all rpmdb files in the repo shall be mentioned."
+    if ! compare "${expected_excludes}" "${actual_excludes}"; then
+        echo >&2 "How to resolve:
+1. Open ${syft_config} and replace ${exclude_attribute} contents with the following.
+${expected_excludes}"
+        record_failure "${FUNCNAME}"
+    fi
+}
+
+compare() {
+    local -r expected="$1"
+    local -r actual="$2"
+
+    if ! diff --brief <(echo "${expected}") <(echo "${actual}") > /dev/null; then
+        echo >&2 "✗ ERROR: the expected contents (left) don't match the actual ones (right):"
+        diff >&2 --side-by-side <(echo "${expected}") <(echo "${actual}") || true
+        return 1
+    else
+        echo "✓ No diff detected."
+    fi
+}
+
+record_failure() {
+    local -r func="$1"
+    echo "${func}" >> "${FAIL_FLAG}"
+}
+
+echo "Checking our Konflux pipelines and builds setup."
+check_example_rpmdb_files_are_ignored
+
+if [[ -s "$FAIL_FLAG" ]]; then
+    echo >&2
+    echo >&2 "✗ Some Konflux checks failed:"
+    cat >&2 "$FAIL_FLAG"
+    exit 1
+else
+    echo
+    echo "✓ All checks passed."
+fi

--- a/scripts/ci/jobs/check-konflux-setup.sh
+++ b/scripts/ci/jobs/check-konflux-setup.sh
@@ -26,7 +26,7 @@ check_testdata_files_are_ignored() {
     expected_excludes="$(git ls-files -- '**/testdata/**' | sed 's@/testdata/.*$@/testdata/**@' | sort | uniq | sed 's/^/- .\//')"
 
     echo
-    echo "➤ ${syft_config} // checking ${exclude_attribute}: all rpmdb files in the repo shall be mentioned."
+    echo "➤ ${syft_config} // checking ${exclude_attribute}: all testdata files in the repo shall be mentioned."
     if ! compare "${expected_excludes}" "${actual_excludes}"; then
         echo >&2 "How to resolve:
 1. Open ${syft_config} and replace ${exclude_attribute} contents with the following.


### PR DESCRIPTION
Adapted from https://github.com/stackrox/stackrox/pull/14065.

### Validation

Ensured style check would fail in CI when `exclude` is empty: https://github.com/stackrox/scanner/actions/runs/13587104793/job/37984431483?pr=1819

When comparing actual sboms, I found no meaningful difference

```bash
$ cosign download sbom quay.io/rhacs-eng/scanner:2.36.x-8-g25fbd5cb83-fast-amd64 > pre-sbom.json
$ cosign download sbom quay.io/rhacs-eng/scanner:2.36.x-11-g14d6649088-fast-amd64 > post-sbom.json

$ wc -l *.json
  58744 post-sbom.json
  58744 pre-sbom.json
```

Also, unlike StackRox (see https://github.com/stackrox/stackrox/pull/14065), there were no redundant entries for `openssl` and no `fc35` mentions in SBOM before the change. I suppose there's something odd with `./pkg/rhelv2/rpm/testdata/rpmdb.sqlite` but I don't know an easy way to check its contents.

tl;dr: this PR does not improve output SBOMs but those don't need improvements and seem already ok. Nevertheless, I still suggest merging the PR in case things (i.e. on the Konflux side) may change in the future.