### PR TITLE
chore: remove reviewers and update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,8 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners
 # This will automatically assign a team / people as reviewers for PRs based on the files changed within the PR.
 
+* @stackrox/scanner
+
 # The RHTAP maintainers for ACS review all changes related to the Konflux (f.k.a. RHTAP) pipelines, such as new
 # pipelines, parameter changes or automated task updates as well as Dockerfile updates.
 **/konflux.*Dockerfile  @stackrox/rhtap-maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       interval: "weekly"
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'stackrox/scanner'
     groups:
       actions:
         patterns:
@@ -24,24 +22,18 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'stackrox/scanner'
   - package-ecosystem: 'gomod'
     directory: '/tools/linters/'
     schedule:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'stackrox/scanner'
   - package-ecosystem: 'gomod'
     directory: '/tools/test/'
     schedule:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'stackrox/scanner'
       
   - package-ecosystem: 'docker'
     directory: 'image/scanner/rhel'
@@ -49,16 +41,12 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 1
-    reviewers:
-      - 'stackrox/scanner'
   - package-ecosystem: 'docker'
     directory: 'image/db/rhel'
     schedule:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 1
-    reviewers:
-      - 'stackrox/scanner'
 
   # Below configuration is workaround for dependabot issue
   # about local actions in .github/actions/ are not checked
@@ -70,8 +58,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'stackrox/scanner'
     groups:
       actions:
         patterns:
@@ -82,8 +68,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'stackrox/scanner'
     groups:
       actions:
         patterns:
@@ -94,8 +78,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-      - 'stackrox/scanner'
     groups:
       actions:
         patterns:


### PR DESCRIPTION
GitHub says the reviewers field will go away this month, and it should be replaced with CODEOWNERS

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/