### PR TITLE
chore: Restore empty lines in `scanner-component-pipeline`

### DIFF
--- a/.tekton/scanner-component-pipeline.yaml
+++ b/.tekton/scanner-component-pipeline.yaml
@@ -2,7 +2,9 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: scanner-component-pipeline
+
 spec:
+
   finally:
   - name: slack-notification
     params:
@@ -24,6 +26,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: show-sbom
     params:
     - name: IMAGE_URL
@@ -37,6 +40,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: post-metric-end
     params:
     - name: AGGREGATE_TASKS_STATUS
@@ -50,6 +54,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   params:
   - description: Source Repository URL
     name: git-url
@@ -116,6 +121,7 @@ spec:
     description: This sets the expiration time for intermediate OCI artifacts produced and used during builds after which they can be garbage collected.
     name: oci-artifact-expires-after
     type: string
+
   results:
   - description: ""
     name: IMAGE_URL
@@ -129,11 +135,15 @@ spec:
   - description: ""
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
+
   workspaces:
   - name: git-auth
+
   tasks:
+
   - name: post-metric-start
     taskRef: *post-bigquery-metrics-ref
+
   - name: init
     params:
     - name: image-url
@@ -154,6 +164,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: clone-repository
     params:
     - name: url
@@ -184,6 +195,7 @@ spec:
     workspaces:
     - name: basic-auth
       workspace: git-auth
+
   - name: determine-image-expiration
     params:
     - name: DEFAULT_IMAGE_EXPIRES_AFTER
@@ -199,6 +211,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: determine-image-tag
     params:
     - name: TAG_SUFFIX
@@ -214,6 +227,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: fetch-scanner-data
     params:
     - name: BLOBS_TO_FETCH
@@ -235,6 +249,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: prefetch-dependencies
     params:
     - name: input
@@ -262,6 +277,7 @@ spec:
     workspaces:
     - name: git-basic-auth
       workspace: git-auth
+
   - name: build-container-amd64
     params:
     - name: IMAGE
@@ -300,6 +316,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: ["true"]
+
   - name: build-container-s390x
     params:
     - name: IMAGE
@@ -340,6 +357,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: ["true"]
+
   - name: build-container-ppc64le
     params:
     - name: IMAGE
@@ -380,6 +398,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: ["true"]
+
   - name: build-container-arm64
     params:
     - name: IMAGE
@@ -420,6 +439,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: ["true"]
+
   - name: build-image-index
     params:
     - name: IMAGE
@@ -447,6 +467,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: ["true"]
+
   - name: build-image-index-konflux
     params:
     - name: IMAGE
@@ -474,6 +495,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: ["true"]
+
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
@@ -500,6 +522,7 @@ spec:
     - input: $(params.build-source-image)
       operator: in
       values: ["true"]
+
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL
@@ -519,6 +542,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+
   - name: clair-scan
     params:
     - name: image-digest
@@ -538,6 +562,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+
   - name: ecosystem-cert-preflight-checks
     params:
     - name: image-url
@@ -555,6 +580,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+
   - name: sast-shell-check
     params:
     - name: image-digest
@@ -578,6 +604,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+
   - name: sast-unicode-check
     params:
     - name: image-digest
@@ -601,6 +628,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+
   - name: sast-snyk-check
     params:
     - name: SOURCE_ARTIFACT
@@ -624,6 +652,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+
   - name: clamav-scan
     params:
     - name: image-digest
@@ -643,6 +672,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+
   - name: rpms-signature-scan
     params:
     - name: image-digest
@@ -662,6 +692,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+
   - name: push-dockerfile
     params:
     - name: IMAGE


### PR DESCRIPTION
For easier reading.
They were killed by some MintMaker's migration but I haven't figured which one.
Release branches don't need this change, they are fine.