### PR TITLE
ROX-27716: Switch to a task version that does not need `SOURCE_BRANCH` param

### DIFF
--- a/.tekton/scanner-component-pipeline.yaml
+++ b/.tekton/scanner-component-pipeline.yaml
@@ -226,7 +226,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:fa86065caf4e491e5fbadc97fe35177d581774cf3c6498d944a86470c09e5f82
+        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ffa21350f2647d0cc15f9f04c4a8752c65e0eb001a1b798f910440b34beb58ae
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/scanner-component-pipeline.yaml
+++ b/.tekton/scanner-component-pipeline.yaml
@@ -50,7 +50,7 @@ spec:
       - name: name
         value: post-bigquery-metrics
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:fa86065caf4e491e5fbadc97fe35177d581774cf3c6498d944a86470c09e5f82
+        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
       - name: kind
         value: task
       resolver: bundles
@@ -177,7 +177,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:fa86065caf4e491e5fbadc97fe35177d581774cf3c6498d944a86470c09e5f82
+        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
       - name: kind
         value: task
       resolver: bundles
@@ -226,7 +226,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ffa21350f2647d0cc15f9f04c4a8752c65e0eb001a1b798f910440b34beb58ae
+        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
       - name: kind
         value: task
       resolver: bundles
@@ -248,7 +248,7 @@ spec:
       - name: name
         value: fetch-scanner-v2-data
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:fa86065caf4e491e5fbadc97fe35177d581774cf3c6498d944a86470c09e5f82
+        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
From https://github.com/stackrox/konflux-tasks/pull/55