### PR TITLE
ROX-36447: Migrate from clair-scan to roxctl-scan

### DIFF
--- a/.tekton/scanner-component-pipeline.yaml
+++ b/.tekton/scanner-component-pipeline.yaml
@@ -417,11 +417,6 @@ spec:
       values: [ "false" ]
 
   - name: roxctl-scan
-    matrix:
-      params:
-      - name: image-platform
-        value:
-        - $(params.build-platforms)
     params:
     - name: image-digest
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)


### PR DESCRIPTION
Replace clair-scan task with roxctl-scan to provide better security coverage as per Konflux Integration Service Team migration plan.

Changes:
- Updated task name from clair-scan to roxctl-scan
- Updated bundle reference to task-roxctl-scan:0.1
- Removed matrix configuration as roxctl-scan handles multi-arch natively