### PR TITLE
fix: increase max grpc message size

### DIFF
--- a/e2etests/utils.go
+++ b/e2etests/utils.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	scannerHTTPEndpointEnv = "SCANNER_ENDPOINT"
-	scannerGRPCEndpointEnv = "SCANNER_GRPC_ENDPOINT"
+	scannerHTTPEndpointEnv    = "SCANNER_ENDPOINT"
+	scannerGRPCEndpointEnv    = "SCANNER_GRPC_ENDPOINT"
+	defaultMaxResponseMsgSize = 256 * 1024 * 1024 // 256MB
 )
 
 func mustGetEnv(t *testing.T, key string) string {
@@ -37,7 +38,11 @@ func connectToScanner(t *testing.T) *grpc.ClientConn {
 	clientTLSConfig := &tls.Config{
 		InsecureSkipVerify: true,
 	}
-	conn, err := grpc.NewClient(gRPCEndpoint, grpc.WithTransportCredentials(credentials.NewTLS(clientTLSConfig)))
+	conn, err := grpc.NewClient(
+		gRPCEndpoint,
+		grpc.WithTransportCredentials(credentials.NewTLS(clientTLSConfig)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaultMaxResponseMsgSize)),
+	)
 	require.NoError(t, err)
 	return conn
 }


### PR DESCRIPTION
## Description

We observed the following error in a recent e2e CI run:
```
rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4237137 vs. 4194304)`
```
Job link: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_scanner/1837/pull-ci-stackrox-scanner-release-2.36-e2e-tests/1902054308703113216

These changes increase the default max grpc receive message size.