### PR TITLE
build: Add CPU limits to scanner builds

### DIFF
--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -68,6 +68,8 @@ spec:
     # This is not required for multi-arch builds, because they are performed off cluster
     - name: build
       computeResources:
+        limits:
+          cpu: 2
         requests:
           cpu: 2
 

--- a/.tekton/scanner-slim-build.yaml
+++ b/.tekton/scanner-slim-build.yaml
@@ -68,6 +68,8 @@ spec:
     # This is not required for multi-arch builds, because they are performed off cluster
     - name: build
       computeResources:
+        limits:
+          cpu: 2
         requests:
           cpu: 2
 


### PR DESCRIPTION
## Description

See <https://www.github.com/konflux-ci/build-definitions/pull/2856>. The one is going to re-introduce explicit `limits.cpu` on all tasks. It may be useful to set our limits.cpu where missing.
Related thread https://redhat-internal.slack.com/archives/C04F4NE15U1/p1759320578511439

I actually don't know what's going to happen when their `limits.cpu` will be less than our `requests.cpu` if we don't apply this change.
I tried simulating it locally with https://github.com/stackrox/scanner/pull/2294 which is most likely what's going to happen once their values are combined with ours and saw this in UI

<img width="774" height="761" alt="image" src="https://github.com/user-attachments/assets/2d926ee5-77b6-44b4-ad84-2514736dc0e6" />

The task's pod did not even get started and I could not find it in `kubectl get pods` output.
Here's what came in `kubectl events`:

> 61s (x2 over 62s)        Warning   Failed                              TaskRun/scanner-on-push-xgxjl-build-container-amd64                       failed to create task run pod "scanner-on-push-xgxjl-build-container-amd64": Pod "scanner-on-push-xgxjl-build-container-amd64-pod" is invalid: spec.containers[1].resources.requests: Invalid value: "2": must be less than or equal to cpu limit of 1. Maybe missing or invalid Task rh-acs-tenant/
> 61s (x2 over 62s)        Warning   InternalError                       TaskRun/scanner-on-push-xgxjl-build-container-amd64                       1 error occurred:
                         * failed to create task run pod "scanner-on-push-xgxjl-build-container-amd64": Pod "scanner-on-push-xgxjl-build-container-amd64-pod" is invalid: spec.containers[1].resources.requests: Invalid value: "2": must be less than or equal to cpu limit of 1. Maybe missing or invalid Task rh-acs-tenant/

## Validation

Only CI. Checked that amd64 buildah duration did not become longer than other platforms.