### PR TITLE
ROX-35270: Update go to 1.26.3 [4.9]

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@
 run:
   timeout: 16m
   modules-download-mode: readonly
-  go: "1.23"
+  go: "1.26"
 
 output:
   formats:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/stackrox/scanner
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.4
+toolchain go1.25.9
 
 require (
 	cloud.google.com/go/storage v1.56.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/stackrox/scanner
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.9
+toolchain go1.26.3
 
 require (
 	cloud.google.com/go/storage v1.56.1

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -1,5 +1,5 @@
 # Compiling scanner binaries and staging repo2cpe and genesis manifests
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.24@sha256:89a421ef4cecc6eb5c2fc347ab49aa094ebbeff6df8ba05ab19ccb28efa63f79 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.25@sha256:e3d5ba0efb0d3cbb5b8964f49ca199ed851ccf4a7f129a34e61cf91166b4e267
 
 ARG SCANNER_TAG
 RUN if [[ "$SCANNER_TAG" == "" ]]; then >&2 echo "error: required SCANNER_TAG arg is unset"; exit 6; fi

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -1,5 +1,5 @@
 # Compiling scanner binaries and staging repo2cpe and genesis manifests
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.25@sha256:e3d5ba0efb0d3cbb5b8964f49ca199ed851ccf4a7f129a34e61cf91166b4e267 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.26@sha256:aa2429f5dcf086b4edb2251f0cea19d54c60638aaedc03a1384d26ec3754cebc AS builder
 
 ARG SCANNER_TAG
 RUN if [[ "$SCANNER_TAG" == "" ]]; then >&2 echo "error: required SCANNER_TAG arg is unset"; exit 6; fi

--- a/image/scanner/rhel/konflux.Dockerfile
+++ b/image/scanner/rhel/konflux.Dockerfile
@@ -1,5 +1,5 @@
 # Compiling scanner binaries and staging repo2cpe and genesis manifests
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.25@sha256:e3d5ba0efb0d3cbb5b8964f49ca199ed851ccf4a7f129a34e61cf91166b4e267
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.25@sha256:e3d5ba0efb0d3cbb5b8964f49ca199ed851ccf4a7f129a34e61cf91166b4e267 AS builder
 
 ARG SCANNER_TAG
 RUN if [[ "$SCANNER_TAG" == "" ]]; then >&2 echo "error: required SCANNER_TAG arg is unset"; exit 6; fi

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/scanner/tools/linters
 
-go 1.24
+go 1.25
 
 require (
 	github.com/golangci/golangci-lint v1.64.8

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/scanner/tools/linters
 
-go 1.25
+go 1.26
 
 require (
 	github.com/golangci/golangci-lint v1.64.8

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -1,5 +1,5 @@
 module github.com/stackrox/scanner/tools/test
 
-go 1.24
+go 1.25
 
 require github.com/jstemmer/go-junit-report/v2 v2.1.0

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -1,5 +1,5 @@
 module github.com/stackrox/scanner/tools/test
 
-go 1.25
+go 1.26
 
 require github.com/jstemmer/go-junit-report/v2 v2.1.0


### PR DESCRIPTION
This should address CVE-2026-32281

We try to align on the version in stackrox/stackrox
