### PR TITLE
chore(feed): cap exponential backoff

### DIFF
--- a/pkg/vulnloader/nvdloader/loader_feed.go
+++ b/pkg/vulnloader/nvdloader/loader_feed.go
@@ -51,6 +51,7 @@ func (l *feedLoader) downloadFeedForYear(enrichments map[string]*FileFormatWrapp
 	url := fmt.Sprintf("https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-%d.json.gz", year)
 
 	const maxRetries = 10
+	const maxBackoff = 5 * time.Minute
 	backoff := 10 * time.Second
 	var apiFeed *apischema.CVEAPIJSON20
 	for attempt := 1; ; attempt++ {
@@ -65,6 +66,9 @@ func (l *feedLoader) downloadFeedForYear(enrichments map[string]*FileFormatWrapp
 		log.Warnf("Feed year %d: attempt %d failed: %v; retrying in %s", year, attempt, err, backoff)
 		time.Sleep(backoff)
 		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
 	}
 
 	cveItems, err := toJSON10(apiFeed.Vulnerabilities)

--- a/pkg/vulnloader/nvdloader/loader_feed.go
+++ b/pkg/vulnloader/nvdloader/loader_feed.go
@@ -51,8 +51,14 @@ func (l *feedLoader) downloadFeedForYear(enrichments map[string]*FileFormatWrapp
 	url := fmt.Sprintf("https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-%d.json.gz", year)
 
 	const maxRetries = 10
-	const maxBackoff = 5 * time.Minute
-	backoff := 10 * time.Second
+	backoffs := []time.Duration{
+		15 * time.Second,
+		30 * time.Second,
+		1 * time.Minute,
+		2 * time.Minute,
+		4 * time.Minute,
+		5 * time.Minute,
+	}
 	var apiFeed *apischema.CVEAPIJSON20
 	for attempt := 1; ; attempt++ {
 		var err error
@@ -63,12 +69,9 @@ func (l *feedLoader) downloadFeedForYear(enrichments map[string]*FileFormatWrapp
 		if attempt >= maxRetries {
 			return errors.Wrapf(err, "failed to download feed for year %d after %d attempts", year, attempt)
 		}
+		backoff := backoffs[min(attempt-1, len(backoffs)-1)]
 		log.Warnf("Feed year %d: attempt %d failed: %v; retrying in %s", year, attempt, err, backoff)
 		time.Sleep(backoff)
-		backoff *= 2
-		if backoff > maxBackoff {
-			backoff = maxBackoff
-		}
 	}
 
 	cveItems, err := toJSON10(apiFeed.Vulnerabilities)


### PR DESCRIPTION
The backoff introduced is a bit 'too exponential' when retries were increased, this change caps backoff to 5 mins


[ex](https://github.com/stackrox/scanner/actions/runs/28510678753/job/84510586373):
```
... retrying in 42m40s
```

```
time="2026-07-01T13:32:06Z" level=warning msg="Feed year 2024: attempt 9 failed: reading feed body (read 93318053 bytes, elapsed: 6m26.142596235s): stream error: stream ID 1; INTERNAL_ERROR; received from peer; retrying in 42m40s"
```