### PR TITLE
ROX-30576: Copy repo 2 cpe to bundle root

### DIFF
--- a/cmd/updater/diffdumps/rhelv2_diff.go
+++ b/cmd/updater/diffdumps/rhelv2_diff.go
@@ -183,7 +183,6 @@ func generateRHELv2VulnsDiff(cfg config, outputDir string, baseLastModifiedTime 
 
 	// Get RHEL Repo to CPE file
 	repoToCPEFile := filepath.Join(vulndump.RHELv2DirName, repo2cpe.RHELv2CPERepoName)
-	repoToCPEFileRoot := filepath.Join(outputDir, repo2cpe.RHELv2CPERepoName)
 	for _, headF := range headZipR.File {
 		name := headF.Name
 
@@ -198,11 +197,9 @@ func generateRHELv2VulnsDiff(cfg config, outputDir string, baseLastModifiedTime 
 			if err := generateRHELv2RepoToCPE(filepath.Join(outputDir, repoToCPEFile), headF); err != nil {
 				return errors.Wrapf(err, "generating %s", repo2cpe.RHELv2CPERepoName)
 			}
-		}
 
-		// additional copy of repo to cpe JSON at bundle root (due to ROX-30576)
-		if name == repoToCPEFileRoot {
-			if err := generateRHELv2RepoToCPE(filepath.Join(outputDir, repoToCPEFileRoot), headF); err != nil {
+			// additional copy of repo to cpe JSON at bundle root (due to ROX-30576)
+			if err := generateRHELv2RepoToCPE(filepath.Join(outputDir, repo2cpe.RHELv2CPERepoName), headF); err != nil {
 				return errors.Wrapf(err, "generating %s at bundle root", repo2cpe.RHELv2CPERepoName)
 			}
 		}

--- a/cmd/updater/diffdumps/rhelv2_diff.go
+++ b/cmd/updater/diffdumps/rhelv2_diff.go
@@ -183,6 +183,7 @@ func generateRHELv2VulnsDiff(cfg config, outputDir string, baseLastModifiedTime 
 
 	// Get RHEL Repo to CPE file
 	repoToCPEFile := filepath.Join(vulndump.RHELv2DirName, repo2cpe.RHELv2CPERepoName)
+	repoToCPEFileRoot := filepath.Join(outputDir, repo2cpe.RHELv2CPERepoName)
 	for _, headF := range headZipR.File {
 		name := headF.Name
 
@@ -196,6 +197,13 @@ func generateRHELv2VulnsDiff(cfg config, outputDir string, baseLastModifiedTime 
 		if name == repoToCPEFile {
 			if err := generateRHELv2RepoToCPE(filepath.Join(outputDir, repoToCPEFile), headF); err != nil {
 				return errors.Wrapf(err, "generating %s", repo2cpe.RHELv2CPERepoName)
+			}
+		}
+
+		// additional copy of repo to cpe JSON at bundle root (due to ROX-30576)
+		if name == repoToCPEFileRoot {
+			if err := generateRHELv2RepoToCPE(filepath.Join(outputDir, repoToCPEFileRoot), headF); err != nil {
+				return errors.Wrapf(err, "generating %s at bundle root", repo2cpe.RHELv2CPERepoName)
 			}
 		}
 

--- a/pkg/rhelv2/rhelv2.go
+++ b/pkg/rhelv2/rhelv2.go
@@ -245,5 +245,16 @@ func updateRepoToCPE(outputDir string) (*repo2cpe.RHELv2MappingFile, error) {
 		return nil, errors.Wrapf(err, "encoding mapping")
 	}
 
+	// Also create copy at bundle root (due to ROX-30576)
+	outFRoot, err := os.Create(filepath.Join(outputDir, repo2cpe.RHELv2CPERepoName))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create file %q at bundle root", repo2cpe.RHELv2CPERepoName)
+	}
+	defer utils.IgnoreError(outFRoot.Close)
+
+	if err := json.NewEncoder(outFRoot).Encode(&mapping); err != nil {
+		return nil, errors.Wrapf(err, "encoding mapping at bundle root")
+	}
+
 	return &mapping, nil
 }

--- a/pkg/vulndump/write.go
+++ b/pkg/vulndump/write.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mholt/archiver/v3"
 	"github.com/pkg/errors"
 	"github.com/stackrox/scanner/database"
+	"github.com/stackrox/scanner/pkg/repo2cpe"
 )
 
 // WriteZip takes the given files and creates the vuln dump zip.
@@ -25,6 +26,7 @@ func WriteZip(inputDir, outFile string, ignoreKubernetesVulns, ignoreRHELv2Vulns
 	}
 	if !ignoreRHELv2Vulns {
 		sources = append(sources, filepath.Join(inputDir, RHELv2DirName))
+		sources = append(sources, filepath.Join(inputDir, repo2cpe.RHELv2CPERepoName))
 	}
 	if !ignoreIstioVulns {
 		sources = append(sources, filepath.Join(inputDir, IstioDirName))


### PR DESCRIPTION
Adds a copy of the `repository-to-cpe.json` file to root of the diff and offline bundles to address an issue where newer Central instances are not returning `repository-to-cpe.json` from the bundles `rhelv2/` dir.

## Testing
Verified via the PR's CI artifacts that the copy of the file exists in both locations:

```
$ cd offline-dump/scanner-vuln-updates/scanner-defs 
$ find . -iname "repository-to-cpe*" -exec ls -l {} \;
-rw-r--r--@ 1 dcaravel  staff  1429794 Aug 20 19:49 ./repository-to-cpe.json
-rw-r--r--@ 1 dcaravel  staff  1429794 Aug 20 19:49 ./rhelv2/repository-to-cpe.json

$ cd diff-dumps-inspect
$ find . -iname "repository-to-cpe*" -exec ls -l {} \;
-rw-r--r--@ 1 dcaravel  staff  1429794 Aug 21 01:47 ./repository-to-cpe.json
-rw-r--r--@ 1 dcaravel  staff  1429794 Aug 21 01:47 ./rhelv2/repository-to-cpe.json
```

Also deployed ACS in offline mode with a remote secured cluster.  Uploaded the `offline-dump` from this PR's CI run (`roxctl scanner upload-db ...`) and then observed scanner successfully pulling the file.

Also sent requests directly to the Central API to verify the same:

```
$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" "https://$ROX_ENDPOINT/api/extensions/scannerdefinitions?uuid=5e26731f-a57e-454a-89af-12417096cd75&file=rhelv2/repository-to-cpe.json"

{"data":{"3scale-amp-2-for-rhel-8-ppc64le-debug-rpms":{"cpes"...
```

For sanity, also uploaded the live offline bundle from `roxctl scanner download-db ...` and observed errors in scanner logs and when hitting the API directly:

```
{"Event":"definition not found: https://sensor.stackrox.svc/scanner/definitions?file=rhelv2%2Frepository-to-cpe.json\u0026uuid=5e26731f-a57e-454a-89af-12417096cd75","Level":"warning","Location":"fetcher.go:45","Time":"2025-08-21 19:39:25.733634"}
```

```sh
curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" "https://$ROX_ENDPOINT/api/extensions/scannerdefinitions?uuid=5e26731f-a57e-454a-89af-12417096cd75&file=rhelv2/repository-to-cpe.json" -i

HTTP/2 404 
vary: Accept-Encoding
content-type: text/plain; charset=utf-8
content-length: 28
date: Thu, 21 Aug 2025 19:31:09 GMT

No scanner definitions found
```

Was unable to test online mode because the URL is hardcoded in Central.