### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for scanner-db-slim-4-8

### DIFF
--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -57,7 +57,8 @@ FROM scanner-db-common AS scanner-db-slim
 LABEL \
     com.redhat.component="rhacs-scanner-db-slim-container" \
     io.k8s.display-name="scanner-db-slim" \
-    name="rhacs-scanner-db-slim-rhel8"
+    name="advanced-cluster-security/rhacs-scanner-db-slim-rhel8" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8"
 
 ENV ROX_SLIM_MODE="true"
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
