### PR TITLE
ROX-29108: Enable `rpm` lockfile renovation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,6 +51,12 @@
       // Override Konflux custom schedule for this manager to our intended one.
       "after 3am and before 7am",
     ],
+    "postUpgradeTasks": {
+      "commands": [
+        // Refresh the rpm lockfile after updating image references in the dockerfile.
+        "rpm-lockfile-prototype rpms.in.yaml",
+      ],
+    },
   },
   "rpm": {
     "schedule": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,9 +52,16 @@
       "after 3am and before 7am",
     ],
   },
+  "rpm": {
+    "schedule": [
+      // Override Konflux custom schedule for this manager to our intended one.
+      "after 3am and before 7am",
+    ],
+  },
   "enabledManagers": [
     // Restrict Renovate focus on Konflux things since we rely on GitHub's dependabot for everything else.
     "tekton",
     "dockerfile",
+    "rpm",
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
 
   // After making changes to this file, you can validate it by running something like this in the root of the repo:
   // $ docker run --rm -it --entrypoint=renovate-config-validator -v "$(pwd)":/mnt -w /mnt renovate/renovate --strict
+  // Note: ignore errors about the config for `rpm`. This is to be addressed with https://issues.redhat.com/browse/CWFHEALTH-4117
   // There are more validation options, see https://docs.renovatebot.com/config-validation/
 
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",


### PR DESCRIPTION
According to <https://konflux-ci.dev/docs/mintmaker/default-config/#rpm-updates>, there's nothing else we should touch.

### Validation

I'll create a follow-up PR where I'd downgrade some package to let MintMaker create its update.