### PR TITLE
fix(ci): use apollo-ci image for generate-db-dump

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,10 @@ jobs:
       - uses: ./.github/actions/handle-tagged-build
 
       - name: Build updater (amd64)
-        run: make build-updater
+        # CGO_ENABLED is set to 0 here so the other steps aren't required to have a particular version of glibc
+        # (or any other dynamically linked libraries). This will only affect the updater isn't included in any images,
+        # so this build variance should be fine.
+        run: CGO_ENABLED=0 make build-updater
 
       - name: Archive the build to preserve permissions
         run: tar -cvzf updater-build.tgz bin/updater

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,6 +199,8 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'generate-dumps-on-pr')
     runs-on: ubuntu-latest
+    container:
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.9
     needs:
       - generate-genesis-dump
     steps:


### PR DESCRIPTION
https://github.com/stackrox/scanner/pull/3303 introduced a bug where `generate-db-dump` will error in the following manner:
```
Run source ./scripts/ci/lib.sh
  source ./scripts/ci/lib.sh
  generate_db_dump
  shell: /usr/bin/bash -e {0}
INFO: Wed Jul  1 01:17:14 UTC 2026: Generating DB dump
groupadd: GID '1001' already exists
```
Example: https://github.com/stackrox/scanner/actions/runs/28485288342/job/84434649671

Additionally, since the updater build job uses an image that won't be in sync with dependent jobs, we may run into issues with the dynamically linked libraries available in the image. Example of when this will cause a problem: https://github.com/stackrox/scanner/actions/runs/28487169799/job/84440317595?pr=3348

These changes add the apollo-ci image back to the `generate-db-dump` job and set `CGO_ENABLED=0` during the updater build to ensure the updater can run properly.