### PR TITLE
ROX-36679: remove curl, vim, rsync from scanner-db image

### DIFF
--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -69,8 +69,11 @@ RUN microdnf upgrade -y --nobest && \
     # https://access.redhat.com/solutions/5616681
     microdnf reinstall -y tzdata && \
     microdnf clean all && \
-    # (Optional) Remove line below to keep package management utilities
-    rpm -e --nodeps $(rpm -qa shadow-utils curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm -e --nodeps $(rpm -qa shadow-utils \
+        # Not needed by postgres, carry unfixable CVEs
+        'libcurl*' 'vim*' \
+        # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
+        'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     mkdir /docker-entrypoint-initdb.d

--- a/image/db/rhel/Dockerfile
+++ b/image/db/rhel/Dockerfile
@@ -71,7 +71,7 @@ RUN microdnf upgrade -y --nobest && \
     microdnf clean all && \
     rpm -e --nodeps $(rpm -qa shadow-utils \
         # Not needed by postgres, carry unfixable CVEs
-        'libcurl*' 'vim*' \
+        'libcurl*' 'vim*' 'rsync*' \
         # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
         'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \

--- a/image/db/rhel/Dockerfile.slim
+++ b/image/db/rhel/Dockerfile.slim
@@ -69,8 +69,11 @@ RUN microdnf upgrade -y --nobest && \
     # https://access.redhat.com/solutions/5616681
     microdnf reinstall -y tzdata && \
     microdnf clean all && \
-    # (Optional) Remove line below to keep package management utilities
-    rpm -e --nodeps $(rpm -qa shadow-utils curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm -e --nodeps $(rpm -qa shadow-utils \
+        # Not needed by postgres, carry unfixable CVEs
+        'libcurl*' 'vim*' \
+        # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
+        'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     mkdir /docker-entrypoint-initdb.d

--- a/image/db/rhel/Dockerfile.slim
+++ b/image/db/rhel/Dockerfile.slim
@@ -71,7 +71,7 @@ RUN microdnf upgrade -y --nobest && \
     microdnf clean all && \
     rpm -e --nodeps $(rpm -qa shadow-utils \
         # Not needed by postgres, carry unfixable CVEs
-        'libcurl*' 'vim*' \
+        'libcurl*' 'vim*' 'rsync*' \
         # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
         'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \

--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -39,7 +39,7 @@ RUN localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     dnf clean all && \
     rpm --verbose -e --nodeps $(rpm -qa \
         # Not needed by postgres, carry unfixable CVEs
-        'libcurl*' 'vim*' \
+        'libcurl*' 'vim*' 'rsync*' \
         # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
         'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum && \

--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -37,7 +37,11 @@ RUN localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     chown -R postgres:postgres /var/lib/postgresql && \
     chown -R postgres:postgres /var/run/postgresql && \
     dnf clean all && \
-    rpm --verbose -e --nodeps $(rpm -qa 'curl*' 'libcurl*' 'vim*' 'python3*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm --verbose -e --nodeps $(rpm -qa \
+        # Not needed by postgres, carry unfixable CVEs
+        'libcurl*' 'vim*' \
+        # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
+        'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     mkdir /docker-entrypoint-initdb.d
 

--- a/image/db/rhel/konflux.Dockerfile
+++ b/image/db/rhel/konflux.Dockerfile
@@ -37,7 +37,7 @@ RUN localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     chown -R postgres:postgres /var/lib/postgresql && \
     chown -R postgres:postgres /var/run/postgresql && \
     dnf clean all && \
-    rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm --verbose -e --nodeps $(rpm -qa 'curl*' 'libcurl*' 'vim*' 'python3*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     mkdir /docker-entrypoint-initdb.d
 


### PR DESCRIPTION
Expand rpm -e glob patterns to match curl-minimal/libcurl-minimal, vim-minimal, and python3 packages that are not needed at runtime and carry HIGH CVEs flagged in GovCloud compliance scans.

Mirrors the fix applied to central-db and scanner-v4-db in stackrox/stackrox#22269.

Partially generated by AI.