### PR TITLE
chore(support): Do not send failure notification for PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -671,7 +671,8 @@ jobs:
       - upload-dumps-for-embedding
       - push-manifests
     runs-on: ubuntu-latest
-    if: failure()
+    # Only notify on failures from scheduled runs or tag pushes, not PRs or branch pushes.
+    if: failure() && (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Send Slack notification on workflow failure
         run: |


### PR DESCRIPTION
Updates the `CI` workflow to only send notifications to slack when a failure occurs from a scheduled or tagged CI run.

Failures from PRs or release branch pushes will no longer generate alerts.

The intent is to reduce noise and ensure alerts are meaningful.