### PR TITLE
ROX-20312: Pin base image digests and extend Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,12 +7,13 @@
 
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    // This inherits the base Konflux config.
-    // Clickable link https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json
-    // The following was used as example (we may want to check it if the base config gets suddenly moved):
+    // Note that the base Konflux's MintMaker config gets inherited/included automatically per
+    // https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1745492139282819?thread_ts=1745309786.090319&cid=C04PZ7H0VA8
+    // The config is: https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json
+    // We found out about it here (we may want to check that location if the base config gets suddenly moved):
     // https://github.com/enterprise-contract/ec-cli/blob/407847910ad420850385eea1db78e2a2e49c7e25/renovate.json#L1C1-L7C2
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
-    // This tells Renovate to combine all updates in one PR so that we have less PRs to deal with.
+
+    // This tells Renovate to combine all updates in one PR so that we have fewer PRs to deal with.
     "group:all",
   ],
   "timezone": "Etc/UTC",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,8 +28,7 @@
   "updateNotScheduled": false,
   "tekton": {
     "schedule": [
-      // For some reason, Konflux config defines custom schedule on each type of dependency manager and that takes
-      // precedence over the global/default schedule. We want our own schedule and hence need to make this override.
+      // Override Konflux custom schedule for this manager to our intended one.
       "after 3am and before 7am",
     ],
   },
@@ -38,6 +37,10 @@
       // Instruct Renovate not try to update Dockerfiles other than konflux.Dockerfile (or konflux.anything.Dockerfile)
       // to have less PR noise.
       "**/*konflux*.Dockerfile",
+    ],
+    "schedule": [
+      // Override Konflux custom schedule for this manager to our intended one.
+      "after 3am and before 7am",
     ],
   },
   "enabledManagers": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,15 @@
       // Override Konflux custom schedule for this manager to our intended one.
       "after 3am and before 7am",
     ],
+    "packageRules": [
+      // Note: the packageRules from the Konflux config (find URL in comments above) get merged with these.
+      {
+        "groupName": "StackRox custom Konflux Tasks",
+        "matchPackageNames": [
+          "/^quay.io/rhacs-eng/konflux-tasks/",
+        ],
+      },
+    ],
   },
   "dockerfile": {
     "includePaths": [

--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel8/postgresql-15:latest AS scanner-db-common
+FROM registry.redhat.io/rhel8/postgresql-15:latest@sha256:2491ac9b904f6b57218100b49e2fe7ad5e9a93f09eed1a695f2c34846e0a1943 AS scanner-db-common
 
 ARG SCANNER_TAG
 RUN if [[ "$SCANNER_TAG" == "" ]]; then >&2 echo "error: required SCANNER_TAG arg is unset"; exit 6; fi

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -1,10 +1,10 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
 ARG BASE_IMAGE=ubi8-minimal
-ARG BASE_TAG=latest
+ARG BASE_TAG=latest@sha256:33161cf5ec11ea13bfe60cad64f56a3aa4d893852e8ec44b2fd2a6b40cc38539
 
 
 # Compiling scanner binaries and staging repo2cpe and genesis manifests
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.23 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.23@sha256:4bd7cb8abd091e6161490da1c3dd615532e537c62b8b98d6b2acd77e248ead62 AS builder
 
 ARG SCANNER_TAG
 RUN if [[ "$SCANNER_TAG" == "" ]]; then >&2 echo "error: required SCANNER_TAG arg is unset"; exit 6; fi


### PR DESCRIPTION
See descriptions of individual commits.

### Validation

1. Relying on CI signal.
2. Ran renovate validator cli.
3. I don't know how renovate config will actually work w.r.t. image digests and our custom tasks. I suggest merging this PR and monitoring things after.