### PR TITLE
analyze non-rhcos nodes

### DIFF
--- a/pkg/nodeinventory/inventorizer.go
+++ b/pkg/nodeinventory/inventorizer.go
@@ -47,7 +47,7 @@ func (n *Scanner) Scan(nodeName string) (*ScanResult, error) {
 		"/host/",
 		nodes.AnalyzeOpts{
 			UncertifiedRHEL: false,
-			IsRHCOSRequired: true},
+			IsRHCOSRequired: false},
 	)
 
 	scanDuration := time.Since(startTime)


### PR DESCRIPTION
testing node analyze with IsRHOCSRequired=false

It looks like ocp4.19 switched from `rhcos` to `rhel` for node baseimages in RC's (ec's were still "rhcos")