### PR TITLE
chore: Bump GHA image expiration to 52 weeks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 
 # Set expiration on Quay.io for non-release tags.
 ifeq ($(findstring x,$(TAG)),x)
-QUAY_TAG_EXPIRATION=13w
+QUAY_TAG_EXPIRATION=52w
 else
 QUAY_TAG_EXPIRATION=never
 endif


### PR DESCRIPTION
Related to https://redhat-internal.slack.com/archives/CELUQKESC/p1777919339423939

Konflux builds already have it set to 52w: https://github.com/stackrox/scanner/blob/5ff2364023f969562fd4654a81a5c539f9e8b0a8/.tekton/scanner-build.yaml#L29-L30