### PR TITLE
ROX-29602: Use updated `determine-image-tag` task

### DIFF
--- a/.tekton/scanner-component-pipeline.yaml
+++ b/.tekton/scanner-component-pipeline.yaml
@@ -221,8 +221,6 @@ spec:
       value: $(params.output-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    - name: SOURCE_BRANCH
-      value: '{{source_branch}}'
     taskRef:
       params:
       - name: name

--- a/.tekton/scanner-component-pipeline.yaml
+++ b/.tekton/scanner-component-pipeline.yaml
@@ -50,7 +50,7 @@ spec:
       - name: name
         value: post-bigquery-metrics
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:f25156593a965451b5e21dd337ae0ffe68cd3b30dacfc76997c1e161788cf7c9
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -210,7 +210,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:f25156593a965451b5e21dd337ae0ffe68cd3b30dacfc76997c1e161788cf7c9
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -226,7 +226,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:f25156593a965451b5e21dd337ae0ffe68cd3b30dacfc76997c1e161788cf7c9
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -248,7 +248,7 @@ spec:
       - name: name
         value: fetch-scanner-v2-data
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:f25156593a965451b5e21dd337ae0ffe68cd3b30dacfc76997c1e161788cf7c9
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
From https://github.com/stackrox/konflux-tasks/pull/66.

### Validation

Only CI here.