### PR TITLE
ROX-30592: Enable tekton Tasks renovation every day

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,10 +37,9 @@
   "updateNotScheduled": false,
   "tekton": {
     "schedule": [
-      // Between 3a.m. and 7a.m. on weekends and Mondays.
-      // Doing more frequently just creates more PR, commit and email traffic. We can afford to be slower here as
-      // Conforma allows 30 days to update tasks.
-      "* 3-7 * * 0,1,6",
+      // Between 3a.m. and 7a.m. every day.
+      // We duplicate our desired schedule here because Konflux global config tends to have a special override for it.
+      "* 3-7 * * *",
     ],
     "packageRules": [
       // Note: the packageRules from the Konflux config (find URL in comments above) get merged with these.


### PR DESCRIPTION
## Description

This partially undoes what I did in https://github.com/stackrox/scanner/pull/2200.

While describing the release process and revising [How to handle MintMaker updates during the release process](https://spaces.redhat.com/spaces/StackRox/pages/661160921/How+to+handle+MintMaker+updates+during+the+release+process), I realized that we ask release engineers to land MintMaker PRs but these may not be ready for Y-Stream with the current "on the weekend" schedule after the release engineer just created GitOps resources.

Therefore, I suggest to enable more frequent tasks renovation as a tradeoff to let release engineers not get stuck.
We'll have to deal with email and commit traffic some other way.

## Validation

Only ran config validator.