### PR TITLE
bump ready timeout for e2e tests

### DIFF
--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -32,7 +32,7 @@ _wait_for_scanner() {
     kubectl -n stackrox get pod
     POD="$(kubectl -n stackrox get pod -o jsonpath='{.items[?(@.metadata.labels.app=="scanner")].metadata.name}')"
     [[ -n "${POD}" ]]
-    kubectl -n stackrox wait "--for=condition=Ready" "pod/${POD}" --timeout=5m
+    kubectl -n stackrox wait "--for=condition=Ready" "pod/${POD}" --timeout=10m
     kubectl -n stackrox get pod
 }
 


### PR DESCRIPTION
Noticed a lot of e2e test runs keep failing waiting on Scanner to be ready. This increases the wait time from 5 minutes to 10 minutes