### PR TITLE
fix(konflux): increase timeout of scanner(-db) pipeline by 2 hours

### DIFF
--- a/.tekton/scanner-build.yaml
+++ b/.tekton/scanner-build.yaml
@@ -68,11 +68,11 @@ spec:
     serviceAccountName: build-pipeline-scanner
 
   # Multiarch builds sometimes make the pipeline timeout after 1h.
-  # Tagged builds wait for blobs to be published, which takes about 1h30m.
+  # Tagged builds wait for blobs to be published, which takes about 3h30m.
   timeouts:
-    tasks: 3h30m
+    tasks: 5h30m
     finally: 10m
-    pipeline: 3h40m
+    pipeline: 5h40m
 
   pipelineRef:
     name: scanner-component-pipeline

--- a/.tekton/scanner-db-build.yaml
+++ b/.tekton/scanner-db-build.yaml
@@ -75,11 +75,11 @@ spec:
   taskRunTemplate:
     serviceAccountName: build-pipeline-scanner-db
 
-  # Tagged builds wait for blobs to be published, which takes about 1h30m.
+  # Tagged builds wait for blobs to be published, which takes about 3h30m.
   timeouts:
-    tasks: 3h0m
+    tasks: 5h0m
     finally: 10m
-    pipeline: 3h10m
+    pipeline: 5h10m
 
 
   pipelineRef:


### PR DESCRIPTION
Generally, the build of the blobs roughly takes 2-3.5 hours these days. We increase the timeouts of the Konflux pipelines accordingly.

We don't need to update the *-slim pipelines because they don't wait for any blobs.

Context: https://redhat-internal.slack.com/archives/C03D78P4RFF/p1787017109044639