### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for scanner-db-4-8

### DIFF
--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -66,8 +66,9 @@ FROM scanner-db-common AS scanner-db
 
 LABEL \
     com.redhat.component="rhacs-scanner-db-container" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8" \
     io.k8s.display-name="scanner-db" \
-    name="rhacs-scanner-db-rhel8"
+    name="advanced-cluster-security/rhacs-scanner-db-rhel8"
 
 COPY --chown=0:0 .konflux/scanner-data/blob-pg-definitions.sql.gz \
      /docker-entrypoint-initdb.d/definitions.sql.gz


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
