### PR TITLE
Backport s390x and CI fixes - 2.35/4.6

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -12,7 +12,7 @@ class Deployer:
     Deployer - Deploys Scanner and ScannerDB resources and port-forwards the necessary endpoints.
     """
 
-    DEPLOY_TIMEOUT = 20 * 60
+    DEPLOY_TIMEOUT = 30 * 60
 
     def __init__(self, slim=False):
         self.slim = slim

--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -12,7 +12,7 @@ class Deployer:
     Deployer - Deploys Scanner and ScannerDB resources and port-forwards the necessary endpoints.
     """
 
-    DEPLOY_TIMEOUT = 10 * 60
+    DEPLOY_TIMEOUT = 20 * 60
 
     def __init__(self, slim=False):
         self.slim = slim

--- a/e2etests/testcase_test.go
+++ b/e2etests/testcase_test.go
@@ -4028,7 +4028,7 @@ All OpenShift Container Platform 4.10 users are advised to upgrade to these upda
 				Name:          "tomcat",
 				VersionFormat: component.JavaSourceType.String(),
 				Version:       "9.0.59",
-				FixedBy:       "9.0.107",
+				FixedBy:       "9.0.108",
 				Location:      "tomcat-embed-core-9.0.59.jar",
 				Vulnerabilities: []apiV1.Vulnerability{
 					{

--- a/image/db/rhel/scripts/download.sh
+++ b/image/db/rhel/scripts/download.sh
@@ -15,8 +15,11 @@ output_dir="/rpms"
 mkdir $output_dir
 
 if [[ "$arch" == "s390x" ]]; then
+  # TODO(ROX-30647): Builds are failing due to UBI9:latest not containing the
+  #  necessary version of openssl-libs to build postgresql-contrib.
+  pg_build_version="0:16.8-1.module_el9+1209+bd6e4013.s390x"
   dnf module enable -y postgresql:16
-  dnf install -y --downloadonly --downloaddir=/tmp postgresql postgresql-private-libs postgresql-server postgresql-contrib
+  dnf install -y --downloadonly --downloaddir=/tmp "postgresql-${pg_build_version}" "postgresql-private-libs-${pg_build_version}" "postgresql-server-${pg_build_version}" "postgresql-contrib-${pg_build_version}"
   mv /tmp/postgresql-contrib-*.rpm "${output_dir}/postgres-contrib.rpm"
   mv /tmp/postgresql-server-*.rpm "${output_dir}/postgres-server.rpm"
   mv /tmp/postgresql-private-libs-*.rpm "${output_dir}/postgres-libs.rpm"

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -32,7 +32,7 @@ _wait_for_scanner() {
     kubectl -n stackrox get pod
     POD="$(kubectl -n stackrox get pod -o jsonpath='{.items[?(@.metadata.labels.app=="scanner")].metadata.name}')"
     [[ -n "${POD}" ]]
-    kubectl -n stackrox wait "--for=condition=Ready" "pod/${POD}" --timeout=10m
+    kubectl -n stackrox wait "--for=condition=Ready" "pod/${POD}" --timeout=20m
     kubectl -n stackrox get pod
 }
 

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -32,7 +32,7 @@ _wait_for_scanner() {
     kubectl -n stackrox get pod
     POD="$(kubectl -n stackrox get pod -o jsonpath='{.items[?(@.metadata.labels.app=="scanner")].metadata.name}')"
     [[ -n "${POD}" ]]
-    kubectl -n stackrox wait "--for=condition=Ready" "pod/${POD}" --timeout=20m
+    kubectl -n stackrox wait "--for=condition=Ready" "pod/${POD}" --timeout=30m
     kubectl -n stackrox get pod
 }
 


### PR DESCRIPTION
Backports https://github.com/stackrox/scanner/pull/2092 to fix s390x builds and #2149 to fix CI tests

ALSO - bumps deploy wait time to 30m (up from 20m) - newer release versions were OK at 20m

Targeting Scanner 2.35 (StackrRox 4.6)