### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for scanner-4-8

### DIFF
--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -95,8 +95,9 @@ FROM scanner-common AS scanner
 
 LABEL \
     com.redhat.component="rhacs-scanner-container" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8" \
     io.k8s.display-name="scanner" \
-    name="rhacs-scanner-rhel8"
+    name="advanced-cluster-security/rhacs-scanner-rhel8"
 
 ENV NVD_DEFINITIONS_DIR="/nvd_definitions"
 ENV K8S_DEFINITIONS_DIR="/k8s_definitions"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
