### PR TITLE
fix(ci): increase timeout processing RH OVAL data

### DIFF
--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -115,7 +115,7 @@ const (
 
 var (
 	client = &http.Client{
-		Timeout:   10 * time.Second,
+		Timeout:   60 * time.Second,
 		Transport: proxy.RoundTripper(),
 	}
 )


### PR DESCRIPTION
## Description

Increases the timeout for the HTTP client that requests Red Hat OVAL feeds. We previously did this for the v2 feed in this PR: https://github.com/stackrox/scanner/pull/1820. However, our "v1" OVAL updater also uses the v2 feed URLs: 
https://github.com/stackrox/scanner/blob/5d2c067ca37b31db830daf54c1a66f4a679db459/ext/vulnsrc/rhel/rhel.go#L44
https://github.com/stackrox/scanner/blob/5d2c067ca37b31db830daf54c1a66f4a679db459/ext/vulnsrc/rhel/rhel.go#L54-L58

Moreover, these changes will keep the timeout consistent between reading from the "v1" and v2 Red Hat OVAL feeds.

Example of the error these changes should fix: https://github.com/stackrox/scanner/actions/runs/14848990112/job/41689019123