### PR TITLE
fix(feed): Improve NVD feed download resilience (x2)

### DIFF
--- a/pkg/vulnloader/nvdloader/loader_api.go
+++ b/pkg/vulnloader/nvdloader/loader_api.go
@@ -22,7 +22,7 @@ import (
 const urlFmt = `https://services.nvd.nist.gov/rest/json/cves/2.0?noRejected&startIndex=%d`
 
 var client = http.Client{
-	Timeout:   6 * time.Minute,
+	Timeout:   10 * time.Minute,
 	Transport: proxy.RoundTripper(),
 }
 

--- a/pkg/vulnloader/nvdloader/loader_feed.go
+++ b/pkg/vulnloader/nvdloader/loader_feed.go
@@ -50,7 +50,7 @@ func (l *feedLoader) DownloadFeedsToPath(outputDir string) error {
 func (l *feedLoader) downloadFeedForYear(enrichments map[string]*FileFormatWrapper, outputDir string, year int) error {
 	url := fmt.Sprintf("https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-%d.json.gz", year)
 
-	const maxRetries = 5
+	const maxRetries = 10
 	backoff := 10 * time.Second
 	var apiFeed *apischema.CVEAPIJSON20
 	for attempt := 1; ; attempt++ {


### PR DESCRIPTION
Expands on https://github.com/stackrox/scanner/pull/3343 to increase the retires / timeouts - based on observed status in https://github.com/stackrox/scanner/actions/runs/28467785361/job/84372363491 riding the threshold (update: and failing)