### PR TITLE
chore(backport): Add backport GH workflow to Scanner repo

### DIFF
--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -1,0 +1,27 @@
+name: Backport PR to release branch
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # ratchet:tibdex/backport@v2.0.4
+        with:
+          github_token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+          title_template: "<%= title %>"


### PR DESCRIPTION
Copied from `stackrox/stackrox` https://github.com/stackrox/stackrox/blob/943c70ededfe015e7397037d59fcaf09539975ed/.github/workflows/backport-pr.yaml

Adding a backport label to a PR, once merged, will yield a backport PR against the target branch.

Assumes secret `RHACS_BOT_GITHUB_TOKEN` is setup at the org level (currently not setup at the repo level)

Will test / iterate as needed once merged.