### PR TITLE
ROX-27060: Downgrade Go from 1.23 to 1.22 for 4.6

### DIFF
--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -1,5 +1,5 @@
 # Compiling scanner binaries and staging repo2cpe and genesis manifests
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.23@sha256:775e4b730b574841b34da2432afda83ef513aa3a0a7f9ffbe1e7cdea7e917012 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22@sha256:0f3196fd088d611076c91c57e2cfd68858ab0511affd232d59dff1ab757f7895 AS builder
 
 ARG SCANNER_TAG
 RUN if [[ "$SCANNER_TAG" == "" ]]; then >&2 echo "error: required SCANNER_TAG arg is unset"; exit 6; fi


### PR DESCRIPTION
1.23 got picked up during backporting in #1945. That's something I overlooked and spotted only in #1956.