### PR TITLE
Bump Scanner deploy wait timeouts and fix testcase (#2149) - 2.37/4.8

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -12,7 +12,7 @@ class Deployer:
     Deployer - Deploys Scanner and ScannerDB resources and port-forwards the necessary endpoints.
     """
 
-    DEPLOY_TIMEOUT = 10 * 60
+    DEPLOY_TIMEOUT = 20 * 60
 
     def __init__(self, slim=False):
         self.slim = slim

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -4028,7 +4028,7 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 				Name:          "tomcat",
 				VersionFormat: component.JavaSourceType.String(),
 				Version:       "9.0.59",
-				FixedBy:       "9.0.107",
+				FixedBy:       "9.0.108",
 				Location:      "tomcat-embed-core-9.0.59.jar",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -32,7 +32,7 @@ _wait_for_scanner() {
     kubectl -n stackrox get pod
     POD="$(kubectl -n stackrox get pod -o jsonpath='{.items[?(@.metadata.labels.app=="scanner")].metadata.name}')"
     [[ -n "${POD}" ]]
-    kubectl -n stackrox wait "--for=condition=Ready" "pod/${POD}" --timeout=10m
+    kubectl -n stackrox wait "--for=condition=Ready" "pod/${POD}" --timeout=20m
     kubectl -n stackrox get pod
 }
 


### PR DESCRIPTION
Backport targeting Scanner 2.37 (StackRox 4.8) to fix CI