### PR TITLE
ROX-30592: Adjust renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,12 +30,14 @@
   ],
   // Allow Renovate updating PRs when outside schedule.
   "updateNotScheduled": true,
+  // Bump the default limit on the number of PRs that can be created per hour.
+  "prHourlyLimit": 4,
   "tekton": {
     "schedule": [
-      // Between 3a.m. and 7a.m. on weekends.
+      // Between 3a.m. and 7a.m. on weekends and Mondays.
       // Doing more frequently just creates more PR, commit and email traffic. We can afford to be slower here as
       // Conforma allows 30 days to update tasks.
-      "* 3-7 * * 0,6",
+      "* 3-7 * * 0,1,6",
     ],
     "packageRules": [
       // Note: the packageRules from the Konflux config (find URL in comments above) get merged with these.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,8 +33,8 @@
     // Between 3a.m. and 7a.m. every day.
     "* 3-7 * * *",
   ],
-  // Allow Renovate updating PRs when outside schedule.
-  "updateNotScheduled": true,
+  // Tell Renovate not to update PRs when outside schedule.
+  "updateNotScheduled": false,
   "tekton": {
     "schedule": [
       // Between 3a.m. and 7a.m. on weekends and Mondays.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,17 +20,22 @@
   "timezone": "Etc/UTC",
   "schedule": [
     // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule
+    // This is a "general" schedule for managers that don't declare their own. Practically, each of our used managers
+    // overrides it either here or in the global config.
     // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
-    // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
-    // that.
-    "after 3am and before 7am",
+    // hours from Central Europe to US West Coast. This way, after we merge a PR, a new one does not pop up immediately
+    // after that.
+    // Between 3a.m. and 7a.m. every day.
+    "* 3-7 * * *",
   ],
-  // Tell Renovate not to update PRs when outside of schedule.
-  "updateNotScheduled": false,
+  // Allow Renovate updating PRs when outside schedule.
+  "updateNotScheduled": true,
   "tekton": {
     "schedule": [
-      // Override Konflux custom schedule for this manager to our intended one.
-      "after 3am and before 7am",
+      // Between 3a.m. and 7a.m. on weekends.
+      // Doing more frequently just creates more PR, commit and email traffic. We can afford to be slower here as
+      // Conforma allows 30 days to update tasks.
+      "* 3-7 * * 0,6",
     ],
     "packageRules": [
       // Note: the packageRules from the Konflux config (find URL in comments above) get merged with these.
@@ -49,8 +54,9 @@
       "**/*konflux*.Dockerfile",
     ],
     "schedule": [
-      // Override Konflux custom schedule for this manager to our intended one.
-      "after 3am and before 7am",
+      // Between 3a.m. and 7a.m. every day.
+      // It's important to keep dockerfiles fresh to avoid releasing with CVEs.
+      "* 3-7 * * *",
     ],
     "postUpgradeTasks": {
       "commands": [
@@ -61,9 +67,9 @@
   },
   "rpm-lockfile": {
     "schedule": [
-      // Override Konflux custom schedule for this manager to our intended one.
-      // Note that MintMaker will create security updates outside of schedule.
-      "after 3am and before 7am",
+      // Between 3a.m. and 7a.m. every day.
+      // Note that MintMaker will create security updates ignoring schedules.
+      "* 3-7 * * *",
     ],
   },
   "enabledManagers": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,8 +20,7 @@
   "timezone": "Etc/UTC",
   "schedule": [
     // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule
-    // This is a "general" schedule for managers that don't declare their own. Practically, each of our used managers
-    // overrides it either here or in the global config.
+    // This is a "general" schedule for managers that don't declare their own.
     // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
     // hours from Central Europe to US West Coast. This way, after we merge a PR, a new one does not pop up immediately
     // after that.
@@ -55,24 +54,12 @@
       // to have less PR noise.
       "**/*konflux*.Dockerfile",
     ],
-    "schedule": [
-      // Between 3a.m. and 7a.m. every day.
-      // It's important to keep dockerfiles fresh to avoid releasing with CVEs.
-      "* 3-7 * * *",
-    ],
     "postUpgradeTasks": {
       "commands": [
         // Refresh the rpm lockfile after updating image references in the dockerfile.
         "rpm-lockfile-prototype rpms.in.yaml",
       ],
     },
-  },
-  "rpm-lockfile": {
-    "schedule": [
-      // Between 3a.m. and 7a.m. every day.
-      // Note that MintMaker will create security updates ignoring schedules.
-      "* 3-7 * * *",
-    ],
   },
   "enabledManagers": [
     // Restrict Renovate focus on Konflux things since we rely on GitHub's dependabot for everything else.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,12 @@
     // This tells Renovate to combine all updates in one PR so that we have fewer PRs to deal with.
     "group:all",
   ],
+  // The number of PRs that can be open against the repo.
+  "prConcurrentLimit": 20,
+  // `null` means the branch limit should be the same as PR limit.
+  "branchConcurrentLimit": null,
+  // The number of PRs MintMaker can open in one hour, effectively in one run.
+  "prHourlyLimit": 4,
   "timezone": "Etc/UTC",
   "schedule": [
     // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule
@@ -29,8 +35,6 @@
   ],
   // Allow Renovate updating PRs when outside schedule.
   "updateNotScheduled": true,
-  // Bump the default limit on the number of PRs that can be created per hour.
-  "prHourlyLimit": 4,
   "tekton": {
     "schedule": [
       // Between 3a.m. and 7a.m. on weekends and Mondays.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -80,18 +80,24 @@
     "dockerfile",
     "rpm-lockfile",
   ],
-  "packageRules": [{
-    "matchPackageNames": ["*"],
-    "groupName": "All updates",
-    "automerge": true,
-    // A known issue is that some non-Konflux CI jobs currently fail, which may prevent successful auto-merging with a "branch" auto-merge setting.
-    // Therefore, we use PR merge type and have automation approve PRs.
-    "automergeType": "pr",
-    "automergeStrategy": "squash",
-    // Tell Renovate that it can automerge branches at any time of the day.
-    "automergeSchedule": [
-      "at any time"
-    ],
-  }],
-  "labels": ["auto-approve"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "*",
+      ],
+      "groupName": "All updates",
+      "automerge": true,
+      // A known issue is that some non-Konflux CI jobs currently fail, which may prevent successful auto-merging with a "branch" auto-merge setting.
+      // Therefore, we use PR merge type and have automation approve PRs.
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      // Tell Renovate that it can automerge branches at any time of the day.
+      "automergeSchedule": [
+        "at any time",
+      ],
+    }
+  ],
+  "labels": [
+    "auto-approve",
+  ],
 }


### PR DESCRIPTION
## Description

Changes here:
1. Foremost: reduce frequency for Task renovation to do that once per week.
2. Remove schedule overrides following the recent announcement <https://groups.google.com/a/redhat.com/g/konflux-announce/c/atbFtt5ad7Y/m/wzl0u96OAAAJ>.
3. Bump concurrent PR limits following the StackRox example <https://github.com/stackrox/stackrox/pull/16877>.
4. Reformat the file.

## Validation

Only ran the config validator. It complains about the unknown `rpm-lockfile`. Otherwise, it's ok.
In general and as always, I don't know how it will work. Let's apply and see.