### PR TITLE
chore(KONFLUX-6210): fix name label and set cpe label

### DIFF
--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -15,6 +15,7 @@ LABEL \
     url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
     # We must set version label to prevent inheriting value set in the base stage.
     version="${SCANNER_TAG}" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8" \
     # Release label is required by EC although has no practical semantics.
     # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
     release="1"
@@ -57,7 +58,7 @@ FROM scanner-db-common AS scanner-db-slim
 LABEL \
     com.redhat.component="rhacs-scanner-db-slim-container" \
     io.k8s.display-name="scanner-db-slim" \
-    name="rhacs-scanner-db-slim-rhel8"
+    name="advanced-cluster-security/rhacs-scanner-db-slim-rhel8"
 
 ENV ROX_SLIM_MODE="true"
 
@@ -67,7 +68,7 @@ FROM scanner-db-common AS scanner-db
 LABEL \
     com.redhat.component="rhacs-scanner-db-container" \
     io.k8s.display-name="scanner-db" \
-    name="rhacs-scanner-db-rhel8"
+    name="advanced-cluster-security/rhacs-scanner-db-rhel8"
 
 COPY --chown=0:0 .konflux/scanner-data/blob-pg-definitions.sql.gz \
      /docker-entrypoint-initdb.d/definitions.sql.gz

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -44,6 +44,7 @@ LABEL \
     url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
     # We must set version label to prevent inheriting value set in the base stage.
     version="${SCANNER_TAG}" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8" \
     # Release label is required by EC although has no practical semantics.
     # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
     release="1"
@@ -85,7 +86,7 @@ FROM scanner-common AS scanner-slim
 LABEL \
     com.redhat.component="rhacs-scanner-slim-container" \
     io.k8s.display-name="scanner-slim" \
-    name="rhacs-scanner-slim-rhel8"
+    name="advanced-cluster-security/rhacs-scanner-slim-rhel8"
 
 ENV ROX_SLIM_MODE="true"
 
@@ -96,7 +97,7 @@ FROM scanner-common AS scanner
 LABEL \
     com.redhat.component="rhacs-scanner-container" \
     io.k8s.display-name="scanner" \
-    name="rhacs-scanner-rhel8"
+    name="advanced-cluster-security/rhacs-scanner-rhel8"
 
 ENV NVD_DEFINITIONS_DIR="/nvd_definitions"
 ENV K8S_DEFINITIONS_DIR="/k8s_definitions"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also:

* https://github.com/stackrox/stackrox/pull/16735
* https://github.com/release-engineering/rhtap-ec-policy/pull/149