### PR TITLE
fix(ci): increase deploy wait timeout 

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -12,7 +12,7 @@ class Deployer:
     Deployer - Deploys Scanner and ScannerDB resources and port-forwards the necessary endpoints.
     """
 
-    DEPLOY_TIMEOUT = 10 * 60
+    DEPLOY_TIMEOUT = 20 * 60
 
     def __init__(self, slim=False):
         self.slim = slim

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -32,7 +32,7 @@ _wait_for_scanner() {
     kubectl -n stackrox get pod
     POD="$(kubectl -n stackrox get pod -o jsonpath='{.items[?(@.metadata.labels.app=="scanner")].metadata.name}')"
     [[ -n "${POD}" ]]
-    kubectl -n stackrox wait "--for=condition=Ready" "pod/${POD}" --timeout=10m
+    kubectl -n stackrox wait "--for=condition=Ready" "pod/${POD}" --timeout=20m
     kubectl -n stackrox get pod
 }
 


### PR DESCRIPTION
Increase the scanner deploy wait timeout even longer (was bumped to 10m here: https://github.com/stackrox/scanner/pull/1835)

CI in the `release-2.35` branch has been failing, in the [latest run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-scanner-release-2.35-merge-e2e-tests/1920835464898547712) scanner was in the middle of loading /nvd_definitions:

```
{"Attempt":3,"Event":"Retrying connection to DB","Level":"warning","Location":"database.go:83","Time":"2025-05-09 15:05:42.427486"}
{"Event":"running database migrations","Level":"info","Location":"pgsql.go:198","Time":"2025-05-09 15:05:52.996493"}
{"Event":"database migration ran successfully","Level":"info","Location":"pgsql.go:205","Time":"2025-05-09 15:05:53.273058"}
{"Event":"Loading NVD definitions into cache","Level":"info","Location":"singleton.go:24","Time":"2025-05-09 15:10:49.985059"}
{"Event":"Loading definitions directory","Level":"info","Location":"load.go:19","Time":"2025-05-09 15:10:49.985196","dir":"/nvd_definitions"}
```
When the job was failed due to timeout:
```
**** 15:10:03: ERROR: pre test failed
```
