### PR TITLE
chore(ci): remove apollo-ci images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,6 @@ jobs:
 
   pre-build-updater:
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -71,8 +69,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -100,8 +96,6 @@ jobs:
 
   style-check:
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -119,8 +113,6 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -166,8 +158,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - pre-build-updater
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -211,8 +201,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - generate-genesis-dump
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -260,8 +248,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -317,8 +303,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - generate-db-dump
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -368,8 +352,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -441,8 +423,6 @@ jobs:
       - generate-scanner-db-bundle
       - build-images
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     env:
       QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
       QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -487,8 +467,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - generate-genesis-dump
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -606,8 +584,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - generate-db-dump
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -634,8 +610,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - generate-db-dump
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -668,8 +642,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - generate-db-dump
-    container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
As of Go 1.21, go will automatically download and use the specified toolchain version if the currently installed Go is older (behavior is configurable with `GOTOOLCHAIN`).

These changes bring scanner V2's GitHub Actions build process more in line with stackrox's.

Note that the `db-integration-tests` job still requires `quay.io/stackrox-io/apollo-ci:scanner-test`.