### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for scanner-slim-4-8

### DIFF
--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -85,7 +85,8 @@ FROM scanner-common AS scanner-slim
 LABEL \
     com.redhat.component="rhacs-scanner-slim-container" \
     io.k8s.display-name="scanner-slim" \
-    name="rhacs-scanner-slim-rhel8"
+    name="advanced-cluster-security/rhacs-scanner-slim-rhel8" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8"
 
 ENV ROX_SLIM_MODE="true"
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
