### PR TITLE
fix(mintmaker): always recreate ACS konflux-tasks update PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,8 @@
         "matchPackageNames": [
           "/^quay.io/rhacs-eng/konflux-tasks/",
         ],
+        "recreateWhen": "always",
+        "rebaseWhen": "behind-base-branch",
       },
     ],
   },


### PR DESCRIPTION
Recently found some PRs on the fact repo that should've updated the custom konflux tasks from stackrox that were not being set to auto-merge, it has been suggested by the MintMaker team that adding the fields in this PR will help with the issue.

More context at: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1782727458789889

This is a sync commit from stackrox/fact#941