### PR TITLE
ROX-33431: Bump memory resources for rpms-signature-scan

### DIFF
--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -61,6 +61,17 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
+  taskRunSpecs:
+  # The following are overrides to default step resources to prevent occasional or deterministic OOM kills.
+  - pipelineTaskName: rpms-signature-scan
+    stepSpecs:
+    - name: rpms-signature-scan
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-scanner-db
 

--- a/.tekton/scanner-db-slim-build.yaml
+++ b/.tekton/scanner-db-slim-build.yaml
@@ -61,6 +61,17 @@ spec:
     secret:
       secretName: '{{ git_auth_secret }}'
 
+  taskRunSpecs:
+  # The following are overrides to default step resources to prevent occasional or deterministic OOM kills.
+  - pipelineTaskName: rpms-signature-scan
+    stepSpecs:
+    - name: rpms-signature-scan
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-scanner-db-slim
 


### PR DESCRIPTION
Scanner-db* containers suffer the same OOMs as central-db and scanner-v4-db did and which got patched in
https://github.com/stackrox/stackrox/pull/20655

Replicating the same to the Scanner repo.

Saw OOMs in these pods in the last 7 days:
- scanner-db-slim-on-push-598gl-rpms-signature-scan-pod
- scanner-db-slim-on-push-m9v7z-rpms-signature-scan-pod

I'm not going to backport this PR to any `release-*` branches because I think the gain is small. Scanner V2 isn't actively changed.