### PR TITLE
ROX-26148: Announce `./rpms.*` files ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,4 @@
 **/konflux.*Dockerfile  @stackrox/rhtap-maintainers
 /.konflux/              @stackrox/rhtap-maintainers
 /.tekton/               @stackrox/rhtap-maintainers
+rpms.*                  @stackrox/rhtap-maintainers


### PR DESCRIPTION
So that we're tagged for review on changes there.