### PR TITLE
chore: Reset `minimumReleaseAge`, disable Dockerfile post-task

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,8 @@
     // This tells Renovate to combine all updates in one PR so that we have fewer PRs to deal with.
     "group:all",
   ],
+  // Don't apply dependency cooldown because via MintMaker we take only Red Hat dependencies.
+  "minimumReleaseAge":  null,
   // The number of PRs that can be open against the repo.
   "prConcurrentLimit": 20,
   // `null` means the branch limit should be the same as PR limit.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,12 +59,6 @@
       // to have less PR noise.
       "**/*konflux*.Dockerfile",
     ],
-    "postUpgradeTasks": {
-      "commands": [
-        // Refresh the rpm lockfile after updating image references in the dockerfile.
-        "rpm-lockfile-prototype rpms.in.yaml",
-      ],
-    },
   },
   // Turns on automerge for the RPM updates coming with CVE fixes.
   // https://konflux-ci.dev/docs/mintmaker/rpm-lockfile/#how-to-enable-automerge-for-rpm-security-updates


### PR DESCRIPTION
Similarly to https://github.com/stackrox/stackrox/pull/21190, I disable the `minimumReleaseAge`.

Also, I diffed the `renovate.json5` file with the one from StackRox and found that we still had `postUpgradeTasks` here.
I did not turn them off when I did https://github.com/stackrox/collector/pull/2894 and https://github.com/stackrox/stackrox/pull/18940 because Scanner's `context` in `rpms.in.yaml` was depending on a stage.
It does not any more after https://github.com/stackrox/scanner/pull/3095/changes#diff-d0c46632e0dce87e83d1f5bc30a13065ebb00527cbd04edfb1d0ccf18990db6eL9